### PR TITLE
Fix: spell-check text in org-mode #+CAPTION affiliated keyword

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -29,6 +29,9 @@
       <action type="add" issue="ltex-plus/ltex-ls-plus#142" due-to="Malik Tuwebti (@Tuwebti)">
         Create official docker images on release#142
       </action>
+      <action type="fix" issue="ltex-plus/ltex-ls-plus#149" due-to="Andrea Alberti (@alberti42)">
+        Fix: spell-check text in org-mode `#+CAPTION` affiliated keyword
+      </action>
     </release>
     <release version="18.6.1" date="2025-10-19">
       <action type="fix" issue="ltex-plus/vscode-ltex-plus#165">

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilder.kt
@@ -133,6 +133,8 @@ class OrgAnnotatedTextBuilder(
       this.elementTypeStack.addLast(ElementType.Headline)
       this.appendAtEndOfLine = "\n"
       addMarkup(matchResult?.value, "\n")
+    } else if (matchFromPosition(CAPTION_PREFIX_REGEX)?.also { matchResult = it } != null) {
+      addMarkup(matchResult?.value)
     } else if (
       matchFromPosition(AFFILIATED_KEYWORDS_REGEX)?.also { matchResult = it } != null
     ) {
@@ -525,10 +527,16 @@ class OrgAnnotatedTextBuilder(
         RegexOption.IGNORE_CASE,
       )
 
+    private val CAPTION_PREFIX_REGEX =
+      Regex(
+        "^#\\+CAPTION(\\[[^\r\n]*?])?: ",
+        RegexOption.IGNORE_CASE,
+      )
+
     private val AFFILIATED_KEYWORDS_REGEX =
       Regex(
-        "^#\\+((CAPTION|HEADER|NAME|PLOT|RESULTS)|" +
-          "((CAPTION|RESULTS)\\[[^\r\n]*?])|ATTR_[-0-9A-Z_a-z]+): [^\r\n]*(?=\r?\n|$)",
+        "^#\\+((HEADER|NAME|PLOT|RESULTS)|" +
+          "(RESULTS\\[[^\r\n]*?])|ATTR_[-0-9A-Z_a-z]+): [^\r\n]*(?=\r?\n|$)",
         RegexOption.IGNORE_CASE,
       )
 

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilderTest.kt
@@ -37,7 +37,7 @@ class OrgAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("org") {
       This is a test.
 
       #+HEADER: test
-      #+CAPTION[abc]: def
+      #+NAME: some-name
       Second sentence.
 
         #+ATTR_foo01_bar: BOOM
@@ -45,6 +45,36 @@ class OrgAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("org") {
 
       """.trimIndent(),
       "This is a test.\n\n\n\nSecond sentence.\n\n\nFinal sentence.\n",
+    )
+  }
+
+  @Test
+  fun testCaptions() {
+    assertPlainText(
+      """
+      This is a test.
+      #+CAPTION: A short caption.
+      This is another test.
+
+      """.trimIndent(),
+      "This is a test.\nA short caption.\nThis is another test.\n",
+    )
+    assertPlainText(
+      """
+      This is a test.
+      #+CAPTION[short]: A longer caption description.
+      This is another test.
+
+      """.trimIndent(),
+      "This is a test.\nA longer caption description.\nThis is another test.\n",
+    )
+    assertPlainText(
+      "This is a test.\n#+CAPTION: A caption with *bold* and [[https://example.com][a link]].\n",
+      "This is a test.\nA caption with bold and a link.\n",
+    )
+    assertPlainText(
+      "#+CAPTION[short alt]: Here is an example [code] with square brackets in it.\n",
+      "Here is an example [code] with square brackets in it.\n",
     )
   }
 


### PR DESCRIPTION
## Problem

In org-mode files, the text on `#+CAPTION:` lines was silently skipped by the spell checker. For example:

```org
#+CAPTION: This is a mispeled caption.
[[file:figure1.png]]
```

LTeX would never flag `mispeled` here, even though the caption is user-visible prose that appears in the exported PDF/HTML.

## Root cause

In `OrgAnnotatedTextBuilder.kt`, `CAPTION` shared a single regex with the other affiliated keywords:

```kotlin
private val AFFILIATED_KEYWORDS_REGEX =
  Regex(
    "^#\\+((CAPTION|HEADER|NAME|PLOT|RESULTS)|" +
      "((CAPTION|RESULTS)\\[[^\r\n]*?])|ATTR_[-0-9A-Z_a-z]+): [^\r\n]*(?=\r?\n|$)",
    ...
  )
```

The branch handling it consumed the **entire** line as markup:

```kotlin
} else if (matchFromPosition(AFFILIATED_KEYWORDS_REGEX)?.also { matchResult = it } != null) {
  addMarkup(matchResult?.value)
}
```

Per the org-mode spec, `CAPTION`, `HEADER`, `NAME`, `PLOT`, `RESULTS`, and `ATTR_*` are all "affiliated keywords" and share the same line shape (`#+KEYWORD: value`), so it's easy to lump them together. But they are not semantically alike:

| Keyword   | Value type                              | Should be spell-checked? |
|-----------|-----------------------------------------|--------------------------|
| `CAPTION` | User-visible prose (with inline markup) | **Yes**                  |
| `HEADER`  | Babel header arguments                  | No                       |
| `NAME`    | Identifier                              | No                       |
| `PLOT`    | Plotting options                        | No                       |
| `RESULTS` | Name reference                          | No                       |
| `ATTR_*`  | Export attributes                       | No                       |

Only `CAPTION` carries prose; the rest are metadata consumed by the exporter. Grouping them by syntax obscured that distinction.

## Fix

Split `CAPTION` out of the shared regex into its own **prefix** regex that matches only `#+CAPTION: ` (and the optional short-form `#+CAPTION[short]: `):

```kotlin
private val CAPTION_PREFIX_REGEX =
  Regex("^#\\+CAPTION(\\[[^\r\n]*?])?: ", RegexOption.IGNORE_CASE)

private val AFFILIATED_KEYWORDS_REGEX =
  Regex(
    "^#\\+((HEADER|NAME|PLOT|RESULTS)|" +
      "(RESULTS\\[[^\r\n]*?])|ATTR_[-0-9A-Z_a-z]+): [^\r\n]*(?=\r?\n|$)",
    RegexOption.IGNORE_CASE,
  )
```

A new branch in `processStartOfLine` consumes only the prefix as markup:

```kotlin
} else if (matchFromPosition(CAPTION_PREFIX_REGEX)?.also { matchResult = it } != null) {
  addMarkup(matchResult?.value)
}
```

After the prefix is consumed, the position is mid-line, so subsequent characters go through the normal `processCharacterInternal` path and are treated as paragraph prose. This automatically preserves correct handling of inline markup (`*bold*`, `/italic/`, `=verbatim=`), links, LaTeX fragments, and everything else that can appear per specification inside a caption.

The other affiliated keywords (`HEADER`, `NAME`, `PLOT`, `RESULTS`, `ATTR_*`) continue to be consumed in full as markup; their behavior is unchanged.

## Tests

- `testAffiliatedKeywords` was updated to no longer include `#+CAPTION` (it now covers only the metadata keywords, which is what the test was actually meant to verify).
- A new `testCaptions` test covers:
  - `#+CAPTION: A short caption.` → prose is checked.
  - `#+CAPTION[short]: A longer caption description.` → short-form variant works.
  - `#+CAPTION: A caption with *bold* and [[https://example.com][a link]].` → inline markup and link descriptions inside a caption are handled by the fallthrough path.
  - `#+CAPTION[short alt]: Here is an example [code] with square brackets in it.` → pins that the lazy `[^\r\n]*?` inside the optional `[...]` group stops at the first `]` and does not gobble square brackets that legitimately appear later in the caption body.

All 36 tests in `OrgAnnotatedTextBuilderTest` pass.

## Manual verification

Tested against a smoke-test org file containing misspellings inside `#+CAPTION:` / `#+CAPTION[short]:` lines and inside `#+NAME:`, `#+HEADER:`, `#+ATTR_html:`, `#+PLOT:` lines. Captions are flagged; metadata lines are not. A plain-prose misspelling confirms the checker itself is active.

## Credits

The bug was identified by [u/TremulousTones](https://www.reddit.com/user/TremulousTones/), who shared it over a Reddit [post](https://www.reddit.com/r/emacs/comments/1sp1wly/).