### PR TITLE
Remove incorrect babel language mapping for estonian

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/parsing/latex/LatexFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/latex/LatexFragmentizer.kt
@@ -455,7 +455,6 @@ class LatexFragmentizer(
         map["english"] = "en-US"
         map["USenglish"] = "en-US"
         map["esperanto"] = "eo"
-        map["estonian"] = "es"
         map["farsi"] = "fa"
         map["french"] = "fr"
         map["irish"] = "ga-IE"


### PR DESCRIPTION
Estonian is `et`, which is not supported by LanguageTool. `es` is Spanish, which is a completely different language.