### PR TITLE
Advertise workspace folders capability in initialize

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -23,6 +23,8 @@ import org.eclipse.lsp4j.InitializeResult
 import org.eclipse.lsp4j.ServerCapabilities
 import org.eclipse.lsp4j.TextDocumentSyncKind
 import org.eclipse.lsp4j.WindowClientCapabilities
+import org.eclipse.lsp4j.WorkspaceFoldersOptions
+import org.eclipse.lsp4j.WorkspaceServerCapabilities
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.services.LanguageClient
 import org.eclipse.lsp4j.services.LanguageClientAware
@@ -103,6 +105,11 @@ class LtexLanguageServer :
     serverCapabilities.executeCommandProvider =
       ExecuteCommandOptions(LtexWorkspaceService.getCommandNames())
     serverCapabilities.textDocumentSync = Either.forLeft(TextDocumentSyncKind.Full)
+
+    val workspaceFoldersOptions = WorkspaceFoldersOptions()
+    workspaceFoldersOptions.supported = true
+    workspaceFoldersOptions.setChangeNotifications(Either.forRight(true))
+    serverCapabilities.workspace = WorkspaceServerCapabilities(workspaceFoldersOptions)
 
     return CompletableFuture.completedFuture(InitializeResult(serverCapabilities))
   }

--- a/src/test/resources/LtexLanguageServerTestLog.txt
+++ b/src/test/resources/LtexLanguageServerTestLog.txt
@@ -282,6 +282,12 @@ Result: {
                 "_ltex.checkDocument",
                 "_ltex.getServerStatus"
             ]
+        },
+        "workspace": {
+            "workspaceFolders": {
+                "supported": true,
+                "changeNotifications": true
+            }
         }
     }
 }


### PR DESCRIPTION
> **TL;DR** — the actual change is 6 lines of code in `LtexLanguageServer.kt` plus 4 lines of test-log fixture. The length of this description isn't a warning sign: most of it is background on LSP multi-root semantics and on how different classes of LSP servers handle workspace-folder notifications. Readers already comfortable with the spec can jump straight to the **Changes** section at the bottom; the rest is there as context for anyone who'd like a refresher or get some more detailed background information on the mechanics of LSP servers.

## Summary

Declares support for workspace.workspaceFolders in the server's initialize response. No runtime behavior changes — the server already handles multiple roots correctly via its flat URI-keyed document map. This is a capability-declaration fix, not a feature.

## Motivation

Multi-root LSP mode lets a single server instance serve loose files and multiple project roots at once. Without it, compliant clients (e.g. `lsp-mode`) must spawn a fresh ltex-ls-plus JVM per root, each consuming ~500 MB of heap — a real problem for users who open unrelated files across several directories.

Per the LSP spec, the client owns the set of workspace folders: it supplies the initial list at `initialize` and notifies the server of subsequent additions and removals. What the server has to *do* in response depends on how stateful it is — for a per-document linter like `ltex-ls-plus`, the answer turns out to be effectively nothing (see "Why is the scope of the changes so circumscribed?" below). Either way, the server still has to declare that it can participate. Today's init response omits the `workspace` key entirely, which tells clients the opposite and discourages developers of clients from enabling multi-root against this server — even though it works fine in practice.

VS Code already uses exactly this mode by default: opening Markdown files across multiple unrelated git repos reuses a single server instance. Easy to verify:

```
watch -n 1 'pgrep -afl "ltex" | grep -v watch | wc -l'
```

The count stays at 1 after the first server starts, no matter how many repos are opened. Multi-root is therefore not a hypothetical capability — it is the path VS Code users are already on. This PR simply lets other compliant clients (e.g. `lsp-mode`) adopt it without having to guess whether the server supports it. With this patch the answer is authoritative: yes, it is supported — and it is the preferred mode of operation.

## Why is the scope of the changes so circumscribed?

Many LSP servers genuinely need to act on `workspace/didChangeWorkspaceFolders` — and on the broader family of workspace notifications (`workspace/didChangeWatchedFiles`, `workspace/didChangeConfiguration`, and others). Servers such as `rust-analyzer`, `clangd`, JDT-LS, or `gopls` maintain project-wide indices, folder-scoped build-system state (Cargo metadata, Maven/Gradle imports, `compile_commands.json`), and cross-file caches that must be created when a folder is added and torn down when it is removed. For them, ignoring a workspace notification would silently corrupt the server's view of the workspace.

`ltex-ls-plus` is in a different class: it is a per-document linter. Each text document is checked independently against a shared LanguageTool instance — there is no project model, no cross-file index, no folder-scoped config loaded from disk, and no build-system integration. Settings are resolved per-document via `workspace/configuration`, keyed by document URI rather than by folder. That is what makes the scope of this PR small.

Concretely, one might still expect multi-root support to require per-folder settings, per-folder LanguageTool caches, and some way for the server to track which document belongs to which folder. None of that is needed here, for two reasons:

1. **Per-folder divergence is the client's problem, not the server's.** If two folders carry conflicting `ltex.*` settings, it is the client's responsibility to spawn a separate server process for each; the server is not expected to partition its own state. Within a single process, settings are therefore uniform across all folders, so `SettingsManager` and `LanguageToolInterface` caches need no folder resolution.

2. **Documents are already keyed by URI.** The existing flat `HashMap<String, LtexTextDocumentItem>` in `LtexTextDocumentService` handles multiple roots for free: URIs are globally unique, so documents from different folders cannot collide.

For the same reason, no `workspace/didChangeWorkspaceFolders` handler is needed. The server never records which folder a document belongs to, so there is no state to update when folders are added or removed at runtime. When a folder goes away, the client sends the usual `textDocument/didClose` for each file in it, and those flow through the existing document-lifecycle path. Ignoring the folder-change notification is correct behavior here, not a shortcut.


## Changes

- LtexLanguageServer.kt: set serverCapabilities.workspace with WorkspaceFoldersOptions(supported=true, changeNotifications=true).
- LtexLanguageServerTestLog.txt: update expected init-response fixture.
