### PR TITLE
Create official docker images on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ on:
     branches:
       - "develop"
   workflow_dispatch:
+    inputs:
+      publish_docker:
+        description: "Also build and push the container image"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -177,7 +183,11 @@ jobs:
       - "build"
       - "validate"
       - "get-version"
-    if: "${{ startsWith(github.ref, 'refs/tags/') }}"
+    if: >-
+      ${{
+        startsWith(github.ref, 'refs/tags/') ||
+        (github.event_name == 'workflow_dispatch' && inputs.publish_docker)
+      }}
     runs-on: "ubuntu-latest"
     permissions:
       contents: read
@@ -209,6 +219,7 @@ jobs:
           images: "ghcr.io/${{ github.repository_owner }}/ltex-ls-plus"
           tags: |
             type=ref,event=tag
+            type=raw,value=${{ format('{0}-test-image', needs.get-version.outputs.ltex_ls_version) }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: "Build and Push"
         uses: "docker/build-push-action@v6"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,3 +170,55 @@ jobs:
           'target/ltex-ls-plus-${{ needs.get-version.outputs.ltex_ls_version }}-windows-aarch64.zip'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: "CI - Deploy Container Image Job"
+    needs:
+      - "build"
+      - "validate"
+      - "get-version"
+    if: "${{ startsWith(github.ref, 'refs/tags/') }}"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: "Checkout Repository"
+        uses: "actions/checkout@v6"
+
+      - name: "Set up QEMU"
+        uses: "docker/setup-qemu-action@v4"
+        with:
+          platforms: "amd64,arm64"
+
+      - name: "Set up Buildx"
+        uses: "docker/setup-buildx-action@v4"
+
+      - name: "Log in to GHCR"
+        uses: "docker/login-action@v4"
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Compute Tags and Labels"
+        id: "meta"
+        uses: "docker/metadata-action@v6"
+        with:
+          images: "ghcr.io/${{ github.repository_owner }}/ltex-ls-plus"
+          tags: |
+            type=ref,event=tag
+
+      - name: "Build and Push"
+        uses: "docker/build-push-action@v6"
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: "."
+          file: "./Dockerfile"
+          push: true
+          build-args: |
+            LTEX_VERSION=${{ needs.get-version.outputs.ltex_ls_version }}
+            SOURCE_MODE=from-local
+          tags: "${{ steps.meta.outputs.tags }}"
+          labels: "${{ steps.meta.outputs.labels }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,44 @@ jobs:
       - name: "Check Source Consistency"
         run: "python -u tools/checkSourceConsistency.py"
 
+  get-version:
+    name: "CI - Get Version Job"
+    runs-on: ubuntu-latest
+    outputs:
+      ltex_ls_version: ${{ steps.meta.outputs.ltex_ls_version }}
+      ltex_ls_is_prerelease: ${{ steps.meta.outputs.ltex_ls_is_prerelease }}
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v6
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: "Install Python Dependencies"
+        run: python -u -m pip install --upgrade pip && pip install semver
+
+      - name: "Compute metadata"
+        id: meta
+        run: |
+          LTEX_LS_VERSION="$(python -u -c "import re; print(re.search(r'<version>(.*?)</version>', open('pom.xml', 'r').read()).group(1), end='')")"
+          if [[ -z "$LTEX_LS_VERSION" ]]; then
+            echo "Error: LTEX_LS_VERSION not set"
+            exit 1
+          fi
+
+            LTEX_LS_IS_PRERELEASE="$(python -u -c "import semver; print('true' if semver.VersionInfo.parse('${LTEX_LS_VERSION}').prerelease is not None else 'false', end='')")"
+
+            echo "ltex_ls_version=$LTEX_LS_VERSION" >> "$GITHUB_OUTPUT"
+            echo "ltex_ls_is_prerelease=$LTEX_LS_IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+
   deploy:
     name: "CI - Deploy Job"
     needs:
       - "build"
       - "validate"
+      - "get-version"
     if: "${{ startsWith(github.ref, 'refs/tags/') }}"
     runs-on: "ubuntu-latest"
     permissions:
@@ -106,20 +139,15 @@ jobs:
       - name: "Install Python Dependencies"
         run: "python -u -m pip install --upgrade pip && pip install semver"
 
-      - name: "Set LTEX_LS_VERSION"
-        run: "echo \"LTEX_LS_VERSION=$(python -u -c \"import re; print(re.search(r'<version>(.*?)</version>', open('pom.xml', 'r').read()).group(1), end='')\")\" >> $GITHUB_ENV"
-
-      - name: "Check LTEX_LS_VERSION"
-        run: "if [[ -z \"$LTEX_LS_VERSION\" ]]; then echo 'Error: LTEX_LS_VERSION not set!'; (exit 1); fi; echo \"LTEX_LS_VERSION set to '$LTEX_LS_VERSION'\""
-
-      - name: "Set LTEX_LS_IS_PRERELEASE"
-        run: "if [[ -z \"$LTEX_LS_VERSION\" ]]; then echo 'Error: LTEX_LS_VERSION not set!'; (exit 1); fi; echo \"LTEX_LS_IS_PRERELEASE=$(python -u -c \"import semver; print('true' if semver.VersionInfo.parse('$LTEX_LS_VERSION').prerelease is not None else 'false', end='')\")\" >> $GITHUB_ENV"
-
-      - name: "Check LTEX_LS_IS_PRERELEASE"
-        run: "if [[ -z \"$LTEX_LS_IS_PRERELEASE\" ]]; then echo 'Error: LTEX_LS_IS_PRERELEASE not set!'; (exit 1); fi; echo \"LTEX_LS_IS_PRERELEASE set to '$LTEX_LS_IS_PRERELEASE'\""
-
       - name: "Set LTEX_LS_CHANGELOG"
-        run: "if [ \"$LTEX_LS_IS_PRERELEASE\" = \"false\" ]; then echo \"LTEX_LS_CHANGELOG<<EOF\" >> $GITHUB_ENV; python -u tools/convertChangelog.py --xml-file changelog.xml --version latest >> $GITHUB_ENV; echo \"EOF\" >> $GITHUB_ENV; else echo \"LTEX_LS_CHANGELOG=This is a pre-release. Use at your own risk.\" >> $GITHUB_ENV; fi"
+        run: |
+          if [ "${{ needs.get-version.outputs.ltex_ls_is_prerelease }}" = "false" ]; then
+            echo "LTEX_LS_CHANGELOG<<EOF" >> "$GITHUB_ENV"
+            python -u tools/convertChangelog.py --xml-file changelog.xml --version latest >> "$GITHUB_ENV"
+            echo "EOF" >> "$GITHUB_ENV"
+          else
+            echo "LTEX_LS_CHANGELOG=This is a pre-release. Use at your own risk." >> "$GITHUB_ENV"
+          fi
 
       - name: "Build LTeX+ LS"
         run: "mvn -B -e package"
@@ -130,15 +158,15 @@ jobs:
       - name: "Create GitHub Release"
         run: >
           gh release create ${{ github.ref_name }}
-          --prerelease=${{ env.LTEX_LS_IS_PRERELEASE }}
-          --title='${{ env.LTEX_LS_VERSION }}'
+          --prerelease=${{ needs.get-version.outputs.ltex_ls_is_prerelease }}
+          --title='${{ needs.get-version.outputs.ltex_ls_version }}'
           --notes='${{ env.LTEX_LS_CHANGELOG }}'
-          'target/ltex-ls-plus-${{ env.LTEX_LS_VERSION }}.tar.gz'
-          'target/ltex-ls-plus-${{ env.LTEX_LS_VERSION }}-linux-x64.tar.gz'
-          'target/ltex-ls-plus-${{ env.LTEX_LS_VERSION }}-mac-x64.tar.gz'
-          'target/ltex-ls-plus-${{ env.LTEX_LS_VERSION }}-windows-x64.zip'
-          'target/ltex-ls-plus-${{ env.LTEX_LS_VERSION }}-linux-aarch64.tar.gz'
-          'target/ltex-ls-plus-${{ env.LTEX_LS_VERSION }}-mac-aarch64.tar.gz'
-          'target/ltex-ls-plus-${{ env.LTEX_LS_VERSION }}-windows-aarch64.zip'
+          'target/ltex-ls-plus-${{ needs.get-version.outputs.ltex_ls_version }}.tar.gz'
+          'target/ltex-ls-plus-${{ needs.get-version.outputs.ltex_ls_version }}-linux-x64.tar.gz'
+          'target/ltex-ls-plus-${{ needs.get-version.outputs.ltex_ls_version }}-mac-x64.tar.gz'
+          'target/ltex-ls-plus-${{ needs.get-version.outputs.ltex_ls_version }}-windows-x64.zip'
+          'target/ltex-ls-plus-${{ needs.get-version.outputs.ltex_ls_version }}-linux-aarch64.tar.gz'
+          'target/ltex-ls-plus-${{ needs.get-version.outputs.ltex_ls_version }}-mac-aarch64.tar.gz'
+          'target/ltex-ls-plus-${{ needs.get-version.outputs.ltex_ls_version }}-windows-aarch64.zip'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,36 @@
 # docker build --build-arg LTEX_VERSION=18.2.0 .
 # docker run ltex-ls-plus --endless
 
+# 1. Define where to get the source (defaults to 'from-release' for standard users)
+ARG SOURCE_MODE=from-release
+
+# --- Source Stages ---
+FROM alpine AS source-from-release
+ARG LTEX_VERSION
+RUN test -n "$LTEX_VERSION" || (echo "Mandatory argument LTEX_VERSION not set" && false)
+RUN apk add --no-cache wget tar
+RUN wget -q https://github.com/ltex-plus/ltex-ls-plus/archive/refs/tags/${LTEX_VERSION}.tar.gz \
+    && tar -xzf ${LTEX_VERSION}.tar.gz \
+    && mv -v ltex-ls-plus-${LTEX_VERSION} /ltex-ls-plus-src
+
+FROM alpine AS source-from-local
+ARG LTEX_VERSION
+RUN test -n "$LTEX_VERSION" || (echo "Mandatory argument LTEX_VERSION not set" && false)
+COPY . /ltex-ls-plus-src/
+
+FROM source-${SOURCE_MODE} AS source-resolved
+# ---------------------
 
 FROM maven:3-eclipse-temurin-21-alpine AS builder
 ARG LTEX_VERSION
-# Argument LTEX_VERSION is mandatory
-RUN test -n "$LTEX_VERSION" || (echo "Mandatory argument LTEX_VERSION not set" && false)
 # Install build dependencies
 RUN apk add --no-cache python3 \
     && ln -sf /usr/bin/python3 /usr/bin/python
-# Download the release
-RUN wget -q https://github.com/ltex-plus/ltex-ls-plus/archive/refs/tags/${LTEX_VERSION}.tar.gz \
-    && tar -xzf ${LTEX_VERSION}.tar.gz \
-    && rm -vf ${LTEX_VERSION}.tar.gz \
-    && mv -v ltex-ls-plus-${LTEX_VERSION} ltex-ls-plus-src
+
+# 2. Obtain the source code from the dynamically resolved stage
+COPY --from=source-resolved /ltex-ls-plus-src /ltex-ls-plus-src
 WORKDIR /ltex-ls-plus-src
+
 # Generate completion lists
 RUN python -u tools/createCompletionLists.py
 # Build


### PR DESCRIPTION
# Create official docker images on release

Make it easier to use ltex-ls-plus by releasing an official container image. This enables users to simply

```
 docker run ghcr.io/ltex-plus/ltex-ls-plus:<version> --endless
```

or run the container as a tcp server using docker compose for example.

I'm not sure this aligns with the current project goals, so feel free to close the pull request without comment if it doesn't.

## features
- Container built for amd64 and aarch64
- Container built and pushed to registry when a tag is pushed or by triggering a manual build on the github actions UI.

## testing

You can see what a manually triggered workflow looks like at https://github.com/Tuwebti/ltex-ls-plus/actions/runs/23150465878

The resulting container can be pulled with 

```
docker pull ghcr.io/tuwebti/ltex-ls-plus:18.7.0-alpha-test-image 
```