### PR TITLE
Two fixes to `textDocument/completion`

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -41,6 +41,12 @@
       <action type="fix" due-to="Andrea Alberti (@alberti42)">
         Markdown: accept spaces and backslashes inside angle-bracketed link destinations (e.g. `[text](&lt;path with spaces.pdf&gt;)` or Windows-style `[text](&lt;C:\Users\My Documents\file.pdf&gt;)`), so the link is recognized and surrounding punctuation does not leak into spell-checked text.
       </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Set `CompletionItemKind.Text` on dictionary completion items. Previously items carried only a `label`, leaving `kind` null; clients that map kinds to icons (VS Code, lsp-mode + Corfu, others) fell through to a generic placeholder icon, making LTEX+ word completions look distinct from every other text-based completion source.
+      </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Allow `textDocument/completion` at the very last position of a document. The fragment lookup and prefix scan both used a strict `&lt;` against `code.length`, so a cursor sitting one past the last character (an unterminated document with no trailing whitespace) produced an empty list. Loosened both checks to treat the position immediately after the last character as a valid completion site.
+      </action>
       <action type="update">
         Update to lsp-cli-plus 2.2.2. See [lsp-cli-plus release notes](https://github.com/ltex-plus/lsp-cli-plus/releases/tag/2.2.2).
       </action>

--- a/src/main/kotlin/org/bsplines/ltexls/server/CompletionListProvider.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/CompletionListProvider.kt
@@ -14,6 +14,7 @@ import org.bsplines.ltexls.parsing.CodeFragment
 import org.bsplines.ltexls.parsing.CodeFragmentizer
 import org.bsplines.ltexls.settings.SettingsManager
 import org.eclipse.lsp4j.CompletionItem
+import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Position
 import org.languagetool.DetectedLanguage
@@ -75,14 +76,23 @@ class CompletionListProvider(
     val completionList = ArrayList<CompletionItem>()
 
     for (entry: String in annotatedTextFragment.codeFragment.settings.dictionary) {
-      if (entry.startsWith(prefix)) completionList.add(CompletionItem(entry))
+      if (entry.startsWith(prefix)) completionList.add(buildCompletionItem(entry))
     }
 
     for (entry: String in fullCompletionList) {
-      if (entry.startsWith(prefix)) completionList.add(CompletionItem(entry))
+      if (entry.startsWith(prefix)) completionList.add(buildCompletionItem(entry))
     }
 
     return CompletionList(completionList)
+  }
+
+  private fun buildCompletionItem(label: String): CompletionItem {
+    val item = CompletionItem(label)
+    // Tag dictionary entries as Text so clients can render them with the
+    // appropriate icon; without a kind, clients typically fall back to a
+    // generic placeholder.
+    item.kind = CompletionItemKind.Text
+    return item
   }
 
   private fun getCodeFragmentFromPosition(

--- a/src/main/kotlin/org/bsplines/ltexls/server/CompletionListProvider.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/CompletionListProvider.kt
@@ -99,7 +99,7 @@ class CompletionListProvider(
 
     for (codeFragment: CodeFragment in codeFragments) {
       if (
-        (codeFragment.fromPos <= pos) && (pos < codeFragment.fromPos + codeFragment.code.length)
+        (codeFragment.fromPos <= pos) && (pos <= codeFragment.fromPos + codeFragment.code.length)
       ) {
         if (
           (matchingCodeFragment == null) ||
@@ -146,7 +146,7 @@ class CompletionListProvider(
     code: String,
     pos: Int,
   ): String {
-    if (pos >= code.length) return ""
+    if (pos > code.length) return ""
 
     for (curPos: Int in pos - 1 downTo 0) {
       val character: Char = code[curPos]

--- a/src/test/kotlin/org/bsplines/ltexls/server/CompletionListProviderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/CompletionListProviderTest.kt
@@ -9,9 +9,11 @@
 package org.bsplines.ltexls.server
 
 import org.eclipse.lsp4j.CompletionItem
+import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.Position
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class CompletionListProviderTest {
@@ -53,6 +55,28 @@ class CompletionListProviderTest {
     assertTrue(completionList.items.isNotEmpty())
     for (completionItem: CompletionItem in completionList.items) {
       assertTrue(completionItem.label.startsWith("wonder"))
+    }
+  }
+
+  @Test
+  fun testCompletionItemsCarryTextKind() {
+    // Regression: items used to be returned with a null `kind`, which made
+    // clients render them with a generic / unknown icon. Dictionary entries
+    // and user-dictionary entries should both come back as Text.
+    val languageServer = LtexLanguageServer()
+    languageServer.settingsManager.settings =
+      languageServer.settingsManager.settings.copy(
+        _allDictionaries = mapOf(Pair("en-US", setOf("testfoobar"))),
+      )
+
+    val document =
+      LtexTextDocumentItem(languageServer, "untitled:test.md", "markdown", 1, "This is a test.\n")
+    val completionList: CompletionList =
+      languageServer.completionListProvider.createCompletionList(document, Position(0, 14))
+
+    assertTrue(completionList.items.isNotEmpty())
+    for (completionItem: CompletionItem in completionList.items) {
+      assertEquals(CompletionItemKind.Text, completionItem.kind, completionItem.label)
     }
   }
 }

--- a/src/test/kotlin/org/bsplines/ltexls/server/CompletionListProviderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/CompletionListProviderTest.kt
@@ -39,4 +39,20 @@ class CompletionListProviderTest {
 
     assertTrue(containsDictionaryWord)
   }
+
+  @Test
+  fun testCreateCompletionListAtEndOfDocument() {
+    // Regression: a cursor at the very last position of a document (no
+    // trailing whitespace) used to return an empty list.
+    val languageServer = LtexLanguageServer()
+    val document =
+      LtexTextDocumentItem(languageServer, "untitled:test.md", "markdown", 1, "wonder")
+    val completionList: CompletionList =
+      languageServer.completionListProvider.createCompletionList(document, Position(0, 6))
+
+    assertTrue(completionList.items.isNotEmpty())
+    for (completionItem: CompletionItem in completionList.items) {
+      assertTrue(completionItem.label.startsWith("wonder"))
+    }
+  }
 }


### PR DESCRIPTION
This PR collects two small, independent fixes to `CompletionListProvider`, both surfaced while integrating [ltex-ls-plus](https://github.com/alberti42/emacs-ltex-plus) completion with an external LSP client. They share the same area and are bundled here for review convenience; either commit can be cherry-picked on its own.

## 1. Set `CompletionItemKind.Text` on every completion item

`CompletionItem` was constructed with only a label, leaving `kind` null.
LSP allows omitting `kind`, but clients that map kinds to icons ([kind-icon](https://github.com/jdtsmith/kind-icon)
in `lsp-mode` [`Corfu`](https://github.com/minad/corfu), the VS Code completion popup, others) then fall through
to a generic "unknown" placeholder. The result is that dictionary words
look visually distinct from every other text-based completion source
exposed in the same popup, even though they are conceptually the same
category.

The fix tags every entry from both the user dictionary and the bundled
language list as `CompletionItemKind.Text`, which is the canonical kind
for prose / dictionary words across the LSP ecosystem. Check the [link](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItemKind) for 
the canonical list of allowed kinds provided by the Microsoft LSP protocol
specification.

No client configuration is required; this is purely additive metadata.

Verification — JSON-RPC response to `textDocument/completion` after the
fix:

```json
{
  "items": [
    { "label": "wondered",    "kind": 1 },
    { "label": "wonderfully", "kind": 1 },
    ...
  ]
}
```

**Manual verification**

The first screenshot below shows the previous behavior in VS Code, displaying 
a generic "tool" icon (the default icon when "kind" is not provided / null).

<img width="1428" height="768" alt="Screenshot 2026-04-29 at 12 37 32" src="https://github.com/user-attachments/assets/bd5d681b-4dd0-4d01-886f-a0ba1ecf33cb" />

The second screenshot below shows the completion menu with this PR fix.
The displayed icon is that corresponding to text completion.

<img width="1416" height="468" alt="Screenshot 2026-04-29 at 12 47 13" src="https://github.com/user-attachments/assets/31e31da5-f2a2-47ac-829c-de9e3e17e155" />

## 2. Allow completion at the very end of a document

`getCodeFragmentFromPosition` and `getPrefixFromPosition` both used a
strict `<` against `code.length`, which excluded a cursor sitting one
past the last character of the matched fragment. In practice that means:

- Document text: `"wonder"` (no trailing newline)
- Cursor position: `Position(0, 6)` — immediately after `r`
- Old behaviour: `getCodeFragmentFromPosition` returns `null` because
  `6 < 0 + 6` is false; `createCompletionList` returns
  `CompletionList(emptyList())`.

In normal editor use the case is rarely hit — most documents have a
trailing newline, and most clients fire completion well before the user
reaches the absolute end — but a minimal reproducer (or any client that
opens an unterminated buffer for editing) returned an empty list.

The fix relaxes both checks:

- Fragment lookup: `pos < fromPos + code.length` → `pos <= fromPos + code.length`
- Prefix scan early-out: `pos >= code.length` → `pos > code.length`

The prefix-scan loop already starts from `pos - 1` and walks backwards,
so once the early-out is loosened it correctly produces the prefix for
a cursor sitting one past the last letter. There is no risk of
`StringIndexOutOfBoundsException`: the loop body indexes `code[curPos]`
where `curPos` ranges over `pos - 1 downTo 0`, all of which are valid
even when `pos == code.length`.

Fragment ownership at boundaries is unchanged: when two fragments meet
at position `N`, both conditions are now satisfied for `N`, but the
existing "highest `fromPos` wins" rule continues to award the position
to the second fragment.

**Manual verification**

The first screenshot below shows the previous behavior in VS Code, where
no completion is provided for the last word in an unterminated document (i.e.,
document with no new line).

<img width="1174" height="460" alt="Screenshot 2026-04-29 at 12 37 42" src="https://github.com/user-attachments/assets/37724acc-dc08-409b-8773-f6b2857006d2" />

The second screenshot below demonstrates that with this PR fix, the last word
is correctly autocompleted.

<img width="1532" height="394" alt="Screenshot 2026-04-29 at 12 47 20" src="https://github.com/user-attachments/assets/c9e3fefd-05b0-4545-8072-a25dbacf270e" />

## Tests

Two regression tests are added in `CompletionListProviderTest`:

- `testCompletionItemsCarryTextKind` — sets up a user-dictionary entry so
  both the user-dict loop and the bundled-dict loop are exercised, and
  asserts every returned item has `kind == CompletionItemKind.Text`.
- `testCreateCompletionListAtEndOfDocument` — opens a document of just
  `"wonder"` and requests completion at `Position(0, 6)`, asserting the
  list is non-empty and every label starts with `"wonder"`. Without the
  patch this test fails with an empty completion list.

The existing `testCreateCompletionList` continues to pass unchanged.