### PR TITLE
Markdown: accept spaces and backslashes in angle-bracketed link URLs

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -38,6 +38,9 @@
       <action type="fix" due-to="Andrea Alberti (@alberti42)">
         Offer the "Add to dictionary" code action for spell-check matches produced by LanguageTool's `QB_NEW_*_ORTHOGRAPHY_*`, `AI_*_GGEC_REPLACEMENT_ORTHOGRAPHY_*`, and `ES_SIMPLE_REPLACE_*` rule families (Premium/HTTP tier plus Spanish common-typo rules). Also split multi-word collapsed match spans on whitespace so each misspelled word is added to the user dictionary individually instead of as a single phrase.
       </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Markdown: accept spaces and backslashes inside angle-bracketed link destinations (e.g. `[text](&lt;path with spaces.pdf&gt;)` or Windows-style `[text](&lt;C:\Users\My Documents\file.pdf&gt;)`), so the link is recognized and surrounding punctuation does not leak into spell-checked text.
+      </action>
       <action type="update">
         Update to lsp-cli-plus 2.2.2. See [lsp-cli-plus release notes](https://github.com/ltex-plus/lsp-cli-plus/releases/tag/2.2.2).
       </action>

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
@@ -276,16 +276,22 @@ class MarkdownAnnotatedTextBuilder(
 
   companion object {
     private val PARSER_OPTIONS: DataHolder =
-      MutableDataSet().set(
-        Parser.EXTENSIONS,
-        listOf(
-          DefinitionExtension.create(),
-          GitLabExtension.create(),
-          LtexMarkdownExtension.create(),
-          StrikethroughExtension.create(),
-          TablesExtension.create(),
-          YamlFrontMatterExtension.create(),
-        ),
-      )
+      MutableDataSet()
+        // CommonMark allows spaces inside angle-bracketed link destinations
+        // (e.g. `[text](<file with spaces.pdf>)`). Flexmark gates this behind
+        // an off-by-default option; without it the link is not recognized
+        // and the surrounding `[` / `(` leak into spell-checked text.
+        .set(Parser.SPACE_IN_LINK_URLS, true)
+        .set(
+          Parser.EXTENSIONS,
+          listOf(
+            DefinitionExtension.create(),
+            GitLabExtension.create(),
+            LtexMarkdownExtension.create(),
+            StrikethroughExtension.create(),
+            TablesExtension.create(),
+            YamlFrontMatterExtension.create(),
+          ),
+        )
   }
 }

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilderTest.kt
@@ -51,6 +51,27 @@ class MarkdownAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("markdown"
   }
 
   @Test
+  fun testAngleBracketedLinkUrlWithSpaces() {
+    // CommonMark allows spaces (and slashes) inside angle-bracketed link
+    // destinations. The link text must replace the whole `[text](<url>)` so
+    // surrounding punctuation does not leak into spell-checked text.
+    assertPlainText(
+      "- Quantum mechanics ([notes](<01 Lectures/Lecture notes 04 - Schroedinger equation.pdf>))\n",
+      "Quantum mechanics (notes)\n",
+    )
+    assertPlainText(
+      "See [the file](<path with spaces.pdf>) for details.\n",
+      "See the file for details.\n",
+    )
+    // Windows-style backslash paths: backslashes before non-punctuation
+    // characters are preserved literally per CommonMark, so the link parses.
+    assertPlainText(
+      "Open [the report](<C:\\Users\\My Documents\\report.pdf>) please.\n",
+      "Open the report please.\n",
+    )
+  }
+
+  @Test
   fun testDefinitionExtension() {
     assertPlainText(
       """


### PR DESCRIPTION
## Problem

In a Markdown document, a link whose destination contains spaces — e.g.

```
- Quantum mechanics ([notes](<01 Lectures/Lecture notes 04 - Schroedinger equation.pdf>))
```

was not recognized as a link. The spell checker then saw the literal `([notes` and flagged it as a misspelling. CommonMark explicitly allows spaces (and other characters) inside angle-bracketed link destinations, so this was a parsing gap on our side.

## Cause

Flexmark gates this behind the parser option `Parser.SPACE_IN_LINK_URLS`, which defaults to `false`. We never set it, so any `[text](<…with spaces…>)` failed to parse as a link, and the surrounding punctuation leaked into the checked text.

## Fix

Enable `Parser.SPACE_IN_LINK_URLS` when building the Markdown parser in MarkdownAnnotatedTextBuilder. One-line change to `PARSER_OPTIONS`.

## Coverage

- Spaces in POSIX-style paths: `[notes](<01 Lectures/Lecture notes.pdf>)`
- Generic spaces in filenames: `[the file](<path with spaces.pdf>)`
- Windows-style backslash paths: `[the report](<C:\Users\My Documents\report.pdf>)`

All three cases are exercised by a new unit test `testAngleBracketedLinkUrlWithSpaces` in `MarkdownAnnotatedTextBuilderTest`.

## Notes

Per CommonMark, backslash only escapes ASCII punctuation, so backslashes inside Windows paths (\U, \M, …) are preserved literally, and the link parses cleanly. The destination is dropped entirely from spell-checked text, so any cosmetic backslash-escape edge cases inside a URL have no effect on checking.
