### PR TITLE
Fix: Magic comments: Allow multiple settings per comment

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsParser.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsParser.kt
@@ -50,8 +50,8 @@ object SettingsParser {
     Regex("^(?<t>true|1|yes)|(?<f>false|0|no)|(?<n>null|nil|clear|#|)$", RegexOption.IGNORE_CASE)
   private val OP_REGEX = Regex("^(?<add>\\+)|(?<remove>-)|(?<keep>#)$", RegexOption.IGNORE_CASE)
 
-  private fun parseSettings(settingsLine: String): Map<String, String> {
-    val settingsMap = HashMap<String, String>()
+  private fun parseSettings(settingsLine: String): Iterable<Pair<String, String>> {
+    val settingsUpdates = ArrayList<Pair<String, String>>()
 
     var remainingLine = settingsLine
 
@@ -65,7 +65,7 @@ object SettingsParser {
 
     var kv = nextMatch()
     while (kv != null) {
-      settingsMap[kv.first] = kv.second
+      settingsUpdates.add(kv)
       kv = nextMatch()
     }
 
@@ -73,7 +73,7 @@ object SettingsParser {
       Logging.LOGGER.warning(I18n.format("ignoringMalformedInlineSetting", remainingLine))
     }
 
-    return settingsMap
+    return settingsUpdates
   }
 
   @Suppress("CyclomaticComplexMethod", "LongMethod", "NestedBlockDepth")
@@ -175,15 +175,15 @@ object SettingsParser {
     settingsLine: String,
     override: SettingsOverride,
   ) {
-    val settingsMap = parseSettings(settingsLine)
-    updateSettingsOverride(settingsMap, override)
+    val settingsUpdates = parseSettings(settingsLine)
+    updateSettingsOverride(settingsUpdates, override)
   }
 
   public fun updateSettingsOverride(
-    settingsMap: Map<String, String>,
+    settingsUpdate: Iterable<Pair<String, String>>,
     override: SettingsOverride,
   ) {
-    for ((settingKey: String, settingValue: String) in settingsMap) {
+    for ((settingKey: String, settingValue: String) in settingsUpdate) {
       updateSettingsOverride(settingKey, settingValue, override)
     }
   }

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -296,6 +296,37 @@ class DocumentCheckerTest {
     assertMatchIs(matches[21], "EN_A_VS_AN", "This is an test with a mistake.", 3935, 3937)
   }
 
+  /**
+   * This is a regression test for https://github.com/ltex-plus/ltex-ls-plus/pull/102#issuecomment-3415086204.
+   */
+  @Test
+  fun testMultipleDictionaryEntriesInMagicComment() {
+    val document =
+      createDocument(
+        "latex",
+        """
+        \documentclass{article}
+        \newcommand{\ltexComment}[1]{}
+        \begin{document}
+        Olching
+
+        Ruedsy
+        % LTeX: dictionary+=Olching dictionary+=Ruedsy
+        Olching
+
+        Ruedsy
+        \end{document}
+        """.trimIndent(),
+      )
+    val checkingResult = checkDocument(document)
+
+    val matches: List<LanguageToolRuleMatch> = checkingResult.first
+    assertEquals(2, matches.size)
+
+    assertMatchIs(matches[0], "MORFOLOGIK_RULE_EN_US", "Olching", 72, 79)
+    assertMatchIs(matches[1], "MORFOLOGIK_RULE_EN_US", "Ruedsy", 81, 87)
+  }
+
   @Test
   fun testMarkdown() {
     val document: LtexTextDocumentItem =


### PR DESCRIPTION
Fixes https://github.com/ltex-plus/ltex-ls-plus/pull/102#issuecomment-3415086204

Previously, only the last magic comment value of any key (such as `dictionary+=...`) per comment was effective. This is because these keys were stored in a Map. I don't remember if there was a specific reason why I used Map there but my tests pass with a collection of pairs.

Also adds a regression test for multiple `dictionary+=` strings.