### PR TITLE
Normalize ltex.language so regional variants don't silently disable checking 

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -14,6 +14,9 @@
   </properties>
   <body>
     <release version="18.7.0" date="upcoming">
+      <action type="fix">
+        Normalize `ltex.language` input so regional variants (e.g. `fr-FR`, `it-IT`, `es-ES`) are mapped to the registered LanguageTool tag rather than silently disabling checking. Also accepts case variants of the `"auto"` sentinel (`"Auto"`, `"AUTO"`) and trims leading/trailing whitespace.
+      </action>
       <action type="fix" issue="ltex-plus/vscode-ltex-plus#170">
         Fix spelling errors for Polish dummies
       </action>

--- a/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
@@ -13,7 +13,10 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import org.bsplines.ltexls.tools.FileIo
+import org.bsplines.ltexls.tools.I18n
+import org.bsplines.ltexls.tools.Logging
 import org.eclipse.lsp4j.DiagnosticSeverity
+import org.languagetool.Languages
 import java.util.logging.Level
 
 data class Settings(
@@ -206,7 +209,8 @@ data class Settings(
       val jsonWorkspaceSpecificSettings2 = jsonWorkspaceSpecificSettings ?: jsonSettings
 
       val enabled: Set<String>? = getEnabledFromJson(jsonSettings)
-      val languageShortCode: String? = getSettingFromJsonAsString(jsonSettings, "language")
+      val languageShortCode: String? =
+        getSettingFromJsonAsString(jsonSettings, "language")?.let { normalizeLanguageShortCode(it) }
       val allDictionaries: Map<String, Set<String>>? =
         mergeMapOfListsIntoMapOfSets(
           convertJsonObjectToMapOfLists(
@@ -342,6 +346,41 @@ data class Settings(
         clearDiagnosticsWhenClosingFile,
       )
     }
+
+    fun normalizeLanguageShortCode(raw: String): String {
+      val trimmed = raw.trim()
+      if (trimmed.equals("auto", ignoreCase = true)) return "auto"
+
+      val canonical =
+        LANGUAGE_TAG_REGEX.matchEntire(trimmed)?.destructured?.let { (lang, region, rest) ->
+          val regionPart = if (region.isEmpty()) "" else "-${region.uppercase()}"
+          "${lang.lowercase()}$regionPart$rest"
+        } ?: trimmed
+
+      if (Languages.isLanguageSupported(canonical)) return canonical
+
+      // The user asked for a regional variant (e.g. "fr-FR") that the bundled
+      // LanguageTool does not register as a distinct tag, but it does register
+      // the bare language (e.g. "fr"). This is the normal case for languages
+      // that LT ships without regional splits (French, Italian, Spanish,
+      // Swedish, ...): the bare code IS the full checker and provides both
+      // spelling and grammar — the user loses nothing.
+      //
+      // The edge case is a typo on a language that DOES have registered
+      // variants (e.g. "en-YZ" -> "en", "de-XX" -> "de"): there the bare code
+      // is a grammar-only umbrella class with no spell dictionary. The log
+      // line covers both cases neutrally so the user can tell what was used.
+      val base = canonical.substringBefore("-")
+      if (base != canonical && Languages.isLanguageSupported(base)) {
+        Logging.LOGGER.info(I18n.format("demotedLanguageToBase", canonical, base))
+        return base
+      }
+
+      return canonical
+    }
+
+    private val LANGUAGE_TAG_REGEX: Regex =
+      Regex("""^([A-Za-z]{2,3})(?:-([A-Za-z]{2}))?(-.*)?$""")
 
     private fun getEnabledFromJson(jsonSettings: JsonElement): Set<String>? {
       val jsonElement: JsonElement? = getSettingFromJsonAsJsonElement(jsonSettings, "enabled")

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsOverride.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsOverride.kt
@@ -133,7 +133,7 @@ class SettingsOverride(
 
   fun updateLanguageShortCode(code: String?) {
     // code / default
-    languageShortCode = code
+    languageShortCode = code?.let { Settings.normalizeLanguageShortCode(it) }
   }
 
   fun updateCurrentDictionary(

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -42,6 +42,9 @@ couldNotReadFile = Could not read file '{0}'
 couldNotSendHttpRequestToLanguageTool = Could not send the HTTP request to the LanguageTool \
     server
 couldNotWriteFile = Could not write file '{0}'
+demotedLanguageToBase = Language '{0}' is not registered in the local LanguageTool; using '{1}' \
+    instead. For languages without registered regional variants (French, Italian, Spanish, ...) \
+    this is the expected mapping and both spelling and grammar are checked normally.
 disableAllRulesWithMatchesInSelection = Disable all rules with matches in selection
 disableRule = Disable rule
 exitingLtexLs = Exiting ltex-ls...

--- a/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
@@ -138,6 +138,29 @@ class SettingsTest {
     assertNotEquals(originalDirPath, expandedDirPath)
   }
 
+  @Test
+  fun testNormalizeLanguageShortCode() {
+    assertEquals("auto", Settings.normalizeLanguageShortCode("auto"))
+    assertEquals("auto", Settings.normalizeLanguageShortCode("Auto"))
+    assertEquals("auto", Settings.normalizeLanguageShortCode("AUTO"))
+
+    assertEquals("en-US", Settings.normalizeLanguageShortCode("en-US"))
+    assertEquals("en-US", Settings.normalizeLanguageShortCode("en-us"))
+    assertEquals("en-US", Settings.normalizeLanguageShortCode("EN-US"))
+    assertEquals("de-DE", Settings.normalizeLanguageShortCode("de-de"))
+
+    assertEquals("fr", Settings.normalizeLanguageShortCode("fr-FR"))
+    assertEquals("fr", Settings.normalizeLanguageShortCode("FR-fr"))
+    assertEquals("it", Settings.normalizeLanguageShortCode("it-IT"))
+
+    assertEquals("ca-ES-valencia", Settings.normalizeLanguageShortCode("CA-es-valencia"))
+
+    assertEquals("en-US", Settings.normalizeLanguageShortCode("  en-US  "))
+    assertEquals("auto", Settings.normalizeLanguageShortCode("  Auto  "))
+
+    assertEquals("zz-ZZ", Settings.normalizeLanguageShortCode("zz-ZZ"))
+  }
+
   companion object {
     private fun compareSettings(
       settings: Settings,


### PR DESCRIPTION
## Problem

When a user configures `ltex.language` with a regional variant that the bundled LanguageTool does not register as a distinct tag — for example `fr-FR`, `it-IT`, `es-ES`, `sv-SE` — the server **silently stops checking** that document. No diagnostics are produced, no error surfaces to the client; only a `severe` line in the log:

```
'fr-FR' is not a recognized language. Leaving LanguageTool uninitialized, checking disabled.
```

This is a frequent cause of confusion because:

1. Remote LanguageTool servers (including the premium offering) happily accept `fr-FR` / `it-IT` / etc., so users copy those tags into local config expecting them to work.
2. The failure mode is invisible at the client — LTeX looks alive, just produces nothing.
3. The `"auto"` sentinel is matched strict-lowercase, so `"Auto"` / `"AUTO"` also results in unrecognized language.

## Root cause

`LanguageToolJavaInterface.kt` delegates language resolution directly to `org.languagetool.Languages.isLanguageSupported(...)`:

```kotlin
init {
  if (Languages.isLanguageSupported(languageShortCode)) {
    val language: Language = Languages.getLanguageForShortCode(languageShortCode)
    ...
    this.languageTool = JLanguageTool(language, motherTongue, this.resultCache, userConfig)
  } else {
    Logging.LOGGER.severe(I18n.format("notARecognizedLanguage", languageShortCode))
    this.languageTool = null
  }
}
```

`Languages.isLanguageSupported("fr-FR")` returns `false` because the bundled LT registers only `fr` for that language. The server has no fallback and no tag normalization on ingest, so the language tag goes through unchanged.

Also, `"auto"` is special-cased at `DocumentChecker.kt:129` and `CompletionListProvider.kt:133` with strict `== "auto"` — any case variation breaks the auto-detection branch.

## Fix

Normalize the incoming tag **once, at the ingress boundary**, so every downstream consumer sees a canonical, LT-registered tag (or `"auto"`). The rest of the code is untouched.

### Helper

A new `Settings.normalizeLanguageShortCode(raw)` (in the companion object of `Settings.kt`) runs input through four steps:

1. **Trim** leading/trailing whitespace.
2. **Short-circuit `"auto"`** case-insensitively → store the lowercase sentinel.
3. **Canonicalize casing** using a regex: `^([A-Za-z]{2,3})(?:-([A-Za-z]{2}))?(-.*)?$` matches language / optional region / optional rest; the language subtag is lowercased, the region is uppercased, everything after is preserved (e.g. `ca-ES-valencia`, `de-DE-x-simple-language`).
4. **LT registry lookup:**
   - If the canonical tag is registered → use it.
   - Otherwise strip the region and check the bare language subtag. If that is registered → use it, and log one INFO line explaining the fallback.
   - Otherwise leave the canonical form unchanged and let the existing `notARecognizedLanguage` path fire as before.

```kotlin
fun normalizeLanguageShortCode(raw: String): String {
  val trimmed = raw.trim()
  if (trimmed.equals("auto", ignoreCase = true)) return "auto"

  val canonical = LANGUAGE_TAG_REGEX.matchEntire(trimmed)?.destructured?.let {
      (lang, region, rest) ->
    val regionPart = if (region.isEmpty()) "" else "-${region.uppercase()}"
    "${lang.lowercase()}$regionPart$rest"
  } ?: trimmed

  if (Languages.isLanguageSupported(canonical)) return canonical

  val base = canonical.substringBefore("-")
  if (base != canonical && Languages.isLanguageSupported(base)) {
    Logging.LOGGER.info(I18n.format("demotedLanguageToBase", canonical, base))
    return base
  }

  return canonical
}

private val LANGUAGE_TAG_REGEX =
  Regex("""^([A-Za-z]{2,3})(?:-([A-Za-z]{2}))?(-.*)?$""")
```

### What "fallback to base language" means for the user

For most languages that trigger it — French, Italian, Spanish, Swedish, Dutch, and others without registered regional variants — the bare code **is** the full checker. The user gets both spelling and grammar, exactly what they expected when they typed `fr-FR` / `it-IT`. No capability is lost.

The edge case is a typo on a language that *does* have registered variants (e.g. `en-YZ` → `en`, `de-XX` → `de`). There the bare code is LT's grammar-only umbrella class with no spell dictionary. The INFO log line covers both cases neutrally so the user can tell which tag was used.

### Ingress wiring

The helper is applied at the two external entry points — nowhere else:

- **`Settings.fromJson()`** (`Settings.kt:209`) — covers the LSP `workspace/configuration` response and `initializationOptions`.
- **`SettingsOverride.updateLanguageShortCode()`** (`SettingsOverride.kt:136`) — covers in-document magic-comment overrides and code-action settings updates, which flow through `SettingsParser.updateSettingsOverride` at `SettingsParser.kt:94`.

Internal-source assignments are left alone because their inputs are already canonical:

- `DocumentChecker.kt:139` — the tag comes from LT's own `shortCodeWithCountryAndVariant`.
- `LatexFragmentizer`'s `BABEL_LANGUAGE_MAP` — hand-curated, already canonical.

### I18n key

A new `demotedLanguageToBase` key is added to `src/main/resources/LtexLsMessagesBundle.properties`:

```
demotedLanguageToBase = Language '{0}' is not registered in the local LanguageTool; using '{1}' \
    instead. For languages without registered regional variants (French, Italian, Spanish, ...) \
    this is the expected mapping and both spelling and grammar are checked normally.
```

## Tests

A new `testNormalizeLanguageShortCode` in `SettingsTest.kt` covers every branch of the helper:

- `"auto"` / `"Auto"` / `"AUTO"` → `"auto"` (case-insensitive sentinel).
- `"en-US"` / `"en-us"` / `"EN-US"` → `"en-US"` (casing canonicalization, registered variant).
- `"de-de"` → `"de-DE"` (registered variant).
- `"fr-FR"` / `"FR-fr"` / `"it-IT"` → `"fr"` / `"fr"` / `"it"` (fallback to registered base).
- `"CA-es-valencia"` → `"ca-ES-valencia"` (three-subtag canonicalization).
- `"  en-US  "` / `"  Auto  "` → trimmed then normalized (whitespace tolerance).
- `"zz-ZZ"` → `"zz-ZZ"` (unknown tag, preserved for the downstream `notARecognizedLanguage` log).

Full test suite: 207 / 207 pass.

## Manual verification

Configure `ltex.language = "fr-FR"` in the LSP client, open a French document containing an obvious misspelling and a grammar error. Before this change: no diagnostics, `notARecognizedLanguage` in the log. After: both issues are flagged, and the log carries a single INFO line reporting the `fr-FR` → `fr` mapping. Same check with `ltex.language = "Auto"` exercises the sentinel-normalization path (auto-detection used, as with lowercase `"auto"`).
