### PR TITLE
Fix: handle dictionary words with surrounding punctuation correctly on LT Premium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
 
       - name: "Build LTeX+ LS"
         run: "mvn -B -e verify"
+        env:
+          LANGUAGETOOL_USERNAME: ${{ secrets.LANGUAGETOOL_USERNAME }}
+          LANGUAGETOOL_API_KEY: ${{ secrets.LANGUAGETOOL_API_KEY }}
 
   validate:
     name: "CI - Validate Job"

--- a/changelog.xml
+++ b/changelog.xml
@@ -45,6 +45,9 @@
         Offer the "Add to dictionary" code action for spell-check matches produced by LanguageTool's `QB_NEW_*_ORTHOGRAPHY_*`, `AI_*_GGEC_REPLACEMENT_ORTHOGRAPHY_*`, and `ES_SIMPLE_REPLACE_*` rule families (Premium/HTTP tier plus Spanish common-typo rules).
       </action>
       <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Trim surrounding punctuation from "Add to dictionary" entries and from the check-path lookup key for matches from rule families known to emit punctuation-adjacent spans (LanguageTool Premium's `QB_NEW_*` / `AI_*`), so a span like `amazng!` (length 7) is persisted as the bare word `amazng` and every later occurrence — `amazng,`, `"amazng"`, `(amazng)` — suppresses against the same single entry. Free LT, the bundled Java backend, and the Spanish `_SIMPLE_REPLACE_` / Slovak gender-suffix rules always emit bare single-word spans and bypass the normalization entirely; no behavior change for those users.
+      </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
         Markdown: accept spaces and backslashes inside angle-bracketed link destinations (e.g. `[text](&lt;path with spaces.pdf&gt;)` or Windows-style `[text](&lt;C:\Users\My Documents\file.pdf&gt;)`), so the link is recognized and surrounding punctuation does not leak into spell-checked text.
       </action>
       <action type="fix" due-to="Andrea Alberti (@alberti42)">

--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/DictionaryWord.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/DictionaryWord.kt
@@ -1,0 +1,33 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.languagetool
+
+object DictionaryWord {
+  // Precompiled once at class-load time (Kotlin `Regex` constructor calls
+  // java.util.regex.Pattern.compile under the hood; the val initializers
+  // run exactly once for this singleton object). Anchored at `^` / `$` so
+  // a no-op match on a bare word is O(1).
+  private val LEADING_NON_WORD_CHARS: Regex = Regex("""^[^\p{L}\p{N}]+""")
+  private val TRAILING_NON_WORD_CHARS: Regex = Regex("""[^\p{L}\p{N}]+$""")
+
+  // Strip leading/trailing Unicode non-letter-non-digit characters. Internal
+  // apostrophes and hyphens survive (\p{L}\p{N} excludes them but they are
+  // not at the ends in cases like `don't`, `state-of-the-art`, `COVID-19`).
+  //
+  // An entirely-punctuation input returns "". Both call sites treat that
+  // as "no word": the add path's `if (word.isEmpty()) continue` skips
+  // persistence (the matched text is effectively not recognized as a
+  // user-provided dictionary word), and the check path's
+  // `lookupKey.isNotEmpty()` guard blocks suppression. Exotic in practice
+  // — no real spell-check rule emits an all-punctuation span — but the
+  // guard makes the boundary explicit and prevents an empty stored entry
+  // from accidentally matching every empty lookup key.
+  fun normalize(word: String): String =
+    word.replace(LEADING_NON_WORD_CHARS, "").replace(TRAILING_NON_WORD_CHARS, "")
+}

--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolInterface.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolInterface.kt
@@ -11,6 +11,20 @@ package org.bsplines.ltexls.languagetool
 import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 
 abstract class LanguageToolInterface {
+  // The user dictionary is stored verbatim. The add path (CodeActionProvider)
+  // sends bare words to the client in the "Add to dictionary" command — for
+  // matches from rule families that emit punctuation-adjacent spans (Premium
+  // QB_NEW_* / AI_*) the matched substring is stripped via
+  // DictionaryWord.normalize before being persisted, so the on-disk entry is
+  // the bare word. For every other rule family the substring is already bare
+  // and is persisted as-is. The server cannot enforce what the client
+  // actually writes to disk, but the reference clients write what we send.
+  //
+  // Hand-edited entries are intentionally left untouched at load time: the
+  // file on disk is the user's data and may carry punctuation or whitespace
+  // by deliberate choice. Normalization on the check side happens only when
+  // the match's rule id falls into the Premium punctuation-adjacent family —
+  // see isCoveredByDictionary below.
   var dictionary: Set<String> = emptySet()
   var disabledRules: Set<String> = emptySet()
 
@@ -31,15 +45,45 @@ abstract class LanguageToolInterface {
     annotatedTextFragment: AnnotatedTextFragment,
     match: LanguageToolRuleMatch,
   ): Boolean =
-    (
-      (
-        !match.isUnknownWordRule() ||
-          !this.dictionary.contains(
-            annotatedTextFragment.getSubstringOfPlainText(match.fromPos, match.toPos),
-          )
-      ) &&
-        !this.disabledRules.contains(match.ruleId)
-    )
+    !this.disabledRules.contains(match.ruleId) &&
+      (!match.isUnknownWordRule() || !isCoveredByDictionary(annotatedTextFragment, match))
+
+  // Suppress a match if the user's dictionary contains the flagged word.
+  //
+  // The lookup key depends on which rule family fired the match. Premium's
+  // QB_NEW_* / AI_* families sometimes emit spans that include adjacent
+  // punctuation, e.g. `amazng!` (length 7) or `"amazng"` (length 8); for
+  // those rules we strip leading/trailing non-letter-non-digit characters
+  // via DictionaryWord.normalize so a single stored entry `amazng` suppresses
+  // every punctuation-context variant.
+  //
+  // For every other rule family (Morfologik / Hunspell / *_SPELLER_RULE /
+  // Slovak gender rules / _SIMPLE_REPLACE_) the span is already bare and we
+  // look it up literally — gaining a stronger no-behavior-change guarantee
+  // for free-LT and local-Java users: not just a no-op normalize call but
+  // no normalize call at all on those code paths.
+  //
+  // Multi-word phrase entries (e.g. a hand-typed `"LTEX LS"`, or the local
+  // Java backend's all-caps Morfologik collapse on `LTEX LS`) still suppress:
+  // those matches fall in the literal branch, and the dictionary holds the
+  // phrase verbatim.
+  //
+  // An entirely-punctuation span normalizes to "" (Premium branch) and is
+  // treated as not covered; the diagnostic stays visible. The user can
+  // disable the rule or fix the text in that exotic case.
+  private fun isCoveredByDictionary(
+    annotatedTextFragment: AnnotatedTextFragment,
+    match: LanguageToolRuleMatch,
+  ): Boolean {
+    val span: String = annotatedTextFragment.getSubstringOfPlainText(match.fromPos, match.toPos)
+    val lookupKey: String =
+      if (LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)) {
+        DictionaryWord.normalize(span)
+      } else {
+        span
+      }
+    return lookupKey.isNotEmpty() && this.dictionary.contains(lookupKey)
+  }
 
   abstract fun isInitialized(): Boolean
 

--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.kt
@@ -150,5 +150,22 @@ data class LanguageToolRuleMatch(
               ruleId.contains("_SIMPLE_REPLACE_")
           )
       )
+
+    // Premium HTTP rule families (QB_NEW_*, AI_*) sometimes emit spell-check
+    // spans that include adjacent punctuation, e.g. `amazng!` (length 7),
+    // `"amazng"` (length 8), or multi-word collapses like `recieved teh`.
+    // MORFOLOGIK_*, HUNSPELL_*, and *_SPELLER_RULE always emit bare
+    // single-word spans, so for those rule families a stored bare-word entry
+    // already matches verbatim and no normalization is needed.
+    //
+    // The dictionary add path (CodeActionProvider.getAddWordToDictionaryCodeAction)
+    // and check path (LanguageToolInterface.isCoveredByDictionary) consult this
+    // predicate to decide whether to normalize the span before persisting or
+    // looking up. Mirrors the rule-family allowlist convention used by
+    // isUnknownWordRule above; if Premium adds new rule families that include
+    // adjacent punctuation, extend this allowlist accordingly.
+    fun isPremiumPunctuationAdjacentSpanRule(ruleId: String?): Boolean =
+      (ruleId != null) &&
+        (ruleId.startsWith("QB_NEW_") || ruleId.startsWith("AI_"))
   }
 }

--- a/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
@@ -11,6 +11,7 @@ package org.bsplines.ltexls.server
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
+import org.bsplines.ltexls.languagetool.DictionaryWord
 import org.bsplines.ltexls.languagetool.LanguageToolRuleMatch
 import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 import org.bsplines.ltexls.parsing.CodeFragment
@@ -118,15 +119,15 @@ class CodeActionProvider(
     }
 
     if (addToDictionaryMatches.isNotEmpty()) {
-      result.add(
-        Either.forRight(
-          getAddWordToDictionaryCodeAction(
-            document,
-            addToDictionaryMatches,
-            annotatedTextFragments,
-          ),
-        ),
-      )
+      val addWordToDictionaryCodeAction: CodeAction? =
+        getAddWordToDictionaryCodeAction(
+          document,
+          addToDictionaryMatches,
+          annotatedTextFragments,
+        )
+      if (addWordToDictionaryCodeAction != null) {
+        result.add(Either.forRight(addWordToDictionaryCodeAction))
+      }
     }
 
     if (hideFalsePositivesMatches.isNotEmpty()) {
@@ -186,11 +187,12 @@ class CodeActionProvider(
     return codeAction
   }
 
+  @Suppress("LoopWithTooManyJumpStatements")
   private fun getAddWordToDictionaryCodeAction(
     document: LtexTextDocumentItem,
     addToDictionaryMatches: List<LanguageToolRuleMatch>,
     annotatedTextFragments: List<AnnotatedTextFragment>,
-  ): CodeAction {
+  ): CodeAction? {
     val unknownWordsMap = HashMap<String, MutableList<String>>()
     val unknownWordsJsonObject = JsonObject()
     val diagnostics = ArrayList<Diagnostic>()
@@ -207,15 +209,34 @@ class CodeActionProvider(
       val codeFragment: CodeFragment = annotatedTextFragment.codeFragment
       val language: String = codeFragment.languageShortCode
       val offset: Int = codeFragment.fromPos
-      val word: String =
+      val matchedText: String =
         annotatedTextFragment.getSubstringOfPlainText(
           match.fromPos - offset,
           match.toPos - offset,
         )
 
+      // Strip leading/trailing punctuation only when the match's rule family
+      // is known to emit punctuation-adjacent spans (Premium's QB_NEW_* /
+      // AI_*); for everyone else the span is already bare and we persist it
+      // verbatim. Same gate runs on the check path
+      // (LanguageToolInterface.isCoveredByDictionary) so the round-trip is
+      // symmetric — a word added under one rule family looks up correctly
+      // when seen again under the same family. Skip the match if the
+      // normalized form is empty (entirely-punctuation span — should never
+      // happen for a real spell-check rule).
+      val word: String =
+        if (LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)) {
+          DictionaryWord.normalize(matchedText)
+        } else {
+          matchedText
+        }
+      if (word.isEmpty()) continue
+
       addToMap(language, word, unknownWordsMap, unknownWordsJsonObject)
       diagnostics.add(createDiagnostic(match, document))
     }
+
+    if (unknownWordsMap.isEmpty()) return null
 
     val arguments = JsonObject()
     arguments.addProperty("uri", document.uri)

--- a/src/test/kotlin/org/bsplines/ltexls/languagetool/DictionaryWordTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/languagetool/DictionaryWordTest.kt
@@ -1,0 +1,82 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.languagetool
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DictionaryWordTest {
+  @Test
+  fun testNormalizeLeavesPlainWordUntouched() {
+    assertEquals("amazng", DictionaryWord.normalize("amazng"))
+  }
+
+  @Test
+  fun testNormalizeStripsSurroundingPunctuation() {
+    assertEquals("amazng", DictionaryWord.normalize("\"amazng\""))
+    assertEquals("amazng", DictionaryWord.normalize("amazng."))
+    assertEquals("amazng", DictionaryWord.normalize(",amazng,"))
+    assertEquals("amazng", DictionaryWord.normalize("…amazng…"))
+    assertEquals("amazng", DictionaryWord.normalize("«amazng»"))
+    assertEquals("amazng", DictionaryWord.normalize("(amazng)"))
+  }
+
+  @Test
+  fun testNormalizePreservesInternalApostrophe() {
+    assertEquals("don't", DictionaryWord.normalize("don't"))
+    assertEquals("l'ami", DictionaryWord.normalize("l'ami"))
+    assertEquals("c'est", DictionaryWord.normalize("c'est"))
+  }
+
+  @Test
+  fun testNormalizePreservesInternalHyphen() {
+    assertEquals("state-of-the-art", DictionaryWord.normalize("state-of-the-art"))
+    assertEquals("COVID-19", DictionaryWord.normalize("COVID-19"))
+  }
+
+  @Test
+  fun testNormalizeStripsLeadingAndTrailingApostropheHyphen() {
+    // Intentional tradeoff: closing-quote case is common, truncated-colloquial
+    // ("lookin'") is the rare casualty — we accept the latter loss.
+    assertEquals("lookin", DictionaryWord.normalize("lookin'"))
+    assertEquals("hello", DictionaryWord.normalize("'hello"))
+    assertEquals("word", DictionaryWord.normalize("-word-"))
+  }
+
+  @Test
+  fun testNormalizeHandlesNonLatinScripts() {
+    assertEquals("Привет", DictionaryWord.normalize("«Привет»"))
+    assertEquals("世界", DictionaryWord.normalize("「世界」"))
+    assertEquals("café", DictionaryWord.normalize("café."))
+  }
+
+  @Test
+  fun testNormalizeKeepsDigits() {
+    assertEquals("42", DictionaryWord.normalize("42"))
+    assertEquals("iPhone12", DictionaryWord.normalize("iPhone12"))
+  }
+
+  @Test
+  fun testNormalizePreservesInternalWhitespaceForPhraseEntries() {
+    // Regex anchors at ^ and $, so internal whitespace is left alone. This
+    // keeps a hand-typed multi-word entry like "LTEX LS" matchable against
+    // the corresponding span (relevant for the local Java backend's all-caps
+    // Morfologik collapse on `LTEX LS` and for any hand-edited dictionary).
+    assertEquals("LTEX LS", DictionaryWord.normalize("LTEX LS"))
+    assertEquals("New York", DictionaryWord.normalize("«New York»"))
+  }
+
+  @Test
+  fun testNormalizeReturnsEmptyForPurelyPunctuation() {
+    assertEquals("", DictionaryWord.normalize("..."))
+    assertEquals("", DictionaryWord.normalize("—"))
+    assertEquals("", DictionaryWord.normalize("\"'\""))
+    assertEquals("", DictionaryWord.normalize(""))
+  }
+}

--- a/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolPremiumIntegrationTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolPremiumIntegrationTest.kt
@@ -1,0 +1,211 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.languagetool
+
+import org.bsplines.ltexls.parsing.AnnotatedTextFragment
+import org.bsplines.ltexls.server.DocumentChecker
+import org.bsplines.ltexls.server.DocumentCheckerTest
+import org.bsplines.ltexls.server.LtexTextDocumentItem
+import org.bsplines.ltexls.settings.Settings
+import org.bsplines.ltexls.settings.SettingsManager
+import org.junit.jupiter.api.extension.ConditionEvaluationResult
+import org.junit.jupiter.api.extension.ExecutionCondition
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Premium-endpoint integration tests.
+ *
+ * These tests hit api.languagetoolplus.com using real Premium credentials
+ * and burn API quota, so they run only when both LANGUAGETOOL_USERNAME and
+ * LANGUAGETOOL_API_KEY are present in the environment. Missing either
+ * variable makes the whole class auto-skip via [RequirePremiumCredentials];
+ * no failure, no CI noise.
+ *
+ * If these tests fail in CI, the maintainer has two options:
+ *
+ *   - Rotate the credentials (renewed subscription, API key cycled, ...).
+ *   - Delete LANGUAGETOOL_USERNAME and LANGUAGETOOL_API_KEY from the repository
+ *     secrets. The tests will then auto-skip, keeping CI green without any
+ *     code change.
+ *
+ * The assertion-failure message produced by [withPremiumFailureHint] repeats
+ * this so a future maintainer doesn't need to open the source to recover.
+ *
+ * The behavior under test is Premium's QB_NEW_* rule family returning spans
+ * that include adjacent punctuation (e.g. `amazng!` length 7, bare `amazng`
+ * length 6, `"amazng"` length 8 — all for the same misspelling in different
+ * contexts). The DictionaryWord.normalize call on the add path and on the
+ * check-path lookup key together ensure that a single stored entry `amazng`
+ * suppresses every variant.
+ */
+@ExtendWith(RequirePremiumCredentials::class)
+class LanguageToolPremiumIntegrationTest {
+  @Test
+  fun testPremiumEmitsSpansWithAdjacentPunctuation() =
+    withPremiumFailureHint {
+      val spans: List<String> = collectMatchSpans(buildSettings())
+
+      assertTrue(
+        spans.size >= 2,
+        "Expected the Premium endpoint to return at least two matches for " +
+          "\"$SAMPLE_TEXT\" (the misspelling \"amazng\" appears in multiple " +
+          "punctuation contexts), but got: $spans.",
+      )
+
+      val withPunct: List<String> = spans.filter { it != DictionaryWord.normalize(it) }
+      assertTrue(
+        withPunct.isNotEmpty(),
+        "Expected at least one returned span to include adjacent punctuation " +
+          "(e.g. \"amazng!\" or \"\\\"amazng\\\"\"), but every span was already " +
+          "bare. Observed spans: $spans. Either Premium behavior changed or " +
+          "the current subscription tier no longer emits punctuation-inclusive " +
+          "spans for this input — re-evaluate whether the normalization fix " +
+          "is still needed.",
+      )
+
+      val normalizedSet: Set<String> = spans.map { DictionaryWord.normalize(it) }.toSet()
+      assertTrue(
+        normalizedSet == setOf("amazng"),
+        "After normalization every span should reduce to the same bare word " +
+          "\"amazng\", but the normalized set is $normalizedSet (from spans $spans).",
+      )
+    }
+
+  @Test
+  fun testPremiumPunctuationSpansSuppressedAfterBareWordAdd() =
+    withPremiumFailureHint {
+      val spans: List<String> =
+        collectMatchSpans(buildSettings(dictionary = setOf("amazng")))
+
+      assertTrue(
+        spans.isEmpty(),
+        "After adding the bare word \"amazng\" to the en-US dictionary, every " +
+          "Premium variant (with or without adjacent punctuation) should be " +
+          "suppressed. Still seeing spans: $spans.",
+      )
+    }
+
+  companion object {
+    private const val PREMIUM_ENDPOINT: String = "https://api.languagetoolplus.com"
+
+    // Probed against api.languagetoolplus.com on 2026-05-15: this text
+    // yields exactly three QB_NEW_EN_ORTHOGRAPHY_ERROR_IDS_1 matches:
+    //   'amazng'    (bare, length 6)
+    //   'amazng!'   (with trailing !, length 7)
+    //   '"amazng"'  (surrounded by quotes, length 8)
+    // All three normalize to "amazng". Other phrasings caused Premium's
+    // QB_NEW_EN_MERGED_MATCH / QB_NEW_EN_OTHER to collapse the misspelling
+    // with an adjacent legitimate word (e.g. "said amazng!"), which would
+    // break the "every span normalizes to amazng" assertion below — avoid
+    // changing this text without re-probing.
+    private const val SAMPLE_TEXT: String =
+      "I think amazng. Or amazng! Or even \"amazng\" works."
+
+    private val FAILURE_HINT: String =
+      """
+      |Premium integration test failed.
+      |
+      |If the LanguageTool Premium subscription is still active:
+      |  - Rotate LANGUAGETOOL_USERNAME / LANGUAGETOOL_API_KEY in the repo secrets.
+      |
+      |If the subscription has been discontinued:
+      |  - Delete both secrets from the repository. The Premium tests will then
+      |    auto-skip (RequirePremiumCredentials), keeping CI green without any
+      |    code change.
+      """.trimMargin()
+
+    private fun buildSettings(dictionary: Set<String> = emptySet()): Settings {
+      var settings =
+        Settings(
+          _languageShortCode = "en-US",
+          _languageToolHttpServerUri = PREMIUM_ENDPOINT,
+          _languageToolOrgUsername = System.getenv("LANGUAGETOOL_USERNAME"),
+          _languageToolOrgApiKey = System.getenv("LANGUAGETOOL_API_KEY"),
+        )
+      if (dictionary.isNotEmpty()) {
+        settings =
+          settings.copy(
+            _allDictionaries = mapOf("en-US" to dictionary),
+          )
+      }
+      return settings
+    }
+
+    private fun collectMatchSpans(settings: Settings): List<String> {
+      val settingsManager = SettingsManager(settings)
+      val documentChecker = DocumentChecker(settingsManager)
+      val document: LtexTextDocumentItem =
+        DocumentCheckerTest.createDocument("markdown", SAMPLE_TEXT)
+      val result: Pair<List<LanguageToolRuleMatch>, List<AnnotatedTextFragment>> =
+        documentChecker.check(document)
+      val (matches, fragments) = result
+      return matches.map { match ->
+        val fragment: AnnotatedTextFragment =
+          fragments.firstOrNull { it.codeFragment.contains(match) } ?: fragments[0]
+        val offset: Int = fragment.codeFragment.fromPos
+        fragment.getSubstringOfPlainText(match.fromPos - offset, match.toPos - offset)
+      }
+    }
+
+    private fun <T> withPremiumFailureHint(block: () -> T): T =
+      try {
+        block()
+      } catch (e: AssertionError) {
+        throw AssertionError("$FAILURE_HINT\n\nOriginal failure: ${e.message}", e)
+      } catch (
+        @Suppress("TooGenericExceptionCaught") e: Exception,
+      ) {
+        throw AssertionError(
+          "$FAILURE_HINT\n\nOriginal failure: ${e.javaClass.simpleName}: ${e.message}",
+          e,
+        )
+      }
+  }
+}
+
+/**
+ * JUnit 5 execution condition that disables the Premium integration tests when
+ * LANGUAGETOOL_USERNAME or LANGUAGETOOL_API_KEY is missing, and — unlike the
+ * vanilla [org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable] — prints
+ * a clear one-time warning line to stdout so the skip is visible in the normal
+ * `mvn test` console output rather than only in the XML surefire reports.
+ */
+class RequirePremiumCredentials : ExecutionCondition {
+  override fun evaluateExecutionCondition(context: ExtensionContext): ConditionEvaluationResult {
+    val missing: List<String> =
+      REQUIRED_ENV_VARS.filter { System.getenv(it).isNullOrEmpty() }
+    if (missing.isEmpty()) {
+      return ConditionEvaluationResult.enabled("Premium credentials present")
+    }
+    if (warningPrinted.compareAndSet(false, true)) {
+      println(SKIP_MESSAGE.format(missing.joinToString(", ")))
+    }
+    return ConditionEvaluationResult.disabled(
+      "Missing env var(s): ${missing.joinToString(", ")}",
+    )
+  }
+
+  companion object {
+    private val REQUIRED_ENV_VARS: List<String> =
+      listOf("LANGUAGETOOL_USERNAME", "LANGUAGETOOL_API_KEY")
+    private val warningPrinted: AtomicBoolean = AtomicBoolean(false)
+    private val SKIP_MESSAGE: String =
+      """
+      |
+      |⚠  Premium integration tests SKIPPED — missing env var(s): %s.
+      |   Set LANGUAGETOOL_USERNAME and LANGUAGETOOL_API_KEY to exercise the
+      |   Premium path against https://api.languagetoolplus.com.
+      |
+      """.trimMargin()
+  }
+}


### PR DESCRIPTION
## TL;DR

LanguageTool Premium's `QB_NEW_*` rule family returns spell-check spans that include adjacent punctuation: the same misspelling `amazng` is reported as `amazng` (length 6) when bare, `amazng!` (length 7) when sentence-final, `"amazng"` (length 8) when quoted, and so on. Clicking "Add to dictionary" used to persist the raw substring punctuation-and-all, so the next occurrence of the same word in a different punctuation context would still flag — the user would see the same word "already in the dictionary" flagged again and again.

This PR introduces a tiny helper, `DictionaryWord.normalize(word)`, that strips leading/trailing Unicode non-letter-non-digit characters and calls it from two sites gated on the match's rule id:

1. **Add path** (`CodeActionProvider.getAddWordToDictionaryCodeAction`) — for matches from rule families that emit punctuation-adjacent spans (Premium's `QB_NEW_*` / `AI_*`), normalize the matched substring before persisting; for everyone else, persist the substring verbatim.
2. **Check path** (`LanguageToolInterface.isCoveredByDictionary`) — same gate. For Premium punctuation-adjacent rule families, normalize the incoming match span before the dictionary lookup; for every other rule family, the literal span is the lookup key.

The gate is a new sibling predicate to `isUnknownWordRule`, named `isPremiumPunctuationAdjacentSpanRule(ruleId)`, that fires for rule ids starting with `QB_NEW_` or `AI_`. Both paths consult the same predicate, so the round-trip is symmetric by construction: a word added under Premium QB_NEW comes back through the same gate on re-check and looks up the normalized form.

**Free LT users and the bundled Java backend see no normalize call at all.** All their matches come from `MORFOLOGIK_*` / `HUNSPELL_*` / `*_SPELLER_RULE`, none of which fire the gate, so the new code paths are entirely bypassed.

The user's stored dictionary is left **verbatim** at load time. The add path produces clean entries by construction; hand-edited entries reflect deliberate user intent and aren't silently rewritten. Normalization happens only on the two paths we control (namely, writing a new entry, looking up an incoming LT span).

New coverage: `DictionaryWordTest` pins `normalize` against plain words, internal apostrophes/hyphens, non-Latin scripts, digits, and the all-punctuation → empty edge case. `LanguageToolPremiumIntegrationTest` runs end-to-end against `api.languagetoolplus.com` when credentials are present and proves both that Premium really does emit punctuation-adjacent spans for the same word and that a bare-word dictionary entry suppresses them all.

## Problem

Probed against `api.languagetoolplus.com` for en-US text:

| Sample | Returned spans |
|---|---|
| `I think amazng. Or amazng! Or even "amazng" works.` | three matches: `'amazng'` (6), `'amazng!'` (7), `'"amazng"'` (8) |

All three are `QB_NEW_EN_ORTHOGRAPHY_ERROR_IDS_1`, all spelling the same misspelled word, all with different span lengths depending on what's adjacent.

Pre-PR `LanguageToolInterface.checkMatchValidity` did a literal substring lookup:

```kotlin
!this.dictionary.contains(
  annotatedTextFragment.getSubstringOfPlainText(match.fromPos, match.toPos),
)
```

So a user clicking "Add to dictionary" on the first variant persists `amazng!` (with the `!`). The check path on the second variant looks up bare `amazng` — miss — diagnostic stays. The user sees: *"I already added this word, why is it still flagged?"*.

Free LT (`api.languagetool.org`) and the bundled Java backend return bare `'amazng'` for all four samples — they never include surrounding punctuation in spell-check spans. So free users never hit this failure.

## Solution

### New file — `languagetool/DictionaryWord.kt`

```kotlin
object DictionaryWord {
  // Precompiled once at class-load time. Anchored at ^ / $ so a no-op match
  // on a bare word is O(1).
  private val LEADING_NON_WORD_CHARS: Regex = Regex("""^[^\p{L}\p{N}]+""")
  private val TRAILING_NON_WORD_CHARS: Regex = Regex("""[^\p{L}\p{N}]+$""")

  fun normalize(word: String): String =
    word.replace(LEADING_NON_WORD_CHARS, "").replace(TRAILING_NON_WORD_CHARS, "")
}
```

`\p{L}\p{N}` excludes `'` and `-`, so internal apostrophes and hyphens survive — `don't`, `state-of-the-art`, `COVID-19`, `iPhone12` all pass through unchanged. Internal whitespace also survives because the regexes are anchored at the ends, so hand-typed multi-word entries like `"LTEX LS"` are preserved verbatim and still match the corresponding Morfologik all-caps collapsed span.

| Input            | `normalize` |
|------------------|-------------|
| `amazng`         | `amazng`    |
| `amazng!`        | `amazng`    |
| `"amazng"`       | `amazng`    |
| `«amazng»`       | `amazng`    |
| `don't`          | `don't`     |
| `state-of-the-art` | `state-of-the-art` |
| `LTEX LS`        | `LTEX LS`   |
| `lookin'`        | `lookin` *(tradeoff)* |

Trailing-apostrophe stripping is a deliberate tradeoff: closing quotes after a word are common, truncated colloquial forms are rare. Users who want `lookin'` preserved can hand-edit their dictionary file.

### Add path — `CodeActionProvider.getAddWordToDictionaryCodeAction`

```kotlin
val matchedText: String =
  annotatedTextFragment.getSubstringOfPlainText(
    match.fromPos - offset,
    match.toPos - offset,
  )

val word: String =
  if (LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)) {
    DictionaryWord.normalize(matchedText)
  } else {
    matchedText
  }
if (word.isEmpty()) continue

addToMap(language, word, unknownWordsMap, unknownWordsJsonObject)
diagnostics.add(createDiagnostic(match, document))
```

Premium QB_NEW / AI match → normalized before persisting. Every other rule family (Morfologik, Hunspell, *_SPELLER_RULE, Slovak gender rules, `_SIMPLE_REPLACE_`) → persisted verbatim. An all-punctuation span on the Premium branch (zero letters/digits — exotic; should never happen for a real spell-check rule) yields the empty string and the match is skipped. The function's return type is `CodeAction?` so the entire code action is omitted when every match in the batch yields empty.

### Check path — `LanguageToolInterface.isCoveredByDictionary`

```kotlin
private fun isCoveredByDictionary(
  annotatedTextFragment: AnnotatedTextFragment,
  match: LanguageToolRuleMatch,
): Boolean {
  val span: String = annotatedTextFragment.getSubstringOfPlainText(match.fromPos, match.toPos)
  val lookupKey: String =
    if (LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)) {
      DictionaryWord.normalize(span)
    } else {
      span
    }
  return lookupKey.isNotEmpty() && this.dictionary.contains(lookupKey)
}
```

Same gate as the add path → symmetric round-trip by construction. The dictionary set itself is **not** transformed at assignment — entries are stored verbatim:

```kotlin
var dictionary: Set<String> = emptySet()
```

## Design decisions (why things are the way they are)

### 1. Gate normalization on the rule id, not on session state

The normalize call runs only when `LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)` returns true — i.e., the match's rule id starts with `QB_NEW_` or `AI_`. Other candidate gates were considered and rejected:

- **`username && apiKey` both set** — proxy for "user is on Premium." But a user could configure credentials against a self-hosted LT instance that doesn't emit `QB_NEW_*` spans; the gate would fire unnecessarily. And we want a per-match decision, not a per-session one.
- **URI contains `languagetoolplus.com`** — direct identification of the Premium endpoint. Empirically verified that the Premium endpoint *without* credentials returns 200 with bare Morfologik spans (`isPremium: false`), so this gate would misfire (`isPremium=true` for a non-Premium response).
- **Combined URI + credentials** — strictest session-level gate, functionally equivalent to the rule-id gate but still a proxy. Misses the case where Premium falls back to Morfologik mid-document for spans `QB_NEW_*` doesn't cover.

The rule id is the *direct* cause of punctuation-adjacent spans existing. If a span includes adjacent punctuation, it's because the rule that produced it does that. So gating on the rule id is the only signal that's accurate by construction: the gate fires exactly when normalize can do something useful and is bypassed entirely otherwise.

This also gives free-LT and local-Java users a stronger guarantee than "normalize is a no-op for them" — the normalize call literally doesn't execute on their match traffic. Any future change to `normalize`'s behavior (e.g., a different stripping rule) cannot accidentally leak into free-LT semantics.

### 2. Asymmetric: normalize on read, respect user data on write

Normalization runs only on the two paths we control: the add path (canonicalize before persisting, for matches that pass the rule-id gate) and the check-path lookup key (LT's output isn't under our control). The user's stored dictionary stays untouched.

Three reasons:

- **The user's dictionary file is user data.** Hand-edited entries reflect user intent — whitespace, punctuation, or unusual shapes are presumed deliberate. Silently rewriting them on load would surprise users who chose those forms.
- **The add path already produces clean entries.** Anyone using "Add to dictionary" via the code action on a Premium QB_NEW/AI match gets a canonical bare-word entry by construction; their dictionary doesn't need "healing" because there's nothing dirty in it.
- **The class of stale entries that load-time normalization would heal is small and finite.** Only Premium users on a previous LTeX+ version who clicked "Add to dictionary" on a punctuation-adjacent match would have a few legacy entries like `"amazng!"`. Easily cleaned by hand once. Not worth a silent global transformation on every settings load.

### 3. We deliberately do **not** split multi-word collapsed spans

Premium's `QB_NEW_*` family also collapses adjacent misspellings into a single span — `recieved teh` (length 12), `Pakket geschtern bekomen` (length 24). An earlier draft of this PR added a `tokenize` helper that split such spans into per-word entries on the add path, and a tokenized fallback on the check path to suppress against per-word entries.

We dropped that machinery. The reasoning:

- Collapsed-span matches are real typos under an orthography rule. The right action for the user is **"Accept suggestion"** (Premium offers the corrected phrase as a one-click fix), not **"Add to dictionary"**. Whitelisting real typos is a misuse of the dictionary.
- A user clicking "Add to dictionary" on `recieved teh` in the old code persists the literal phrase. Subsequent identical collapsed spans suppress via literal lookup — works. The phrase entry doesn't generalize to bare `recieved` later, but that's the user's problem for whitelisting typos in the first place.
- The "splitting" machinery only paid off in a contrived scenario: user wants both `recieved` and `teh` whitelisted globally **and** those misspellings recur singly elsewhere in the document. Not a real user pattern.

The PR is therefore scoped narrowly to the punctuation-adjacent fix, which is the case real Premium users actually hit.

### 4. Precompiled regex constants

`LEADING_NON_WORD_CHARS` and `TRAILING_NON_WORD_CHARS` are `private val` in a Kotlin `object`, so each `Regex(...)` constructor (which calls `Pattern.compile` internally) runs exactly once at class-load time. The anchors `^` and `$` make a no-op match on a bare word O(1).

### 5. Unicode-aware via `\p{L}\p{N}`, not ASCII blacklist

A literal ASCII regex like `[.,;!?…«»()…]` would break on Cyrillic quotes, French guillemets, Japanese corner brackets (`「`/`」`), and any future punctuation we didn't anticipate. `\p{L}` / `\p{N}` covers all Unicode letters and digits respectively, and the complement is a full-fidelity "not a word character" class. Preserves Greek, Cyrillic, CJK, Arabic, accented Latin, Devanagari — verified against `«Привет»`, `「世界」`, `café.`.

## Files changed

| File | Change |
|------|--------|
| `src/main/kotlin/.../languagetool/DictionaryWord.kt` | **New** — `normalize` helper; single source of truth for dictionary-word canonicalization. |
| `src/main/kotlin/.../languagetool/LanguageToolRuleMatch.kt` | New sibling predicate `isPremiumPunctuationAdjacentSpanRule(ruleId)` next to the existing `isUnknownWordRule`. Returns true iff the rule id starts with `QB_NEW_` or `AI_` — the rule families empirically observed to emit punctuation-adjacent spans. |
| `src/main/kotlin/.../languagetool/LanguageToolInterface.kt` | `checkMatchValidity` delegates to a new `isCoveredByDictionary` helper that consults `isPremiumPunctuationAdjacentSpanRule(match.ruleId)` to decide whether to normalize the LT span before the dictionary lookup, or use it literally. The `dictionary` field is intentionally not modified at assignment — entries stay verbatim. Doc comments explain the gate and asymmetric design. |
| `src/main/kotlin/.../server/CodeActionProvider.kt` | `getAddWordToDictionaryCodeAction` consults the same predicate to decide whether to normalize the match span before persisting; non-Premium-punctuation rule matches are persisted verbatim. Skips all-empty (after normalization) entries; return type becomes `CodeAction?` so the caller can omit the action when nothing was persisted. |
| `src/test/kotlin/.../languagetool/DictionaryWordTest.kt` | **New** — unit tests covering plain words, surrounding punctuation, internal apostrophes/hyphens, non-Latin scripts, digits, internal-whitespace preservation, the trailing-apostrophe tradeoff, and all-punctuation → empty. |
| `src/test/kotlin/.../languagetool/LanguageToolPremiumIntegrationTest.kt` | **New** — 2 env-gated integration tests against `api.languagetoolplus.com`. Test 1 asserts Premium returns multiple spans for `amazng` with different adjacent punctuation, and that they all normalize to the same bare word. Test 2 asserts seeding `{amazng}` into the dictionary suppresses every variant. Custom `RequirePremiumCredentials` ExecutionCondition prints a one-time visible skip warning when env vars are missing. |
| `.github/workflows/ci.yml` | Wire `LANGUAGETOOL_USERNAME` and `LANGUAGETOOL_API_KEY` repository secrets into the `Build LTeX+ LS` step so CI exercises the Premium path on every push and PR (fork PRs auto-skip — GitHub policy doesn't expose secrets to forks). |
| `changelog.xml` | New `<action type="fix">` entry under the upcoming release. |

## What changes over the wire and in the UI

**Command arguments** sent to the client for a Premium punctuation-adjacent match — Premium flags `amazng!` (length 7):

```json
{"uri":"…","words":{"en-US":["amazng"]}}
```

Before this PR: `["amazng!"]` — trailing exclamation persisted, later occurrences of bare `amazng` would not match.

**Code-action title** — unchanged. The action label still reads `Add 'amazng' to dictionary`.

**Persisted dictionary state** — one entry per accepted word, bare, no surrounding punctuation.

## Verification

1. **`mvn clean test`** — full suite passes. With Premium env vars unset, the Premium tests skip with a visible one-line warning and the build stays green.

2. **Premium integration, end-to-end.** With `LANGUAGETOOL_USERNAME` + `LANGUAGETOOL_API_KEY` exported:
   - Sample text `"I think amazng. Or amazng! Or even \"amazng\" works."`, language `en-US`, Premium endpoint.
   - Test 1 asserts Premium returns ≥ 2 matches, at least one with adjacent punctuation in the span, and that every normalized span reduces to the same bare word `amazng`. Proves Premium still emits punctuation-inclusive spans and `DictionaryWord.normalize` handles them.
   - Test 2 re-runs with `{amazng}` seeded; asserts every Premium variant is suppressed. Proves the round-trip works.

3. **Regression — multi-word phrase entries.** `DocumentCheckerTest.testDictionary` adds `"LTEX LS"` (hand-typed phrase) to an en-US dictionary and checks markdown that resolves to `LTEX LS` in plaintext. After markdown processing, the local Java Morfologik backend collapses the adjacent all-caps unknowns into one span `LTEX LS` under rule `MORFOLOGIK_RULE_EN_US` — the gate doesn't fire for that rule family, so the lookup is literal; the dictionary contains the literal phrase `LTEX LS`; the lookup hits and the diagnostic is suppressed. Test passes unchanged.

4. **Regression — existing single-word paths.** Free LT Morfologik/Hunspell/SPELLER_RULE single-word spans like `pekné`, `mmots`, `unknownword` don't fire the gate, so the lookup is literal — identical to the pre-PR literal-substring path. `testDictionary` confirms.

5. **All-punctuation guard.** Unit-tested in `DictionaryWordTest.testNormalizeReturnsEmptyForPurelyPunctuation` (`""`, `"..."`, `"—"`, `"\"'\""` all produce empty). The add-path's `if (word.isEmpty()) continue` + `if (unknownWordsMap.isEmpty()) return null` ensures no code action is offered for such matches.

## Non-goals / follow-ups

- **Heal legacy dictionary entries from prior versions.** Premium users on a pre-PR version who clicked "Add to dictionary" on a punctuation-adjacent match have a few stale entries (e.g. `"amazng!"`) in their on-disk dictionary. We intentionally do **not** transform these at load time — see Design Decision 2 (asymmetric: normalize on read, respect user data on write). The user can re-add via the code action or hand-edit the file. Small one-time annoyance for a tiny user subset; not worth a silent global transformation.

- **Handle Premium-collapsed multi-word spans.** Premium's `QB_NEW_*` family also returns spans like `recieved teh` (two adjacent misspellings collapsed). The "Add to dictionary" code action on such a match persists the literal phrase, which doesn't generalize to the bare words elsewhere. We deliberately do not handle this — the right user action for these matches is "Accept suggestion" (Premium offers the corrected phrase as a one-click fix), not "Add to dictionary." See Design Decision 3.

## Breaking changes

None in the server's LSP contract. One observable behavioral shift, which is a strict improvement:

- *"Add to dictionary"* on a Premium punctuation-adjacent match now persists the bare word instead of the raw substring with punctuation.

Legacy entries from prior LTeX+ versions are not auto-healed — see Design Decision 2 and the Non-goals section. Hand-typed multi-word phrase entries (`"LTEX LS"`, `"New York"`) continue to match unchanged: the rule family that fires for them (`MORFOLOGIK_RULE_*`) doesn't pass the gate, so the lookup is literal and the verbatim phrase entry matches.

## Client-side notes (for `vscode-ltex-plus` / `lsp-ltex-plus` maintainers)

- The command argument shape (`{uri, words: {lang: [...]}}`) is unchanged.
- Persisted words on disk are now consistently bare (no surrounding punctuation) when added via the code action.
- No migration is required for on-disk dictionary files. Hand-typed entries with internal whitespace continue to suppress correctly.
