### PR TITLE
Make empty completion responses more robust across editors

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentService.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentService.kt
@@ -41,15 +41,21 @@ class LtexTextDocumentService(
   override fun completion(
     params: CompletionParams,
   ): CompletableFuture<Either<List<CompletionItem>, CompletionList>> {
+    // Empty results are returned as `CompletionList(isIncomplete=false, items=[])` rather than a
+    // bare `[]`. Per the LSP spec an empty array is already complete, but some clients (notably
+    // outside VS Code) misread it as incomplete and keep re-requesting; the explicit object form
+    // is unambiguous.
     return if (this.languageServer.settingsManager.settings.completionEnabled) {
       val uri: String =
         params.textDocument?.uri ?: return CompletableFuture.completedFuture(
-          Either.forLeft(emptyList()),
+          Either.forRight(CompletionList(emptyList())),
         )
       val document: LtexTextDocumentItem =
         getDocument(uri) ?: run {
           Logging.LOGGER.warning(I18n.format("couldNotFindDocumentWithUri", uri))
-          return CompletableFuture.completedFuture(Either.forLeft(emptyList()))
+          return CompletableFuture.completedFuture(
+            Either.forRight(CompletionList(emptyList())),
+          )
         }
 
       CompletableFuture.completedFuture(
@@ -61,7 +67,7 @@ class LtexTextDocumentService(
         ),
       )
     } else {
-      CompletableFuture.completedFuture(Either.forLeft(emptyList()))
+      CompletableFuture.completedFuture(Either.forRight(CompletionList(emptyList())))
     }
   }
 

--- a/src/test/kotlin/org/bsplines/ltexls/server/LtexTextDocumentServiceTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/LtexTextDocumentServiceTest.kt
@@ -8,15 +8,22 @@
 
 package org.bsplines.ltexls.server
 
+import org.eclipse.lsp4j.CompletionList
 import org.eclipse.lsp4j.CompletionParams
 import org.eclipse.lsp4j.DidChangeTextDocumentParams
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
 import org.eclipse.lsp4j.DidOpenTextDocumentParams
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent
+import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
+import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class LtexTextDocumentServiceTest {
   @Test
@@ -34,5 +41,48 @@ class LtexTextDocumentServiceTest {
     )
     service.didSave(DidSaveTextDocumentParams(versionedDocument))
     service.didClose(DidCloseTextDocumentParams(versionedDocument))
+  }
+
+  @Test
+  fun testCompletionEmptyResultIsCompletionListNotBareArray() {
+    // Regression: empty completion responses must serialize as
+    // `{"isIncomplete":false,"items":[]}` rather than a bare `[]` or
+    // `{"isIncomplete":null,"items":[]}`. Per the LSP spec a bare array is already complete,
+    // but some non-VS-Code clients misread it as incomplete and keep re-requesting; the
+    // explicit object form with `isIncomplete=false` is unambiguous.
+    //
+    // The serialization to JSON is asserted explicitly because lsp4j's Gson handler
+    // distinguishes "field never written" from "field set to false" for primitive booleans —
+    // the 1-arg `CompletionList(items)` constructor leaves `isIncomplete` unwritten and yields
+    // `null` on the wire even though `getIsIncomplete()` returns `false` from Java code.
+    val server = LtexLanguageServer()
+    val service = LtexTextDocumentService(server)
+    val handler = MessageJsonHandler(emptyMap())
+
+    fun assertEmptyCompletionListOnWire(result: Either<*, *>) {
+      assertTrue(result.isRight, "expected CompletionList (Right), got bare array (Left)")
+      val responseMessage = ResponseMessage()
+      responseMessage.result = result.right as CompletionList
+      val json = handler.serialize(responseMessage)
+      assertTrue(
+        json.contains(""""result":{"isIncomplete":false,"items":[]}"""),
+        "expected result with isIncomplete=false, got: $json",
+      )
+    }
+
+    // 1. completionEnabled=false branch
+    assertEmptyCompletionListOnWire(service.completion(CompletionParams()).get())
+
+    // Enable completion for the remaining branches.
+    server.settingsManager.settings =
+      server.settingsManager.settings.copy(_completionEnabled = true)
+
+    // 2. missing textDocument branch
+    assertEmptyCompletionListOnWire(service.completion(CompletionParams()).get())
+
+    // 3. unknown document URI branch
+    val unknownDocParams = CompletionParams()
+    unknownDocParams.textDocument = TextDocumentIdentifier("untitled:does-not-exist.md")
+    assertEmptyCompletionListOnWire(service.completion(unknownDocParams).get())
   }
 }


### PR DESCRIPTION
## Non-technical description

When you type in an editor and the editor asks LTeX+ "what word completions 
do you suggest here?", LTeX+ sometimes has nothing to suggest. For example:

- you have turned word completion off (`ltex.completionEnabled = false`),
- the cursor is somewhere completions don't apply, or
- there are simply no matching words in the dictionary.

In all of those cases, LTeX+ used to reply with an empty list written in
the shortest possible form: `[]`.

This PR changes that empty reply to a slightly longer, more explicit form:

```json
{ "isIncomplete": false, "items": [] }
```

This is the only change. We preserve the same meaning
("no suggestions, and we're done—don't ask again"), just spelled out instead of
relying on the LSP protocol convention (which certain clients do not honor).

## Relevance

Both forms are technically allowed by the Language Server Protocol (LSP) —
the open standard that editors and language servers like LTeX+ use to talk
to each other. But not all editors interpret the short form the same way,
and a few of them get confused.

Concretely: **`lsp-mode` in Emacs** treats the short `[]` reply as if the
server were saying "I haven't finished thinking—keep asking me." So as the
user continues to type, Emacs keeps re-asking LTeX+ for completions, over and
over, even though there's nothing to suggest it. The longer form removes that
ambiguity: it spells out "this is the final answer."

Switching to the explicit form costs essentially nothing (a handful of extra
bytes per reply, sent only when the reply is empty) and helps editors that
are stricter than VS Code about reading the spec.

## Safe and complying with lsp specs

The LSP specification for `textDocument/completion` defines the reply as
either a plain array `CompletionItem[]` **or** an object called
`CompletionList`. The `CompletionList` object has a field called
`isIncomplete`, defined as:

> *"This list is not complete. Further typing should result in recomputing
> this list."*  
> — [LSP 3.17 specification, `CompletionList`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion)

Setting `isIncomplete: false` is the spec-explicit way of saying "the list is
complete, no need to recompute."

The official spec says verbatim:

> result: CompletionItem[] | CompletionList | null. 
> If a CompletionItem[] is provided it is interpreted to be complete.
> So it is the same as { isIncomplete: false, items }

So this PR isn't introducing anything non-standard: it's using the standard's
own explicit form instead of relying on every editor to correctly infer the
same thing from a bare `[]`.

The change also doesn't add or remove any suggestions; it only changes how
the *empty* answer is wrapped in the message. Editors that already worked
correctly (like VS Code) will continue to work identically.

## Internal consistency

LTeX+ has two places that produce empty completion replies:

- the **dispatcher** (the front door that decides whether to even attempt a
  completion), and
- the **provider** (the part that actually computes the suggestions).

The provider already returned, before this PR, the explicit object form
(`{ "isIncomplete": false, "items": [] }`) when it had nothing to suggest.
The dispatcher was the odd one out, returning the abbreviated `[]`. After
this PR, both speak the same way, which makes the server's behavior easier
to reason about—you don't have to know *which* internal path produced an
empty answer to predict what the editor will see.

## Risk

I expect it very low. The change is a few lines; the shape of the response is one of
the two forms the LSP spec already describes, and a regression test now
locks in the format so future edits won't accidentally revert it.
