### PR TITLE
Hardcode ltex-plus org/repo in common.py instead of inferring from or…

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -18,15 +18,7 @@ import urllib.request
 
 
 
-def getGitHubOrganizationRepository() -> Tuple[str, str]:
-  output = subprocess.run(["git", "remote", "get-url", "origin"],
-      stdout=subprocess.PIPE).stdout.decode()
-  regexMatch = re.search(r"github.com[:/](.*?)/(.*?)(?:\.git)?$", output)
-  assert regexMatch is not None, output
-  organization, repository = regexMatch.group(1), regexMatch.group(2)
-  return organization, repository
-
-organization, repository = getGitHubOrganizationRepository()
+organization, repository = "ltex-plus", "ltex-ls-plus"
 
 
 


### PR DESCRIPTION
getGitHubOrganizationRepository() inferred (organization, repository) from `git remote get-url origin` and asserted on the regex match. On clones without an `origin` remote at all (e.g., a contributor who renamed their fork remote to `fork` and named the upstream remote `upstream`), the assertion fails, and any tool that imports common crashes on import.

Even when `origin` exists but points to a personal fork (`alberti42/ltex-ls-plus`), the wrong organization is inferred, which leaks into convertChangelog.py's parseIssue and renders unprefixed issue references in changelog.xml as `alberti42/ltex-ls-plus` URLs in the published docs.

Replace the function with robust and safer hardcoded values. The repository's identity is permanent: this is and will always be ltex-ls-plus under the ltex-plus organization. Inferring it from a Git remote was fragile premature flexibility that only created bugs.

Moreover, even if one day we decided to migrate this organization to a different name, there would be plenty of other hardcoded links that would need to be updated anyway. So hardcoding the link here makes no difference in the future but only makes maintenance today safer and more robust.