### PR TITLE
Add support comprehensive magic comments

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/parsing/RegexCodeFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/RegexCodeFragmentizer.kt
@@ -8,7 +8,9 @@
 
 package org.bsplines.ltexls.parsing
 
+import SettingsParser
 import org.bsplines.ltexls.settings.Settings
+import org.bsplines.ltexls.settings.SettingsOverride
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
 
@@ -21,15 +23,15 @@ open class RegexCodeFragmentizer(
     originalSettings: Settings,
   ): List<CodeFragment> {
     val codeFragments = ArrayList<CodeFragment>()
-    var curSettings: Settings = originalSettings
+    val settingsOverride = SettingsOverride(originalSettings)
+    var curSettings: Settings = settingsOverride.toSettings()
     var curPos = 0
 
     for (matchResult: MatchResult in this.regex.findAll(code)) {
       var lastPos: Int = curPos
       curPos = matchResult.range.first
       var lastCode: String = code.substring(lastPos, curPos)
-      var lastSettings: Settings = curSettings
-      codeFragments.add(CodeFragment(codeLanguageId, lastCode, lastPos, lastSettings))
+      codeFragments.add(CodeFragment(codeLanguageId, lastCode, lastPos, curSettings))
 
       var settingsLine: String? = null
 
@@ -45,13 +47,13 @@ open class RegexCodeFragmentizer(
         continue
       }
 
-      curSettings = SettingsParser.createUpdatedSettings(settingsLine, curSettings)
+      SettingsParser.updateSettingsOverride(settingsLine, settingsOverride)
+      curSettings = settingsOverride.toSettings()
 
       lastPos = curPos
       curPos = matchResult.range.last + 1
       lastCode = code.substring(lastPos, curPos)
-      lastSettings = curSettings
-      codeFragments.add(CodeFragment("nop", lastCode, lastPos, lastSettings))
+      codeFragments.add(CodeFragment("nop", lastCode, lastPos, curSettings))
     }
 
     codeFragments.add(

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/html/HtmlFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/html/HtmlFragmentizer.kt
@@ -11,6 +11,7 @@ package org.bsplines.ltexls.parsing.html
 import org.bsplines.ltexls.parsing.CodeFragment
 import org.bsplines.ltexls.parsing.CodeFragmentizer
 import org.bsplines.ltexls.settings.Settings
+import org.bsplines.ltexls.settings.SettingsOverride
 
 class HtmlFragmentizer(
   codeLanguageId: String,
@@ -25,7 +26,8 @@ class HtmlFragmentizer(
     originalSettings: Settings,
   ): List<CodeFragment> {
     val codeFragments = ArrayList<CodeFragment>()
-    var currentSettings: Settings = originalSettings
+    val currentOverride = SettingsOverride(originalSettings)
+    var currentSettings = currentOverride.toSettings()
 
     var currentIndex = 0
 
@@ -65,7 +67,8 @@ class HtmlFragmentizer(
         val matchResult = regex.matchEntire(commentContent)
         if (matchResult != null) {
           val settingsLine = matchResult.groups[1]!!.value
-          currentSettings = SettingsParser.createUpdatedSettings(settingsLine, currentSettings)
+          SettingsParser.updateSettingsOverride(settingsLine, currentOverride)
+          currentSettings = currentOverride.toSettings()
         }
 
         codeFragments.add(CodeFragment("nop", comment, openingTagIndex, currentSettings))

--- a/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
@@ -85,6 +85,10 @@ data class Settings(
   val clearDiagnosticsWhenClosingFile: Boolean
     get() = (this._clearDiagnosticsWhenClosingFile ?: true)
 
+  /**
+   * Returns differences between `this` and `other` that call for
+   * ``SettingsManager.reinitializeLanguageToolInterface()``
+   * */
   fun getDifferencesRelevantForLanguageTool(other: Settings?): Set<SettingsDifference> {
     val differences = HashSet<SettingsDifference>()
 

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsOverride.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsOverride.kt
@@ -1,0 +1,340 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.settings
+
+import java.util.logging.Level
+
+@Suppress("TooManyFunctions")
+class SettingsOverride(
+  private val _inner: Settings,
+) {
+  private var enabled: Boolean? = null
+  private var languageShortCode: String? = null
+  private var allDictionaries: Map<String, Map<String, SetUpdate>>? = null
+  private var allRules: Map<String, Map<String, MapUpdate<Boolean>>>? = null
+  private var allHiddenFalsePositives: Map<String, Map<HiddenFalsePositive, SetUpdate>>? = null
+  private var bibtexFields: Map<String, MapUpdate<Boolean>>? = null
+  private var latexCommands: Map<String, MapUpdate<String>>? = null
+  private var latexEnvironments: Map<String, MapUpdate<String>>? = null
+  private var markdownNodes: Map<String, MapUpdate<String>>? = null
+  private var enablePickyRules: Boolean? = null
+  private var motherTongueShortCode: String? = null
+  private var languageModelRulesDirectory: String? = null
+  private var logLevel: Level? = null
+
+  val activeLanguageShortCode: String
+    get() = languageShortCode ?: _inner.languageShortCode
+
+  @Suppress("LongMethod", "CyclomaticComplexMethod")
+  fun toSettings(): Settings {
+    var newSettings = _inner
+    if (enabled == false) {
+      newSettings = newSettings.copy(_enabled = setOf())
+    }
+    languageShortCode?.let {
+      newSettings = newSettings.copy(_languageShortCode = it)
+    }
+    allDictionaries?.let {
+      newSettings =
+        newSettings.copy(
+          _allDictionaries =
+            overrideMapSet(
+              // hacky: get _allDictionaries.
+              newSettings.getModifiedDictionary(newSettings.dictionary),
+              it,
+            ),
+        )
+    }
+    allRules?.let {
+      // REMOVE -> REMOVE, REMOVE
+      // INSERT(true) -> INSERT, REMOVE
+      // INSERT(false) -> REMOVE, INSERT
+      fun mapSetOverride(invert: Boolean): Map<String, Map<String, SetUpdate>> =
+        it
+          .map { (lang, rules) ->
+            lang to
+              rules
+                .map { (rule, update) ->
+                  rule to
+                    if (update is MapUpdate.SetValue<Boolean>) {
+                      SetUpdate.fromBoolean(update.value).inverted(invert)
+                    } else {
+                      SetUpdate.REMOVE
+                    }
+                }.toMap()
+          }.toMap()
+      newSettings =
+        newSettings.copy(
+          _allEnabledRules =
+            overrideMapSet(
+              _inner.getModifiedEnabledRules(newSettings.enabledRules),
+              mapSetOverride(false),
+            ),
+          _allDisabledRules =
+            overrideMapSet(
+              _inner.getModifiedDisabledRules(newSettings.disabledRules),
+              mapSetOverride(true),
+            ),
+        )
+    }
+    allHiddenFalsePositives?.let {
+      newSettings =
+        newSettings.copy(
+          _allHiddenFalsePositives =
+            overrideMapSet(
+              newSettings.getModifiedHiddenFalsePositives(newSettings.hiddenFalsePositives),
+              it,
+            ),
+        )
+    }
+    bibtexFields?.let {
+      newSettings =
+        newSettings.copy(
+          _bibtexFields = overrideMap(newSettings.bibtexFields, it),
+        )
+    }
+    latexCommands?.let {
+      newSettings =
+        newSettings.copy(
+          _latexCommands = overrideMap(newSettings.latexCommands, it),
+        )
+    }
+    latexEnvironments?.let {
+      newSettings =
+        newSettings.copy(
+          _latexEnvironments = overrideMap(newSettings.latexEnvironments, it),
+        )
+    }
+    markdownNodes?.let {
+      newSettings =
+        newSettings.copy(
+          _markdownNodes = overrideMap(newSettings.markdownNodes, it),
+        )
+    }
+    enablePickyRules?.let { newSettings = newSettings.copy(_enablePickyRules = it) }
+    motherTongueShortCode?.let { newSettings = newSettings.copy(_motherTongueShortCode = it) }
+    languageModelRulesDirectory?.let {
+      newSettings = newSettings.copy(_languageModelRulesDirectory = it)
+    }
+    logLevel?.let { newSettings = newSettings.copy(_logLevel = it) }
+    return newSettings
+  }
+
+  fun updateEnabled(enabled: Boolean?) {
+    // default / disabled
+    this@SettingsOverride.enabled = enabled ?: true
+  }
+
+  fun updateLanguageShortCode(code: String?) {
+    // code / default
+    languageShortCode = code
+  }
+
+  fun updateCurrentDictionary(
+    word: String,
+    included: Boolean?,
+  ) {
+    // included / not included / fallback to _inner
+    allDictionaries =
+      overrideMapMap(
+        allDictionaries,
+        mapOf(activeLanguageShortCode to mapOf(word to MapUpdate.fromBoolean(included))),
+      )
+  }
+
+  fun updateCurrentRule(
+    rule: String,
+    enabled: Boolean?,
+  ) {
+    // enabled / disabled / fallback
+    allRules =
+      overrideMapMap(
+        allRules,
+        mapOf(activeLanguageShortCode to mapOf(rule to MapUpdate.metaUpdate(enabled))),
+      )
+  }
+
+  fun updateCurrentFalsePositive(
+    falsePositive: HiddenFalsePositive,
+    active: Boolean?,
+  ) {
+    // enabled / disabled / fallback
+    allHiddenFalsePositives =
+      overrideMapMap(
+        allHiddenFalsePositives,
+        mapOf(activeLanguageShortCode to mapOf(falsePositive to MapUpdate.fromBoolean(active))),
+      )
+  }
+
+  fun updateBibtexField(
+    field: String,
+    checked: Boolean?,
+  ) {
+    // checked / unchecked / fallback
+    bibtexFields =
+      overrideMap(
+        bibtexFields,
+        mapOf(field to MapUpdate.metaUpdate(checked)),
+      )
+  }
+
+  fun updateLatexCommand(
+    command: String,
+    action: String?,
+  ) {
+    latexCommands =
+      overrideMap(
+        latexCommands,
+        mapOf(command to MapUpdate.metaUpdate(action)),
+      )
+  }
+
+  fun updateLatexEnvironment(
+    environment: String,
+    action: String?,
+  ) {
+    latexEnvironments =
+      overrideMap(
+        latexEnvironments,
+        mapOf(environment to MapUpdate.metaUpdate(action)),
+      )
+  }
+
+  fun updateMarkdownNode(
+    node: String,
+    action: String?,
+  ) {
+    markdownNodes =
+      overrideMap(
+        markdownNodes,
+        mapOf(node to MapUpdate.metaUpdate(action)),
+      )
+  }
+
+  fun updatePickyRules(enabled: Boolean?) {
+    enablePickyRules = enabled
+  }
+
+  fun updateMotherTongueShortCode(code: String?) {
+    motherTongueShortCode = code
+  }
+
+  fun updateLanguageModelRulesDirectory(dir: String?) {
+    languageModelRulesDirectory = dir
+  }
+
+  fun updateLogLevel(level: Level?) {
+    logLevel = level
+  }
+
+  private companion object {
+    sealed class MapUpdate<V> {
+      class SetValue<V>(
+        val value: V,
+      ) : MapUpdate<V>()
+
+      class RemoveValue<V> : MapUpdate<V>()
+
+      companion object {
+        fun <V> fromNullable(value: V?): MapUpdate<V> = value?.let { SetValue(it) } ?: RemoveValue()
+
+        fun fromBoolean(boolean: Boolean?): MapUpdate<SetUpdate> {
+          // return value updates a set: null -> ignore, true -> insert, false -> remove
+          return if (boolean == null) RemoveValue() else SetValue(SetUpdate.fromBoolean(boolean))
+        }
+
+        fun <V> metaUpdate(value: V?): MapUpdate<MapUpdate<V>> =
+          if (value == null) RemoveValue() else SetValue(SetValue(value))
+      }
+
+      fun <K> performOn(
+        map: MutableMap<K, V>,
+        key: K,
+      ) {
+        if (this is SetValue) {
+          map[key] = this.value
+        } else {
+          map.remove(key)
+        }
+      }
+    }
+
+    enum class SetUpdate {
+      INSERT,
+      REMOVE,
+      ;
+
+      companion object {
+        fun fromBoolean(boolean: Boolean): SetUpdate = if (boolean) INSERT else REMOVE
+      }
+
+      fun <V> performOn(
+        set: MutableSet<V>,
+        value: V,
+      ) {
+        when (this) {
+          INSERT -> set.add(value)
+          REMOVE -> set.remove(value)
+        }
+      }
+
+      fun inverted(invert: Boolean): SetUpdate {
+        if (!invert) return this
+        return when (this) {
+          INSERT -> REMOVE
+          REMOVE -> INSERT
+        }
+      }
+    }
+
+    fun <K1, K2, V> overrideMapMap(
+      old: Map<K1, Map<K2, V>>?,
+      override: Map<K1, Map<K2, MapUpdate<V>>>,
+    ): Map<K1, Map<K2, V>> {
+      val new = old?.toMutableMap() ?: mutableMapOf()
+      for ((mapKey, mapOverride) in override) {
+        new[mapKey] = overrideMap(new[mapKey], mapOverride)
+      }
+      return new
+    }
+
+    fun <K, V> overrideMapSet(
+      old: Map<K, Set<V>>?,
+      override: Map<K, Map<V, SetUpdate>>,
+    ): Map<K, Set<V>> {
+      val new = old?.toMutableMap() ?: mutableMapOf()
+      for ((mapKey, setOverride) in override) {
+        new[mapKey] = overrideSet(new[mapKey], setOverride)
+      }
+      return new
+    }
+
+    fun <V> overrideSet(
+      old: Set<V>?,
+      override: Map<V, SetUpdate>,
+    ): MutableSet<V> {
+      val new = old?.toMutableSet() ?: mutableSetOf()
+      for ((setElement, setUpdate) in override) {
+        setUpdate.performOn(new, setElement)
+      }
+      return new
+    }
+
+    fun <K, V> overrideMap(
+      old: Map<K, V>?,
+      override: Map<K, MapUpdate<V>>,
+    ): MutableMap<K, V> {
+      val new = old?.toMutableMap() ?: mutableMapOf()
+      for ((mapKey, mapUpdate) in override) {
+        mapUpdate.performOn(new, mapKey)
+      }
+      return new
+    }
+  }
+}

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsParser.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsParser.kt
@@ -6,66 +6,233 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import org.bsplines.ltexls.settings.Settings
+import org.bsplines.ltexls.settings.SettingsOverride
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
+import java.util.logging.Level
 
 object SettingsParser {
-  private val SPLIT_SETTINGS_REGEX = Regex("[ \t]+")
+  class InlineSettingsParserException(
+    message: String,
+  ) : Exception(message)
+
+  private val KEY_VALUE_REGEX =
+    Regex("^[ \t\n\r]*(?<key>[^ \t]+)=(?<value>[^ \t\n\r]*)[ \t\n\r]*", RegexOption.MULTILINE)
+
+  private val ENABLED_REGEX = Regex("^enabled$", RegexOption.IGNORE_CASE)
+  private val LANGUAGE_SHORT_CODE_REGEX = Regex("^language$", RegexOption.IGNORE_CASE)
+  private val DICTIONARY_REGEX =
+    Regex("^(?:ltex\\.)?dictionary(?<op>[+#-])$", RegexOption.IGNORE_CASE)
+  private val RULE_REGEX = Regex("^(?:ltex\\.)?rules(?<op>[+#-])$", RegexOption.IGNORE_CASE)
+
+  @Suppress("UnusedPrivateProperty") // False positives are too complex to parse for now.
+  private val FALSE_POSITIVE_REGEX =
+    Regex("^(?:ltex\\.)?hiddenFalsePositives(?<op>[+#-])$", RegexOption.IGNORE_CASE)
+  private val BIBTEX_FIELD_REGEX =
+    Regex("^(?:ltex\\.)?bibtex\\.fields\\.(?<field>.+?)$", RegexOption.IGNORE_CASE)
+  private val LATEX_COMMAND_REGEX =
+    Regex("^(?:ltex\\.)?latex\\.commands\\.(?<command>.+?)$", RegexOption.IGNORE_CASE)
+  private val LATEX_ENVIRONMENT_REGEX =
+    Regex("^(?:ltex\\.)?latex\\.environments\\.(?<env>.+?)$", RegexOption.IGNORE_CASE)
+  private val MARKDOWN_NODES_REGEX =
+    Regex("^(?:ltex\\.)?markdown\\.nodes\\.(?<node>.+?)$", RegexOption.IGNORE_CASE)
+  private val PICKY_RULES_REGEX =
+    Regex("^(?:ltex\\.)?(additionalRules\\.)?enablePickyRules$", RegexOption.IGNORE_CASE)
+  private val MOTHER_TONGUE_SHORTCODE_REGEX =
+    Regex("^(?:ltex\\.)?(?:additionalRules\\.)?motherTongue$", RegexOption.IGNORE_CASE)
+  private val LANGUAGE_MODEL_REGEX =
+    Regex("^(?:ltex\\.)?(?:additionalRules\\.)?languagemodel$", RegexOption.IGNORE_CASE)
+  private val LOG_LEVEL_REGEX =
+    Regex("^(?:ltex\\.)?(?:ltex-ls\\.)?logLevel", RegexOption.IGNORE_CASE)
+
+  private val NULL_REGEX = Regex("^(?:null|nil|clear|#)$", RegexOption.IGNORE_CASE)
+  private val NULL_BOOL_REGEX =
+    Regex("^(?<t>true|1|yes)|(?<f>false|0|no)|(?<n>null|nil|clear|#|)$", RegexOption.IGNORE_CASE)
+  private val OP_REGEX = Regex("^(?<add>\\+)|(?<remove>-)|(?<keep>#)$", RegexOption.IGNORE_CASE)
 
   private fun parseSettings(settingsLine: String): Map<String, String> {
     val settingsMap = HashMap<String, String>()
 
-    for (settingsChange: String in settingsLine.trim().split(SPLIT_SETTINGS_REGEX)) {
-      val settingKeyLength: Int = settingsChange.indexOf('=')
+    var remainingLine = settingsLine
 
-      if (settingKeyLength == -1) {
-        Logging.LOGGER.warning(I18n.format("ignoringMalformedInlineSetting", settingsChange))
-        continue
+    fun nextMatch(): Pair<String, String>? {
+      val match = KEY_VALUE_REGEX.matchAt(remainingLine, 0)
+      return match?.let {
+        remainingLine = remainingLine.substring(it.groupValues[0].length)
+        return Pair(match.groups["key"]!!.value, match.groups["value"]!!.value)
       }
+    }
 
-      val settingKey: String = settingsChange.substring(0, settingKeyLength).trim()
-      val settingValue: String = settingsChange.substring(settingKeyLength + 1).trim()
-      settingsMap[settingKey] = settingValue
+    var kv = nextMatch()
+    while (kv != null) {
+      settingsMap[kv.first] = kv.second
+      kv = nextMatch()
+    }
+
+    if (remainingLine.isNotEmpty()) {
+      Logging.LOGGER.warning(I18n.format("ignoringMalformedInlineSetting", remainingLine))
     }
 
     return settingsMap
   }
 
-  /*
-    Return the original settings when no valid settings pair was found else it creates a modified copy
-   */
-  public fun createUpdatedSettings(
-    settingsMap: Map<String, String>,
-    currentSettings: Settings,
-  ): Settings {
-    var newSettings = currentSettings
-    for ((settingKey: String, settingValue: String) in settingsMap) {
+  @Suppress("CyclomaticComplexMethod", "LongMethod", "NestedBlockDepth")
+  public fun updateSettingsOverride(
+    key: String,
+    value: String,
+    override: SettingsOverride,
+  ) {
+    try {
       when {
-        settingKey.equals("enabled", ignoreCase = true) -> {
-          newSettings =
-            newSettings.copy(
-              _enabled = (if (settingValue == "true") Settings.DEFAULT_ENABLED else emptySet()),
-            )
+        ENABLED_REGEX
+          .matchEntire(key)
+          ?.let { override.updateEnabled(nullableBool(value, key)) } != null -> {
         }
-        settingKey.equals("language", ignoreCase = true) -> {
-          newSettings = newSettings.copy(_languageShortCode = settingValue)
+
+        LANGUAGE_SHORT_CODE_REGEX
+          .matchEntire(key)
+          ?.let { override.updateLanguageShortCode(nullableString(value)) } != null -> {
         }
+
+        DICTIONARY_REGEX.matchEntire(key)?.let {
+          override.updateCurrentDictionary(value, opToIncluded(it.groups["op"]!!.value, key))
+        } != null -> {
+        }
+
+        RULE_REGEX.matchEntire(key)?.let {
+          override.updateCurrentRule(value, opToIncluded(it.groups["op"]!!.value, key))
+        } != null -> {
+        }
+        // FALSE_POSITIVE_REGEX.matchEntire(key)?.let {
+        //   // parsing is too complicated for now
+        //   updateCurrentFalsePositive(???, nullableBool(value))
+        // } != null -> {}
+        BIBTEX_FIELD_REGEX.matchEntire(key)?.let {
+          override.updateBibtexField(it.groups["field"]!!.value, nullableBool(value, key))
+        } != null -> {
+        }
+
+        LATEX_COMMAND_REGEX.matchEntire(key)?.let {
+          override.updateLatexCommand(it.groups["command"]!!.value, nullableString(value))
+        } != null -> {
+        }
+
+        LATEX_ENVIRONMENT_REGEX.matchEntire(key)?.let {
+          override.updateLatexEnvironment(it.groups["env"]!!.value, nullableString(value))
+        } != null -> {
+        }
+
+        MARKDOWN_NODES_REGEX.matchEntire(key)?.let {
+          override.updateMarkdownNode(it.groups["node"]!!.value, nullableString(value))
+        } != null -> {
+        }
+
+        PICKY_RULES_REGEX
+          .matchEntire(key)
+          ?.let { override.updatePickyRules(nullableBool(value, key)) } != null -> {
+        }
+
+        MOTHER_TONGUE_SHORTCODE_REGEX
+          .matchEntire(key)
+          ?.let { override.updateMotherTongueShortCode(nullableString(value)) } != null -> {
+        }
+
+        LANGUAGE_MODEL_REGEX
+          .matchEntire(key)
+          ?.let { override.updateLanguageModelRulesDirectory(nullableString(value)) } != null -> {
+        }
+
+        LOG_LEVEL_REGEX.matchEntire(key)?.let {
+          override.updateLogLevel(
+            if (nullableString(value) == null) {
+              null
+            } else {
+              try {
+                Level.parse(value.uppercase())
+              } catch (_: IllegalArgumentException) {
+                throw InlineSettingsParserException(
+                  I18n.format(
+                    "ignoringUnknownInlineSettingValue",
+                    value,
+                  ),
+                )
+              }
+            },
+          )
+        } != null -> {
+        }
+
         else -> {
-          Logging.LOGGER.warning(
-            I18n.format("ignoringUnknownInlineSetting", settingKey, settingValue),
+          Logging.LOGGER.warning(I18n.format("ignoringUnknownInlineSetting", key, value))
+        }
+      }
+    } catch (e: InlineSettingsParserException) {
+      Logging.LOGGER.warning(e.message)
+    }
+  }
+
+  public fun updateSettingsOverride(
+    settingsLine: String,
+    override: SettingsOverride,
+  ) {
+    val settingsMap = parseSettings(settingsLine)
+    updateSettingsOverride(settingsMap, override)
+  }
+
+  public fun updateSettingsOverride(
+    settingsMap: Map<String, String>,
+    override: SettingsOverride,
+  ) {
+    for ((settingKey: String, settingValue: String) in settingsMap) {
+      updateSettingsOverride(settingKey, settingValue, override)
+    }
+  }
+
+  fun nullableString(s: String): String? = if (NULL_REGEX.matchEntire(s) != null) null else s
+
+  fun nullableBool(
+    s: String,
+    key: String,
+  ): Boolean? {
+    val m = NULL_BOOL_REGEX.matchEntire(s)
+    return m?.let {
+      return when {
+        (m.groups["t"] != null) -> true
+        (m.groups["f"] != null) -> false
+        (m.groups["n"] != null) -> null
+        else -> {
+          throw InlineSettingsParserException(
+            I18n.format(
+              "ignoringMalformedInlineSettingBoolean",
+              s,
+              key,
+            ),
           )
         }
       }
     }
-    return newSettings
   }
 
-  public fun createUpdatedSettings(
-    settingsLine: String,
-    currentSettings: Settings,
-  ): Settings {
-    val settingsMap: Map<String, String> = SettingsParser.parseSettings(settingsLine)
-    return SettingsParser.createUpdatedSettings(settingsMap, currentSettings)
+  fun opToIncluded(
+    s: String,
+    key: String,
+  ): Boolean? {
+    val m = OP_REGEX.matchEntire(s)
+    return m?.let {
+      return when {
+        (m.groups["add"] != null) -> true
+        (m.groups["remove"] != null) -> false
+        (m.groups["keep"] != null) -> null
+        else -> {
+          throw InlineSettingsParserException(
+            I18n.format(
+              "ignoringMalformedInlineSettingOperation",
+              s,
+              key,
+            ),
+          )
+        }
+      }
+    }
   }
 }

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -53,7 +53,10 @@ hideFalsePositive = Hide false positive
 hidingFalsePositive = Hiding false positive with rule '{0}' and sentence '{1}'
 ignoreEnvironmentEndPatternNotSet = ignoreEnvironmentEndPattern not set
 ignoringMalformedInlineSetting = Ignoring malformed inline setting '{0}'
-ignoringUnknownInlineSetting = Ignoring unknown inline setting with name '{0}' and value '{1}"'
+ignoringUnknownInlineSetting = Ignoring unknown inline setting with name '{0}' and value '{1}'
+ignoringUnknownInlineSettingValue = Ignoring malformed inline setting value '{0}' for name '{1}'
+ignoringMalformedInlineSettingBoolean = Ignoring malformed inline setting value '{0}' for name '{1}'. Expected a boolean: '0', '1', 'true', 'false', or '#' to remove this setting
+ignoringMalformedInlineSettingOperation = Ignoring malformed inline setting operation '{0}=' for name '{1}'. Expected '+=', '-=' or '#='
 initializingLtexLs = ltex-ls {0} - initializing...
 inputDocumentsAndSettingsFileAreDeprecated = --input-documents and --settings-file are deprecated \
     and will be removed in a future release. Use ltex-cli-plus instead.

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -53,10 +53,10 @@ hideFalsePositive = Hide false positive
 hidingFalsePositive = Hiding false positive with rule '{0}' and sentence '{1}'
 ignoreEnvironmentEndPatternNotSet = ignoreEnvironmentEndPattern not set
 ignoringMalformedInlineSetting = Ignoring malformed inline setting '{0}'
-ignoringUnknownInlineSetting = Ignoring unknown inline setting with name '{0}' and value '{1}'
-ignoringUnknownInlineSettingValue = Ignoring malformed inline setting value '{0}' for name '{1}'
 ignoringMalformedInlineSettingBoolean = Ignoring malformed inline setting value '{0}' for name '{1}'. Expected a boolean: '0', '1', 'true', 'false', or '#' to remove this setting
 ignoringMalformedInlineSettingOperation = Ignoring malformed inline setting operation '{0}=' for name '{1}'. Expected '+=', '-=' or '#='
+ignoringUnknownInlineSetting = Ignoring unknown inline setting with name '{0}' and value '{1}'
+ignoringUnknownInlineSettingValue = Ignoring malformed inline setting value '{0}' for name '{1}'
 initializingLtexLs = ltex-ls {0} - initializing...
 inputDocumentsAndSettingsFileAreDeprecated = --input-documents and --settings-file are deprecated \
     and will be removed in a future release. Use ltex-cli-plus instead.

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -114,6 +114,189 @@ class DocumentCheckerTest {
   }
 
   @Test
+  @Suppress("LongMethod")
+  fun testMagicComments() {
+    val document =
+      createDocument(
+        "latex",
+        """
+        \documentclass{article}
+
+        \newcommand{\ltexComment}[1]{}
+
+        \begin{document}
+
+        % LTeX: latex.commands.\ltexComment{}=ignore
+        \ltexComment{This text is now ignored. This is an test.}
+        \ltexComment{
+            Use KEY=VALUE to set scalar properties.
+            Use KEY=# to restore global settings (undo magic commands for this KEY).
+            Use KEY-=VALUE to remove VALUE from a set.
+            Use KEY+=VALUE to add VALUE to a set.
+            Use KEY#=VALUE to have VALUE in a set if and only if it is in the global set (undo magic commands for this KEY and VALUE).
+
+            Use 'true' or 'false' without quotes for booleans.
+        }
+
+        \ltexComment{}
+
+        \ltexComment{Enable and disable all checks.}
+        This is an \textbf{test} with a mistake.
+        % LTeX: enabled=false
+        This is an \textbf{test} with no mistake.
+        % LTeX: enabled=true
+        This is an \textbf{test} with a mistake.
+        % LTeX: enabled=#
+        This is an \textbf{test} with a mistake.
+
+        \ltexComment{Change the language.}
+        % LTeX: language=de-DE
+        This test contains the mistake. Dies ist ein Test ohne Fehler.
+        % LTeX: language=#
+        This is a test with no mistake. Dies ist ein Test with mistakes.
+
+
+        \ltexComment{Enable and disable rules.}
+        This is an \textbf{test} with a mistake.
+        % LTeX: rules-=EN_A_VS_AN
+        This is an \textbf{test} with no mistake.
+        % LTeX: rules+=EN_A_VS_AN
+        This is an \textbf{test} with a mistake.
+        % LTeX: rules#=EN_A_VS_AN
+        This is an \textbf{test} with a mistake.
+
+
+        \ltexComment{Add and remove words from the dictionary.}
+        \ltexComment{Known word: BROKEN}
+        Test is a word.
+        % LTeX: dictionary-=Test
+        Test is not a word.
+        % LTeX: dictionary+=Test
+        Test is a word.
+        % LTeX: dictionary#=Test
+        Test is a word.
+
+        \ltexComment{Unknown word}
+        Dcba is not a word.
+        % LTeX: dictionary-=Dcba
+        Dcba is not a word.
+        % LTeX: dictionary+=Dcba
+        Dcba is a word.
+        % LTeX: dictionary#=Dcba
+        Dcba is not a word.
+
+        \ltexComment{Set actions for latex commands.}
+        This is an \textbf{test} with a mistake.
+        % LTeX: latex.commands.\textbf{}=default 'default': parameters are checked.
+        This is an \textbf{test} with a mistake.
+        % LTeX: latex.commands.\textbf{}=ignore 'ignore': pretend it is not there.
+        This is an \textbf{test} ignored test without a mistake.
+        % LTeX: latex.commands.\textbf{}=dummy
+        \ltexComment{Apparently dummy can be plural.}
+        This \textbf{test} has no mistake.
+        These \textbf{test} have no mistake.
+        % LTeX: latex.commands.\textbf{}=pluralDummy
+        This \textbf{test} has a mistake.
+        These \textbf{test} have no mistake.
+        % LTeX: latex.commands.\textbf{}=vowelDummy
+        This is an \textbf{test} with no mistake.
+        % LTeX: latex.commands.\textbf{}=#
+        This is an \textbf{test} with a mistake.
+
+        \ltexComment{Set actions for latex environments.}
+        \begin{center}
+            This is an test with a mistake.
+        \end{center}
+        % LTeX: latex.environments.center=default 'default': check contents
+        \begin{center}
+            This is an test with a mistake.
+        \end{center}
+        % LTeX: latex.environments.center=ignore 'default': check nothing
+        \begin{center}
+            This is an test with no mistake.
+        \end{center}
+        % LTeX: latex.environments.center=#
+        \begin{center}
+            This is an test with a mistake.
+        \end{center}
+
+        \ltexComment{Enable picky rules}
+        The rules have been enabled by the comment. The sentence is fine.
+        % LTeX: enablePickyRules=false
+        The rules have been enabled by the comment. The sentence is fine.
+        % LTeX: enablePickyRules=true
+        The rules have been enabled by the comment. The sentence should be in active voice.
+        % LTeX: enablePickyRules=#
+        The rules have been enabled by the comment. The sentence is fine.
+
+        \ltexComment{Set logLevel for debugging a specific section}
+
+        % LTeX: logLevel=finer
+        Suppose this sentence produces weird logs.
+        % LTeX: logLevel=#
+
+        \ltexComment{You can change multiple values at once.}
+        % Ltex: language=de-DE rules-=DE_AGREEMENT
+        Dies ist eine Test.
+        % Ltex: language=#
+
+        \ltexComment{Comment suffixes that do not conform to KEY=VALUE are ignored.}
+        % Ltex: rules-=EN_A_VS_AN       I know what I am doing!
+        This is an test with no mistake.
+        % Ltex: rules#=EN_A_VS_AN       Never mind.
+        This is an test with a mistake.
+
+        \end{document}
+        """.trimIndent(),
+      )
+    val checkingResult = checkDocument(document)
+
+    val matches: List<LanguageToolRuleMatch> = checkingResult.first
+    assertEquals(matches.size, 22)
+
+    assertMatchIs(matches[0], "EN_A_VS_AN", "This is an test with a mistake.", 656, 658)
+    assertMatchIs(matches[1], "EN_A_VS_AN", "This is an test with a mistake.", 782, 784)
+    assertMatchIs(matches[2], "EN_A_VS_AN", "This is an test with a mistake.", 841, 843)
+    assertMatchIs(matches[3], "GERMAN_SPELLER_RULE", "This test contains the mistake.", 952, 955)
+    assertMatchIs(matches[4], "GERMAN_SPELLER_RULE", "This test contains the mistake.", 956, 963)
+    assertMatchIs(
+      matches[5],
+      "MORFOLOGIK_RULE_EN_US",
+      "Dies ist ein Test with mistakes.",
+      1052,
+      1055,
+    )
+    assertMatchIs(
+      matches[6],
+      "MORFOLOGIK_RULE_EN_US",
+      "Dies ist ein Test with mistakes.",
+      1056,
+      1059,
+    )
+    assertMatchIs(matches[7], "EN_A_VS_AN", "This is an test with a mistake.", 1130, 1132)
+    assertMatchIs(matches[8], "EN_A_VS_AN", "This is an test with a mistake.", 1265, 1267)
+    assertMatchIs(matches[9], "EN_A_VS_AN", "This is an test with a mistake.", 1332, 1334)
+    assertMatchIs(matches[10], "MORFOLOGIK_RULE_EN_US", "Dcba is not a word.", 1627, 1631)
+    assertMatchIs(matches[11], "MORFOLOGIK_RULE_EN_US", "Dcba is not a word.", 1672, 1676)
+    assertMatchIs(matches[12], "MORFOLOGIK_RULE_EN_US", "Dcba is not a word.", 1758, 1762)
+    assertMatchIs(matches[13], "EN_A_VS_AN", "This is an test with a mistake.", 1833, 1835)
+    assertMatchIs(matches[14], "EN_A_VS_AN", "This is an test with a mistake.", 1950, 1952)
+    assertMatchIs(matches[15], "AGREEMENT_SENT_START", "This Dummies has a mistake.", 2322, 2335)
+    assertMatchIs(matches[16], "EN_A_VS_AN", "This is an test with a mistake.", 2517, 2519)
+    assertMatchIs(matches[17], "EN_A_VS_AN", "This is an test with a mistake.", 2628, 2630)
+    assertMatchIs(matches[18], "EN_A_VS_AN", "This is an test with a mistake.", 2760, 2762)
+    assertMatchIs(matches[19], "EN_A_VS_AN", "This is an test with a mistake.", 2991, 2993)
+    assertMatchIs(
+      matches[20],
+      "PASSIVE_VOICE_SIMPLE",
+      "The rules have been enabled by the comment.",
+      3255,
+      3297,
+    )
+    assertMatchIs(matches[21], "EN_A_VS_AN", "This is an test with a mistake.", 3935, 3937)
+  }
+
+  @Test
   fun testMarkdown() {
     val document: LtexTextDocumentItem =
       createDocument(
@@ -128,6 +311,72 @@ class DocumentCheckerTest {
         """.trimIndent(),
       )
     assertMatches(checkDocument(document).first, 8, 10, 62, 73)
+  }
+
+  @Test
+  @Suppress("LongMethod")
+  fun testMagicCommentsMarkdown() {
+    val document =
+      createDocument(
+        "markdown",
+        """
+        # Magic comments
+
+        <!-- LTeX: loglevel=finest rules-=CONSECUTIVE_SPACES -->
+
+        This is an **test** with a mistake.
+        <!-- LTeX: markdown.nodes.StrongEmphasis=ignore -->
+        This is an **test** ignored test without a mistake.
+        <!-- LTeX: markdown.nodes.StrongEmphasis=default -->
+        This is an **test** with a mistake.
+        <!-- LTeX: markdown.nodes.StrongEmphasis=dummy -->
+        This is an **test** with a mistake.
+        <!-- LTeX: markdown.nodes.StrongEmphasis=# -->
+        This is an **test** with a mistake.
+        """.trimIndent(),
+      )
+    val checkingResult = checkDocument(document)
+
+    val matches: List<LanguageToolRuleMatch> = checkingResult.first
+    assertEquals(matches.size, 4)
+
+    assertMatchIs(matches[0], "EN_A_VS_AN", "This is an test with a mistake.", 84, 86)
+    assertMatchIs(matches[1], "EN_A_VS_AN", "This is an test with a mistake.", 277, 279)
+    assertMatchIs(matches[2], "EN_A_VS_AN", "This is an Dummy0 with a mistake.", 364, 366)
+    assertMatchIs(matches[3], "EN_A_VS_AN", "This is an test with a mistake.", 447, 449)
+  }
+
+  @Test
+  @Suppress("LongMethod")
+  fun testMagicCommentsBibtex() {
+    val document =
+      createDocument(
+        "bibtex",
+        """
+        % Set actions for bibtex fields.
+        @misc{sample,
+          author    = {This is an test.},
+        }
+        % LTeX: bibtex.fields.author=false
+        @misc{sample,
+          author    = {This is an test.},
+        }
+        % LTeX: bibtex.fields.author=true
+        @misc{sample,
+          author    = {This is an test.},
+        }
+        % LTeX: bibtex.fields.author=#
+        @misc{sample,
+          author    = {This is an test.},
+        }
+        """.trimIndent(),
+      )
+    val checkingResult = checkDocument(document)
+
+    val matches: List<LanguageToolRuleMatch> = checkingResult.first
+    assertEquals(matches.size, 1)
+
+    assertMatchIs(matches[0], "EN_A_VS_AN", "This is an test.", 239, 241)
   }
 
   @Test
@@ -398,6 +647,19 @@ class DocumentCheckerTest {
       assertEquals("ein Test", matches[1].suggestedReplacements[0])
       assertEquals("einen Test", matches[1].suggestedReplacements[1])
       assertEquals("einem Test", matches[1].suggestedReplacements[2])
+    }
+
+    fun assertMatchIs(
+      match: LanguageToolRuleMatch,
+      rule: String,
+      sentence: String,
+      fromPos: Int,
+      toPos: Int,
+    ) {
+      assertEquals(rule, match.ruleId)
+      assertEquals(sentence.trim(), match.sentence?.trim())
+      assertEquals(fromPos, match.fromPos)
+      assertEquals(toPos, match.toPos)
     }
   }
 }


### PR DESCRIPTION
This PR adds settings overrides that can shadow the user's settings in a document. With that, I added support for magic comments that "temporarily" disable or enable rules, add words to the dictionary etc.

Example:

```tex
% LTeX: rules-=EN_A_VS_AN
% The rule is disabled.
This is an \textbf{test} with no mistake.
% LTeX: rules+=EN_A_VS_AN
% The rule is enabled. 
This is an \textbf{test} with a mistake.
% LTeX: rules#=EN_A_VS_AN
% The override for this rule removed. It is enabled if and only if it is enabled through "normal" settings. 
This is an \textbf{test} with a mistake.
```

More examples are in the tests.

Fixes #86.