### PR TITLE
Fix flaky TCP socket test on Windows by polling for listener readiness

### DIFF
--- a/src/test/kotlin/org/bsplines/ltexls/LtexLanguageServerLauncherTcpSocketTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/LtexLanguageServerLauncherTcpSocketTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.TestInstance
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.net.ConnectException
 import java.net.Socket
 import java.net.UnknownHostException
 import java.util.concurrent.ExecutionException
@@ -57,9 +58,17 @@ class LtexLanguageServerLauncherTcpSocketTest {
     launcherThread.start()
     this.launcherThread = launcherThread
 
-    // wait until server is listening for connections
-    Thread.sleep(2000)
-    val socket = Socket(HOST, PORT)
+    // poll until the server is listening for connections (Windows runners can be slow to bind)
+    val deadline = System.currentTimeMillis() + CONNECT_TIMEOUT_MS
+    var socket: Socket? = null
+    while (socket == null) {
+      try {
+        socket = Socket(HOST, PORT)
+      } catch (e: ConnectException) {
+        if (System.currentTimeMillis() > deadline) throw e
+        Thread.sleep(CONNECT_RETRY_INTERVAL_MS)
+      }
+    }
     this.inputStream = socket.getInputStream()
     this.outputStream = socket.getOutputStream()
     this.socket = socket
@@ -86,5 +95,7 @@ class LtexLanguageServerLauncherTcpSocketTest {
   companion object {
     private const val HOST = "localhost"
     private const val PORT = 52714
+    private const val CONNECT_TIMEOUT_MS = 30_000L
+    private const val CONNECT_RETRY_INTERVAL_MS = 100L
   }
 }


### PR DESCRIPTION
## Summary

`LtexLanguageServerLauncherTcpSocketTest` has a race on Windows runners: it sleeps
a fixed 2s after launching the server thread, then attempts a single
`Socket(HOST, PORT)` connect. If the JVM hasn't bound the listener in that window,
the connect is refused and the test fails (see recent Windows CI run for #150):

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.766 s <<< FAILURE! -- in
org.bsplines.ltexls.LtexLanguageServerLauncherTcpSocketTest
java.net.ConnectException: Connection refused: connect
  at java.base/sun.nio.ch.Net.connect0(Native Method)
  ...
  at java.base/java.net.Socket.<init>(Socket.java:324)
  at org.bsplines.ltexls.LtexLanguageServerLauncherTcpSocketTest.setUp(LtexLanguageServerLauncherTcpSocketTest.kt:62)
  ```

Replace the fixed sleep + single attempt with a bounded poll: retry the connect
every 100ms, catching only `ConnectException`, up to a 30s deadline.  Fast path
returns as soon as the listener binds; slow runners get more headroom.

## Why self-merge

This test has been flagging unrelated Windows builds as failing, which
blocks/distracts reviews on other open PRs. Since the change only affects a
test, the risk is low and self-merging unblocks the queue. @spitzerd: feel free
to comment or request changes. I am happy to revert or iterate.

## Test plan

- [x] `mvn test -Dtest=LtexLanguageServerLauncherTcpSocketTest` passes locally (macOS)
- [x] `mvn verify -DskipTests` passes (ktlint + detekt)
- [x] CI green on Windows, Ubuntu, macOS