### PR TITLE
Don't parse regions of the document we've been told to ignore

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -47,6 +47,9 @@
       <action type="fix" due-to="Andrea Alberti (@alberti42)">
         Allow `textDocument/completion` at the very last position of a document. The fragment lookup and prefix scan both used a strict `&lt;` against `code.length`, so a cursor sitting one past the last character (an unterminated document with no trailing whitespace) produced an empty list. Loosened both checks to treat the position immediately after the last character as a valid completion site.
       </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Don't parse regions of the document the user has disabled with a magic comment (e.g. `# ltex: enabled=false` in org, `% ltex: enabled=false` in LaTeX, etc.). Previously the language-specific parser ran over every fragment, including disabled ones, and the result was discarded just before the LanguageTool check. On documents where most of the body sits behind such a directive this dominated request latency: a 135 KB org file with ~130 KB hidden behind `enabled=false` took ~3 s warm and now takes ~25–55 ms — about the same as if the disabled tail weren't there at all. The optimization lives in the shared check pipeline and benefits every fragmentized language (LaTeX, Markdown, HTML, AsciiDoc, reStructuredText, Typst, org, gitcommit, BibTeX, …).
+      </action>
       <action type="update">
         Update to lsp-cli-plus 2.2.2. See [lsp-cli-plus release notes](https://github.com/ltex-plus/lsp-cli-plus/releases/tag/2.2.2).
       </action>

--- a/src/main/kotlin/org/bsplines/ltexls/server/DocumentChecker.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/DocumentChecker.kt
@@ -27,6 +27,7 @@ import org.eclipse.lsp4j.Range
 import org.languagetool.DetectedLanguage
 import org.languagetool.language.identifier.SimpleLanguageIdentifier
 import org.languagetool.markup.AnnotatedText
+import org.languagetool.markup.AnnotatedTextBuilder
 import org.languagetool.markup.TextPart
 import java.io.OutputStream
 import java.io.PrintStream
@@ -82,11 +83,25 @@ class DocumentChecker(
   private fun buildAnnotatedTextFragments(
     codeFragments: List<CodeFragment>,
     document: LtexTextDocumentItem,
-    hasRange: Boolean = false,
+    rangeStartPos: Int? = null,
   ): List<AnnotatedTextFragment> {
     val annotatedTextFragments = ArrayList<AnnotatedTextFragment>()
+    val hasRange: Boolean = (rangeStartPos != null)
 
     for (codeFragment: CodeFragment in codeFragments) {
+      if (
+        shouldSkipCheck(codeFragment.codeLanguageId, codeFragment.settings, rangeStartPos)
+      ) {
+        // Fragment will be skipped at the check phase (e.g., region after
+        // "# ltex: enabled=false"). Skip parsing too — running the
+        // CodeAnnotatedTextBuilder over a large disabled region is pure
+        // overhead, and on big files (>100KB) it dominates request latency.
+        annotatedTextFragments.add(
+          AnnotatedTextFragment(AnnotatedTextBuilder().build(), codeFragment, document),
+        )
+        continue
+      }
+
       val builder: CodeAnnotatedTextBuilder =
         if (
           hasRange && ProgramCommentRegexs.isSupportedCodeLanguageId(codeFragment.codeLanguageId)
@@ -313,7 +328,7 @@ class DocumentChecker(
     try {
       val codeFragments: List<CodeFragment> = fragmentizeDocument(document, range)
       val annotatedTextFragments: List<AnnotatedTextFragment> =
-        buildAnnotatedTextFragments(codeFragments, document, (range != null))
+        buildAnnotatedTextFragments(codeFragments, document, rangeStartPos)
       val matches: List<LanguageToolRuleMatch> =
         checkAnnotatedTextFragments(annotatedTextFragments, rangeStartPos)
       return Pair(matches, annotatedTextFragments)

--- a/tools/measureLspLatency.py
+++ b/tools/measureLspLatency.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Drive ltex-ls-plus over LSP stdio and measure didOpen → publishDiagnostics.
+
+Reports the latency from sending textDocument/didOpen to receiving the
+matching textDocument/publishDiagnostics for one or more files, all driven
+through a single warm server process so JVM/LanguageTool startup is paid
+only once. Useful for diagnosing whether a slow check is server-side and
+for finding fragments of the pipeline that scale poorly with input size.
+
+Usage:
+  tools/measureLspLatency.py [--server PATH] [--language-id ID] FILE [FILE ...]
+
+Examples:
+  # default: org language id, server from target/appassembler/bin
+  tools/measureLspLatency.py test2.org test1.org test2.org
+
+  # markdown with a custom server binary
+  tools/measureLspLatency.py --language-id markdown --server ./ltex-ls-plus a.md
+
+The first run on each cold server pays JVM + LanguageTool warmup (~1-2s).
+Repeat a file to see warm-server latency.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+DEFAULT_SERVER = (
+    Path(__file__).resolve().parent.parent
+    / "target"
+    / "appassembler"
+    / "bin"
+    / "ltex-ls-plus"
+)
+
+
+def encode(msg: dict) -> bytes:
+    body = json.dumps(msg).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    return header + body
+
+
+def read_message(stream) -> dict | None:
+    headers = b""
+    while b"\r\n\r\n" not in headers:
+        chunk = stream.read(1)
+        if not chunk:
+            return None
+        headers += chunk
+    head_part = headers.split(b"\r\n\r\n", 1)[0]
+    length = 0
+    for line in head_part.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            length = int(line.split(b":", 1)[1].strip())
+    body = b""
+    while len(body) < length:
+        chunk = stream.read(length - len(body))
+        if not chunk:
+            break
+        body += chunk
+    return json.loads(body.decode("utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure ltex-ls-plus didOpen → publishDiagnostics latency.",
+    )
+    parser.add_argument(
+        "--server",
+        default=str(DEFAULT_SERVER),
+        help=f"Path to ltex-ls-plus launcher (default: {DEFAULT_SERVER}).",
+    )
+    parser.add_argument(
+        "--language-id",
+        default="org",
+        help="LSP languageId for the documents (default: org).",
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        help="Files to check. Repeat a file to measure warm-server latency.",
+    )
+    args = parser.parse_args()
+
+    server_path = Path(args.server)
+    if not server_path.exists():
+        print(f"server not found: {server_path}", file=sys.stderr)
+        print("hint: run `mvn package -DskipTests` first", file=sys.stderr)
+        return 1
+
+    proc = subprocess.Popen(
+        [str(server_path)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    # Drain stderr in background so the pipe never fills up.
+    def drain() -> None:
+        for _ in iter(proc.stderr.readline, b""):
+            pass
+
+    threading.Thread(target=drain, daemon=True).start()
+
+    next_id = 1
+
+    def send(msg: dict) -> None:
+        proc.stdin.write(encode(msg))
+        proc.stdin.flush()
+
+    # initialize
+    send({
+        "jsonrpc": "2.0",
+        "id": next_id,
+        "method": "initialize",
+        "params": {
+            "processId": None,
+            "rootUri": None,
+            "capabilities": {
+                "workspace": {"configuration": True},
+                "textDocument": {
+                    "publishDiagnostics": {},
+                    "synchronization": {},
+                },
+            },
+            "initializationOptions": {},
+        },
+    })
+    init_id = next_id
+    next_id += 1
+
+    while True:
+        msg = read_message(proc.stdout)
+        if msg is None:
+            print("server died during initialize", file=sys.stderr)
+            return 1
+        if msg.get("id") == init_id and "result" in msg:
+            break
+
+    send({"jsonrpc": "2.0", "method": "initialized", "params": {}})
+
+    for i, path_str in enumerate(args.files):
+        path = Path(path_str)
+        text = path.read_text(encoding="utf-8")
+        # Unique URI per iteration so didOpen always opens a fresh document.
+        uri = f"file://{path.resolve()}?iter={i}"
+
+        t_start = time.perf_counter()
+        send({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": uri,
+                    "languageId": args.language_id,
+                    "version": 1,
+                    "text": text,
+                },
+            },
+        })
+
+        diag_count = 0
+        while True:
+            msg = read_message(proc.stdout)
+            if msg is None:
+                print("server died", file=sys.stderr)
+                return 1
+            method = msg.get("method")
+            if method == "workspace/configuration":
+                items = msg.get("params", {}).get("items", [])
+                send({
+                    "jsonrpc": "2.0",
+                    "id": msg["id"],
+                    "result": [{} for _ in items],
+                })
+            elif method == "window/workDoneProgress/create":
+                send({"jsonrpc": "2.0", "id": msg["id"], "result": None})
+            elif method == "textDocument/publishDiagnostics":
+                p = msg.get("params", {})
+                if p.get("uri") == uri:
+                    diag_count = len(p.get("diagnostics", []))
+                    break
+
+        elapsed_ms = (time.perf_counter() - t_start) * 1000
+        size = len(text.encode("utf-8"))
+        print(
+            f"{path}: {size:>8} bytes  →  {elapsed_ms:8.1f} ms  "
+            f"({diag_count} diagnostics)"
+        )
+
+    # shutdown
+    shutdown_id = next_id
+    next_id += 1
+    send({"jsonrpc": "2.0", "id": shutdown_id, "method": "shutdown", "params": None})
+    while True:
+        msg = read_message(proc.stdout)
+        if msg is None or msg.get("id") == shutdown_id:
+            break
+    send({"jsonrpc": "2.0", "method": "exit", "params": None})
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

LTeX+ lets you switch checking off in part of a document with a magic
comment, e.g. `# ltex: enabled=false` in an org file (or the equivalent
in LaTeX, Markdown, HTML, AsciiDoc, …). The intent is obvious: skip that
region. The expectation is that skipping it makes the server **fast**.

It didn't. Until this PR, the server was still doing all the heavy
work — running its language-specific parser over every character of the
disabled region — and only at the very end realising "oh, we were
supposed to ignore this" and throwing the result away.

For documents where most of the body sits behind such a directive, that
wasted work dominated the response time. A 135 KB org file whose first
4 KB are real prose and whose remaining 130 KB are hidden behind
`enabled=false` took **~3 seconds** to check on a warm server. After
this PR it takes **~25–55 milliseconds** — about the same as if the
disabled tail weren't there at all. That's a ~60–100× speed-up on that
one file, and the same gain applies to any document of any supported
language that uses the same pattern.

## What was wrong

The check pipeline runs in two stages:

1. **Parse.** The document is broken into "fragments" (separated by the
   magic comments), and each fragment is fed through a language-specific
   parser that builds the structured representation LanguageTool wants.
2. **Check.** Each fragment's parsed result is handed to LanguageTool —
   *unless* the fragment is in a disabled region, in which case it's
   skipped.

The skip decision was being made at stage 2, which is too late. By that
point the parser at stage 1 had already walked every character. For a
130 KB disabled region, that's a lot of wasted character-by-character
work — and on top of it we then immediately discarded the result.

The simplest possible fix is to move the skip decision up. If we already
know we're going to throw the parse away, don't do the parse.

## What this PR does

In the function that produces the parsed fragments
(`buildAnnotatedTextFragments` in `DocumentChecker.kt`), we now consult
the very same skip predicate that stage 2 uses (`shouldSkipCheck`)
**before** running the parser. If a fragment is going to be skipped, we
substitute an empty parsed result and move on. The parser is never
invoked on disabled regions.

The skip predicate already had everything it needed at this earlier
point — the fragment's language id, its settings, and whether the user
asked for a partial-range check. No new state, no new logic, just an
earlier check.

Importantly, this is not an org-mode-only fix. The change lives in the
shared pipeline that every fragmentized language flows through (LaTeX,
Markdown, HTML, AsciiDoc, reStructuredText, Typst, org, gitcommit,
BibTeX, plaintext, source-code comments). Any large document in any of
those languages that uses an `enabled=false` directive will see the same
improvement.

## Before / after

Driven through `tools/measureLspLatency.py` (a small LSP harness shipped
with this PR — see appendix). The same 135 KB file is opened four times
in a row in a single server process; the first row is the cold start
(JVM + LanguageTool initialisation), the rest are warm:

```
$ tools/measureLspLatency.py --language-id org \
      ~/Downloads/test1.org ~/Downloads/test1.org \
      ~/Downloads/test1.org ~/Downloads/test1.org
```

Before this PR:

```
test1.org:   135 399 bytes  →   4 620.0 ms   (1 diagnostics)
test1.org:   135 399 bytes  →   3 182.5 ms   (1 diagnostics)
test1.org:   135 399 bytes  →   3 148.9 ms   (1 diagnostics)
test1.org:   135 399 bytes  →   2 880.5 ms   (1 diagnostics)
```

After this PR:

```
test1.org:   135 399 bytes  →   2 063.4 ms   (1 diagnostics)
test1.org:   135 399 bytes  →      27.2 ms   (1 diagnostics)
test1.org:   135 399 bytes  →      55.4 ms   (1 diagnostics)
test1.org:   135 399 bytes  →      24.2 ms   (1 diagnostics)
```

The warm latency drops from roughly 3 seconds to roughly 25–55
milliseconds. The cold start also improves substantially (4.6 s →
2.1 s) because the wasted parse used to happen on the very first request
too, on top of JVM + LanguageTool initialisation; with this PR the cold
request only pays the latter.

## Why this is safe

- LanguageTool still receives a parsed fragment for every region the
  user wants checked. Only the disabled regions get an empty placeholder.
- The wire-level diagnostics published to the editor are identical to
  before. We verified this by running the full existing test suite
  (220 tests, all pass), including `DocumentCheckerTest.testEnabled`
  which is precisely the round-trip test for `enabled=false` /
  `enabled=true` directives.
- Range-limited checks (when an editor asks LTeX+ to re-check just a
  selection) are unaffected — the skip predicate already returns
  `false` for those, and the new early call respects the same condition.
- `nop` and `plaintext` fragments were already exempt from the skip
  predicate, and they remain so.

## Tooling included

`tools/measureLspLatency.py` (added in the previous commit on this
branch) drives the LSP server over stdio and reports the time from
`textDocument/didOpen` to `textDocument/publishDiagnostics` for any
file you point it at. It's how the numbers above were measured, and
it's a useful first-stop for anyone investigating future "why is the
server slow on this file" reports.

## Appendix: the latency-measurement script

`tools/measureLspLatency.py` is a small Python script (no external
dependencies, just the standard library) that talks LSP to
`ltex-ls-plus` over stdio and prints the round-trip latency of each
check.

### What it does, step by step

1. Spawns one `ltex-ls-plus` process and keeps it alive for the whole
   run, so JVM and LanguageTool initialisation are paid only once.
2. Sends `initialize` and `initialized` to bring the server up.
3. For each file passed on the command line, sends
   `textDocument/didOpen` and starts a stopwatch.
4. Reads messages until it sees the matching
   `textDocument/publishDiagnostics`. That message is the server's
   answer; the elapsed time is what gets reported.
5. Each file is opened under a unique URI (a `?iter=N` is appended to
   the path), so reopening the same physical file always behaves like a
   fresh document on the server side and earlier requests can't leak
   diagnostics into a later measurement.
6. After the last file, sends `shutdown` + `exit` and waits for the
   process to terminate.

Along the way it answers a few server-initiated requests (e.g.
`workspace/configuration`) with empty stubs so the server doesn't
deadlock waiting for the client.

### Usage

```sh
# build the server
mvn package -DskipTests

# default: org language id
tools/measureLspLatency.py path/to/file.org

# repeat a file to see warm-server latency
tools/measureLspLatency.py path/to/big.org path/to/big.org path/to/big.org

# different language id, custom server binary
tools/measureLspLatency.py --language-id markdown \
                           --server ./ltex-ls-plus \
                           README.md
```

### Output format

One line per file:

```
<path>:   <bytes> bytes  →   <elapsed_ms> ms   (<n> diagnostics)
```

`<elapsed_ms>` is wall-clock time on the *client* side, which means it
includes a tiny bit of stdio framing overhead, but the dominant cost is
always the server's parse + check, so this is a faithful proxy for
server latency.

### Conventions for reading the output

- The **first** line for any given language is a cold-start cost (JVM
  startup, LanguageTool initialisation, JIT warmup of the parser code
  paths). For en-US LanguageTool this is typically 1.5–2 s.
- **Subsequent** lines on the same language are warm latency — what an
  editor user actually feels while typing.
- Mixing languages in one run will trigger a smaller cold start the
  first time each new language is encountered.

### When to use it

- Comparing server performance before and after a change — repeat the
  exact same invocation on both branches and read off the warm rows.
- Triaging "the server is slow" reports — if the script reports fast
  warm times, the bottleneck is likely on the client side; if not, it's
  in the server pipeline and worth profiling.
- Spotting parts of the parse pipeline that scale poorly — feed it
  files of growing size in the same language and watch the warm latency
  curve.
