### PR TITLE
Fix: "Add to dictionary" code action for Premium/HTTP and SIMPLE_REPLACE spell-check matches

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -35,6 +35,9 @@
       <action type="fix" issue="ltex-plus/ltex-ls-plus#149" due-to="Andrea Alberti (@alberti42)">
         Fix: spell-check text in org-mode `#+CAPTION` affiliated keyword
       </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Offer the "Add to dictionary" code action for spell-check matches produced by LanguageTool's `QB_NEW_*_ORTHOGRAPHY_*`, `AI_*_GGEC_REPLACEMENT_ORTHOGRAPHY_*`, and `ES_SIMPLE_REPLACE_*` rule families (Premium/HTTP tier plus Spanish common-typo rules). Also split multi-word collapsed match spans on whitespace so each misspelled word is added to the user dictionary individually instead of as a single phrase.
+      </action>
     </release>
     <release version="18.6.1" date="2025-10-19">
       <action type="fix" issue="ltex-plus/vscode-ltex-plus#165">

--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.kt
@@ -126,7 +126,16 @@ data class LanguageToolRuleMatch(
               ruleId.endsWith("_SPELLING_RULE") ||
               (ruleId == "MUZSKY_ROD_NEZIV_A") ||
               (ruleId == "ZENSKY_ROD_A") ||
-              (ruleId == "STREDNY_ROD_A")
+              (ruleId == "STREDNY_ROD_A") ||
+              // Premium/HTTP rule families emitted by api.languagetoolplus.com that
+              // don't use the legacy MORFOLOGIK_/HUNSPELL_ prefixes but consistently
+              // carry ORTHOGRAPHY in the rule id for spell-check matches (e.g.
+              // QB_NEW_EN_ORTHOGRAPHY_ERROR_IDS_1,
+              // QB_NEW_DE_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING,
+              // AI_DE_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELL).
+              ruleId.contains("ORTHOGRAPHY") ||
+              // Anonymous-tier common-typo rules such as ES_SIMPLE_REPLACE_SIMPLE_ESTAVA.
+              ruleId.contains("_SIMPLE_REPLACE_")
           )
       )
   }

--- a/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatchTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatchTest.kt
@@ -1,0 +1,137 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.languagetool
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LanguageToolRuleMatchTest {
+  @Test
+  fun testIsUnknownWordRuleLegacyPrefixes() {
+    // MORFOLOGIK_ / HUNSPELL_ prefixes — produced by LanguageTool's local Java
+    // engine and anonymous HTTP tier across all Morfologik-backed languages.
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("MORFOLOGIK_RULE_EN_US"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("MORFOLOGIK_RULE_EN_GB"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("MORFOLOGIK_RULE_DE_DE"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("MORFOLOGIK_RULE_PT_BR"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("HUNSPELL_RULE"))
+  }
+
+  @Test
+  fun testIsUnknownWordRuleLegacySuffixes() {
+    // *_SPELLER_RULE / *_SPELLING_RULE — German, Swiss German, Austrian German,
+    // French spelling rules.
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("GERMAN_SPELLER_RULE"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("AUSTRIAN_GERMAN_SPELLER_RULE"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("SWISS_GERMAN_SPELLER_RULE"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("FR_SPELLING_RULE"))
+  }
+
+  @Test
+  fun testIsUnknownWordRuleSlovakSpecialCases() {
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("MUZSKY_ROD_NEZIV_A"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("ZENSKY_ROD_A"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("STREDNY_ROD_A"))
+  }
+
+  @Test
+  fun testIsUnknownWordRulePremiumQbNewFamily() {
+    // QB_NEW_*_ORTHOGRAPHY_* — Premium spell-check families empirically
+    // observed via api.languagetoolplus.com for en-US, de-DE, es, fr, nl, pt-BR.
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("QB_NEW_EN_ORTHOGRAPHY_ERROR_IDS_1"))
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("QB_NEW_EN_ORTHOGRAPHY_ERROR_IDS_42"))
+    assertTrue(
+      LanguageToolRuleMatch.isUnknownWordRule(
+        "QB_NEW_DE_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING",
+      ),
+    )
+    assertTrue(
+      LanguageToolRuleMatch.isUnknownWordRule(
+        "QB_NEW_ES_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING",
+      ),
+    )
+    assertTrue(
+      LanguageToolRuleMatch.isUnknownWordRule(
+        "QB_NEW_FR_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING",
+      ),
+    )
+    assertTrue(
+      LanguageToolRuleMatch.isUnknownWordRule(
+        "QB_NEW_NL_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING",
+      ),
+    )
+    assertTrue(
+      LanguageToolRuleMatch.isUnknownWordRule(
+        "QB_NEW_PT_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING",
+      ),
+    )
+  }
+
+  @Test
+  fun testIsUnknownWordRulePremiumAiFamily() {
+    // AI_*_GGEC_REPLACEMENT_ORTHOGRAPHY_* — Premium GGEC rules for de-AT and es-AR.
+    // Note the trailing "_SPELL" vs "_SPELLING" variant — both caught via the
+    // ORTHOGRAPHY substring.
+    assertTrue(
+      LanguageToolRuleMatch.isUnknownWordRule("AI_DE_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELL"),
+    )
+    assertTrue(
+      LanguageToolRuleMatch.isUnknownWordRule("AI_ES_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELLING"),
+    )
+  }
+
+  @Test
+  fun testIsUnknownWordRuleSimpleReplaceFamily() {
+    // ES_SIMPLE_REPLACE_* — anonymous-tier Spanish common-typo table that
+    // carries issueType=misspelling but no MORFOLOGIK_/HUNSPELL_ prefix.
+    assertTrue(LanguageToolRuleMatch.isUnknownWordRule("ES_SIMPLE_REPLACE_SIMPLE_ESTAVA"))
+  }
+
+  @Test
+  fun testIsUnknownWordRuleNegatives() {
+    // Null / empty / bare prefix — anchor sanity.
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule(null))
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule(""))
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule("MORFOLOGIK"))
+
+    // Grammar / punctuation / style rules that MUST NOT trigger "Add to dictionary".
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule("QB_NEW_EN_OTHER"))
+    assertFalse(
+      LanguageToolRuleMatch.isUnknownWordRule(
+        "QB_NEW_FR_OTHER_ERROR_IDS_REPLACEMENT_VERB_FORM",
+      ),
+    )
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule("PLACE_DE_LA_VIRGULE"))
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule("KOMMA_MAAR"))
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule("VERB_COMMA_CONJUNCTION"))
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule("AUX_ETRE_VCONJ"))
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule("ZWEI_INFORMATIONSEINHEITEN_PRO_SATZ"))
+  }
+
+  @Test
+  fun testIsUnknownWordRuleDocumentedMisses() {
+    // Known limitations — spell-check matches we deliberately do NOT catch
+    // because their rule IDs contain neither ORTHOGRAPHY/SPELLING nor
+    // SIMPLE_REPLACE. If LanguageTool changes the naming or we add an
+    // issueType/Type-aware overload later, these assertions should flip to
+    // assertTrue.
+    //
+    // AI_DE_MERGED_MATCH: observed on de-DE-x-simple-language Premium when a
+    // cluster of misspellings is merged into one match.
+    assertFalse(LanguageToolRuleMatch.isUnknownWordRule("AI_DE_MERGED_MATCH"))
+    // QB_NEW_PT_OTHER_ERROR_IDS_REPLACEMENT_OTHER: observed on pt-BR Premium
+    // for some misspellings routed under the generic _OTHER replacement tail.
+    assertFalse(
+      LanguageToolRuleMatch.isUnknownWordRule(
+        "QB_NEW_PT_OTHER_ERROR_IDS_REPLACEMENT_OTHER",
+      ),
+    )
+  }
+}


### PR DESCRIPTION
## TL;DR – PR compact description

> This PR extends LanguageToolRuleMatch.isUnknownWordRule() with two substring clauses (contains("ORTHOGRAPHY") and contains("_SIMPLE_REPLACE_")) so the "Add to dictionary" code action also appears for LanguageTool Premium spell-check rules (QB_NEW_*, AI_*) and for the anonymous-tier Spanish ES_SIMPLE_REPLACE_* family.
>
> The change is purely additive — every rule ID the predicate previously accepted still matches, no public API or LSP contract changes, and Premium users gain a capability they previously did not have at all. One edge case (multi-word collapsed Premium spans) is handled less completely than single-word matches and is fully resolved by a follow-up PR; even there this PR strictly improves on the pre-fix state, where no "Add to dictionary" action appeared in the first place. A new LanguageToolRuleMatchTest suite pins the behavior, including two assertFalse cases for documented residual misses.
>
> The length of the description that follows is deliberate: it captures the rule-ID landscape across free/Premium tiers, the historical reasoning behind the isUnknownWordRule name, and the empirical probe that grounds the fix, so future maintainers don't have to reconstruct any of it.

### The gap

The predicate currently anchors on four pattern shapes plus three Slovak-specific rule IDs:

- `MORFOLOGIK_*` / `HUNSPELL_*` prefixes
- `*_SPELLER_RULE` / `*_SPELLING_RULE` suffixes
- `MUZSKY_ROD_NEZIV_A`, `ZENSKY_ROD_A`, `STREDNY_ROD_A` (Slovak)

This covers every spell-check rule produced by LanguageTool's local Java engine and every rule produced by the anonymous HTTP tier of `api.languagetool.org` / `api.languagetoolplus.com` — but it does **not** cover two separate families that the predicate silently misses:

1. **Premium HTTP rule families** (`QB_NEW_*`, `AI_*`). Users who configure `ltex.languageToolHttpServerUri = "https://api.languagetoolplus.com"` with Premium credentials (`ltex.languageToolOrgUsername` / `ltex.languageToolOrgApiKey`) get spell-check matches under rule IDs like `QB_NEW_EN_ORTHOGRAPHY_ERROR_IDS_1` or `AI_DE_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELL`. These are classified as `category: GRAMMAR`, `issueType: grammar` or `issueType: uncategorized` by the server — so neither category nor `issueType` alone discriminates them from genuine grammar rules. The predicate never returns `true` for them, so "Add to dictionary" never appears in the code-action menu, and the user has no way to accept a Premium-flagged misspelling as a legitimate word.

2. **Older `*_SIMPLE_REPLACE_*` tables** hit in the **free** tier for some languages. The clearest case is Spanish: LanguageTool flags `estava` (should be `estaba`) under `ES_SIMPLE_REPLACE_SIMPLE_ESTAVA`, category `TYPOS`, `issueType: misspelling`. Despite the explicit "misspelling" issue type, the rule ID matches none of the predicate's prefix/suffix patterns, so "Add to dictionary" doesn't appear there either. This affects anonymous users, not just Premium.

### Empirical evidence

Probed `api.languagetoolplus.com` across 11 Latin-script languages (en, de, fr, es, it, nl, pt, pl + regional variants en-US/GB/AU/CA/NZ/ZA, de-DE/AT/CH, pt-PT/BR/AO/MZ) × 2 tiers (anonymous and Premium with my own credentials), using deliberate misspellings. Full data in [RULE_REPORT.md](https://github.com/user-attachments/files/27010541/RULE_REPORT.md).

Summary of rule-ID families observed for spell-check matches, by tier:

| Tier         | Locale    | Rule ID family                                                 | Current predicate |
| ------------ | --------- | -------------------------------------------------------------- | ----------------- |
| Anonymous    | en-\*     | `MORFOLOGIK_RULE_EN_{US,GB,AU,CA,NZ,ZA}`                       | ✓                 |
| Anonymous    | de-DE     | `GERMAN_SPELLER_RULE`                                          | ✓                 |
| Anonymous    | de-AT     | `AUSTRIAN_GERMAN_SPELLER_RULE`                                 | ✓                 |
| Anonymous    | de-CH     | `SWISS_GERMAN_SPELLER_RULE`                                    | ✓                 |
| Anonymous    | fr        | `FR_SPELLING_RULE`                                             | ✓                 |
| Anonymous    | es        | `MORFOLOGIK_RULE_ES`, **`ES_SIMPLE_REPLACE_SIMPLE_ESTAVA`**    | partial           |
| Anonymous    | it/nl/pl  | `MORFOLOGIK_RULE_{IT_IT,NL_NL,PL_PL}`                          | ✓                 |
| Anonymous    | pt-\*     | `MORFOLOGIK_RULE_PT_{PT,BR,AO,MZ}`                             | ✓                 |
| Premium      | en-US     | **`QB_NEW_EN_ORTHOGRAPHY_ERROR_IDS_1`**                        | ✗                 |
| Premium      | en-GB/AU/CA/NZ/ZA | `MORFOLOGIK_RULE_EN_*` (no Premium upgrade)            | ✓                 |
| Premium      | de-DE/CH  | **`QB_NEW_DE_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING`** | ✗               |
| Premium      | de-AT     | **`AI_DE_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELL`**                 | ✗                 |
| Premium      | de-DE-x-simple-language | `AI_DE_MERGED_MATCH`                             | ✗ (residual miss) |
| Premium      | fr        | **`QB_NEW_FR_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING`** | ✗               |
| Premium      | es        | **`QB_NEW_ES_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING`** | ✗               |
| Premium      | es-AR     | **`AI_ES_GGEC_REPLACEMENT_ORTHOGRAPHY_SPELLING`**              | ✗                 |
| Premium      | nl        | **`QB_NEW_NL_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING`** | ✗               |
| Premium      | nl-BE     | `MORFOLOGIK_RULE_NL_NL` (no Premium upgrade)                   | ✓                 |
| Premium      | pt-BR     | **`QB_NEW_PT_OTHER_ERROR_IDS_REPLACEMENT_ORTHOGRAPHY_SPELLING`**, `QB_NEW_PT_OTHER_ERROR_IDS_REPLACEMENT_OTHER` | partial |
| Premium      | pt-PT/AO/MZ | `MORFOLOGIK_RULE_PT_*` (no Premium upgrade)                  | ✓                 |
| Premium      | it/pl     | `MORFOLOGIK_RULE_{IT_IT,PL_PL}` (no Premium upgrade)           | ✓                 |

Premium rollout is per-locale, not blanket — only some variants are upgraded to `QB_NEW_*` / `AI_*`. The pattern-level commonality, however, is stable: every Premium spell-check rule ID carries the substring `ORTHOGRAPHY`, and every spell-check rule ID missed today carries either `ORTHOGRAPHY` or `_SIMPLE_REPLACE_` (with two documented exceptions, see **Non-goals / follow-ups**).

## Solution

Two new substring clauses appended to the existing `||` chain in `isUnknownWordRule(ruleId)`:

```kotlin
ruleId.contains("ORTHOGRAPHY") ||       // QB_NEW_*_ORTHOGRAPHY_*, AI_*_GGEC_REPLACEMENT_ORTHOGRAPHY_*
ruleId.contains("_SIMPLE_REPLACE_")     // ES_SIMPLE_REPLACE_* and any sibling families
```

The choice of `contains(...)` rather than `startsWith("QB_NEW_")` + contains was a deliberate outcome of the probe data: the prefix varies (`QB_NEW_`, `AI_`, and potentially others as LT expands), but the token `ORTHOGRAPHY` is uniformly present in spell-rule IDs and absent from every non-spell rule observed (tested against `QB_NEW_EN_OTHER`, `QB_NEW_FR_OTHER_ERROR_IDS_REPLACEMENT_VERB_FORM`, `PLACE_DE_LA_VIRGULE`, `KOMMA_MAAR`, `VERB_COMMA_CONJUNCTION`, `AUX_ETRE_VCONJ`, `ZWEI_INFORMATIONSEINHEITEN_PRO_SATZ`). No prefix gate is needed, and dropping it makes the predicate robust to future families LT may add.

The same predicate is consulted at `LanguageToolRuleMatch.kt:98-102` inside `fromLanguageTool` to decide whether to prepend the matched word to the diagnostic message. That remains correct for the new cases — `'amazng': <message>`, `'estava': <message>` — all helpful.

## Files changed

| File | Change |
|------|--------|
| `src/main/kotlin/.../languagetool/LanguageToolRuleMatch.kt` | Extend `isUnknownWordRule(ruleId)` with two substring clauses (`ORTHOGRAPHY`, `_SIMPLE_REPLACE_`). |
| `src/test/kotlin/.../languagetool/LanguageToolRuleMatchTest.kt` | **New** — 8 JUnit 5 tests covering legacy prefixes/suffixes, Slovak special-cases, new `QB_NEW_*` / `AI_*` / `SIMPLE_REPLACE_*` positives, and negatives including all observed non-spell rules. Two `assertFalse` cases document the known residual misses. |
| `changelog.xml` | New `<action type="fix">` entry under the 18.7.0 upcoming release. |

## What changes over the wire and in the UI

**Code-action list** returned by `textDocument/codeAction` on a Premium/HTTP-flagged misspelling — before the fix, contained only `Disable rule …` and `Hide false positives …`. After the fix, additionally contains `Add '<word>' to dictionary`.

**Command arguments** sent to the client when the action is triggered — unchanged in shape: `{"uri": "…", "words": {"en-US": ["amazng"]}}`.

**Persisted dictionary state** in clients that write to disk (e.g. `lsp-ltex-plus` writes a per-language plist): one entry per accepted word, just as today for Morfologik/Hunspell matches.

## Verification

1. **`mvn test`** — full suite passes on the branch, including 8 new `LanguageToolRuleMatchTest` cases.
2. **End-to-end Premium (Emacs `lsp-ltex-plus` client):** set `lsp-ltex-plus-lt-server-uri` to `https://api.languagetoolplus.com` with Premium credentials, open a Markdown buffer containing `"The report is amazng."`, trigger the code action on the `amazng` diagnostic flagged under `QB_NEW_EN_ORTHOGRAPHY_ERROR_IDS_1`. Expect `Add 'amazng' to dictionary`; triggering it persists `amazng` under `:en-US` in `~/.emacs.d/lsp-ltex-plus/stored-dictionary`. Re-running the check no longer flags `amazng`. Before the fix: no code action appears at all.
3. **Anonymous Spanish `ES_SIMPLE_REPLACE_SIMPLE_ESTAVA`:** in free-tier Spanish mode, a document containing `estava` now offers `Add 'estava' to dictionary`. Previously the action was missing from the menu despite the diagnostic being labeled `issueType: misspelling`.
4. **Regression — existing Morfologik/Hunspell/SPELLER_RULE paths:** open a document with plain typos in anonymous mode (`ltex.languageToolHttpServerUri = ""` or the free endpoint) across English, German, French, and Spanish. Code actions produced unchanged; clicking persists one entry per word exactly as before. No behavior change on the paths the original predicate already covered.

## Edge case: multi-word collapsed Premium spans

Premium rules commonly collapse adjacent misspellings into a single match span — e.g. `recieved teh` (English, one match of length 12), `Pakket geschtern bekomen` (German, one match of length 24). With the predicate widened but `getAddWordToDictionaryCodeAction` unchanged, triggering the action on such a match persists the literal phrase (`"recieved teh"`) under the language's dictionary list. On re-check, `checkMatchValidity` looks up each individual word's span in the dictionary set, finds neither `recieved` nor `teh` stored individually, and the per-word diagnostics continue to fire — so on those specific matches the dictionary entry doesn't silence the re-check.

This is still a strict improvement on every axis: before this PR, Premium users had no way to accept these misspellings at all — "Add to dictionary" never appeared on a Premium-flagged match. After this PR the action appears, works exactly as expected on single-word Premium matches (the common case), and on multi-word collapsed spans at least records the user's intent in the dictionary file. Users also retain the existing escape hatches (`Disable rule …`, `Hide false positives …`) throughout. A follow-up PR (currently under test) splits the match span into individual words and strips leading/trailing punctuation so each underlying misspelling lands as its own dictionary entry; it was intentionally scoped out of this PR to keep the change focused on the predicate fix.

## Non-goals / follow-ups

- **Tokenize multi-word match spans + strip leading/trailing punctuation.** Deferred to a dedicated follow-up PR, which is currently under test and will soon be submitted. Will also introduce a shared `normalizeDictionaryWord` helper used by both `CodeActionProvider.getAddWordToDictionaryCodeAction` (the add path) and `LanguageToolInterface.checkMatchValidity` (the check path) so the two stay symmetrical. An opt-out setting (tentatively `ltex.dictionary.tokenizeMultiWordMatches`) may be introduced alongside if power users report edge cases.

- **Two residual predicate misses, explicitly documented.**
  - `AI_DE_MERGED_MATCH` — observed on `de-DE-x-simple-language` Premium when LT merges a cluster of misspellings under an ML-model "merged match" rule whose ID contains neither `ORTHOGRAPHY` nor `SPELLING`.
  - `QB_NEW_PT_OTHER_ERROR_IDS_REPLACEMENT_OTHER` — observed on `pt-BR` Premium for misspellings that get routed under the generic `_REPLACEMENT_OTHER` tail rather than `_REPLACEMENT_ORTHOGRAPHY_SPELLING`.

  Both are asserted as `assertFalse` in `LanguageToolRuleMatchTest.testIsUnknownWordRuleDocumentedMisses`. Addressing them would require either a coarser substring gate (risking false positives on grammar rules) or a shift to an `issueType`/`RuleMatch.Type`-aware overload — a bigger API change deferred to a later PR.

- **`issueType`-aware classification.** The `LanguageToolRuleMatch` class already stores `RuleMatch.Type` at line 26. A richer predicate taking the full match rather than just `ruleId: String?` could combine substring heuristics with the type field for cleaner semantics. Not done here — would add risk to a fix-focused PR and is orthogonal to closing the regression.

- **User-configurable regex for rule-ID classification.** I considered letting users supply their own regex to decide which rule IDs count as spell-check rules, and chose not to add it for now. We can reconsider this decision if a user reports a specific rule-ID family that the built-in substring heuristics keep missing.

## Client-side notes (for `vscode-ltex-plus` / `lsp-ltex-plus` maintainers)

- The structure of `_ltex.addToDictionary` command arguments (`{uri, words: {lang: [...]}}`) is unchanged. Clients continue to work without modification.
- Users on Premium HTTP endpoints will suddenly see "Add to dictionary" actions where they previously didn't. That's the intended fix; no migration needed.

## Breaking changes

None in the server's LSP contract. The only observable change is that `_ltex.addToDictionary` code actions now appear in situations where they previously were absent. Existing dictionary entries are unaffected.

