### PR TITLE
Org: two fixes for how list items reach LanguageTool

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -53,6 +53,9 @@
       <action type="fix" due-to="Andrea Alberti (@alberti42)">
         Don't parse regions of the document the user has disabled with a magic comment (e.g. `# ltex: enabled=false` in org, `% ltex: enabled=false` in LaTeX, etc.). Previously the language-specific parser ran over every fragment, including disabled ones, and the result was discarded just before the LanguageTool check. On documents where most of the body sits behind such a directive this dominated request latency: a 135 KB org file with ~130 KB hidden behind `enabled=false` took ~3 s warm and now takes ~25–55 ms — about the same as if the disabled tail weren't there at all. The optimization lives in the shared check pipeline and benefits every fragmentized language (LaTeX, Markdown, HTML, AsciiDoc, reStructuredText, Typst, org, gitcommit, BibTeX, …).
       </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Org: don't flag the wrapped half of a list item for "first letter not uppercase". Previously every list-item line emitted a paragraph break at end-of-line, so a continuation line indented to the bullet body (e.g. `+ A long sentence that wraps\n  onto the next line.`) was sent to LanguageTool as a fresh paragraph and its lowercase first word was flagged. The parser now tracks the bullet body column and, when the next line is a true wrap (indented past the bullet and not itself a new bullet), suppresses the paragraph break so the wrap stays in the same paragraph.
+      </action>
       <action type="update">
         Update to lsp-cli-plus 2.2.2. See [lsp-cli-plus release notes](https://github.com/ltex-plus/lsp-cli-plus/releases/tag/2.2.2).
       </action>

--- a/changelog.xml
+++ b/changelog.xml
@@ -56,6 +56,9 @@
       <action type="fix" due-to="Andrea Alberti (@alberti42)">
         Org: don't flag the wrapped half of a list item for "first letter not uppercase". Previously every list-item line emitted a paragraph break at end-of-line, so a continuation line indented to the bullet body (e.g. `+ A long sentence that wraps\n  onto the next line.`) was sent to LanguageTool as a fresh paragraph and its lowercase first word was flagged. The parser now tracks the bullet body column and, when the next line is a true wrap (indented past the bullet and not itself a new bullet), suppresses the paragraph break so the wrap stays in the same paragraph.
       </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Org: spell-check the term in description lists. The prefix of a description-list item (e.g. `- Apple :: a red fruit`) used to be consumed as one chunk of markup, which silently dropped the term ("Apple") on the floor — typos in it went unnoticed. The parser now splits the prefix into bullet, **term (text)**, and ` ::` separator, so the term reaches LanguageTool and is spell- and grammar-checked like any other word. A single `\n` separator keeps the term in the same LanguageTool paragraph as the description, so the description's lowercase first word ("a red fruit") is not flagged.
+      </action>
       <action type="update">
         Update to lsp-cli-plus 2.2.2. See [lsp-cli-plus release notes](https://github.com/ltex-plus/lsp-cli-plus/releases/tag/2.2.2).
       </action>

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilder.kt
@@ -203,7 +203,7 @@ class OrgAnnotatedTextBuilder(
       val bulletLength: Int = bulletGroup?.value?.length ?: 1
       this.itemBodyIndent = this.indentation + bulletLength + 1
       this.appendAtEndOfLine = "\n"
-      addMarkup(matchResult?.value, "\n")
+      addItemPrefixMarkup(matchResult)
     } else if (matchFromPosition(BABEL_CALL_REGEX)?.also { matchResult = it } != null) {
       addMarkup(matchResult?.value)
     } else if (matchFromPosition(CLOCK_REGEX)?.also { matchResult = it } != null) {
@@ -439,6 +439,33 @@ class OrgAnnotatedTextBuilder(
     }
   }
 
+  private fun addItemPrefixMarkup(matchResult: MatchResult?) {
+    val matchValue: String = matchResult?.value ?: ""
+    val descriptionGroup: MatchGroup? = matchResult?.groups?.get(ITEM_DESCRIPTION_TERM_GROUP)
+
+    if (descriptionGroup != null) {
+      // Description list item: "- Term :: body". Emit the term as plain text
+      // so LanguageTool can spell-check it; keep the bullet, " ::" and
+      // surrounding whitespace as markup. A single "\n" replacement on the
+      // separator keeps term and body in the same LT paragraph, so the body's
+      // first letter isn't flagged for not being uppercase.
+      val termMatch: MatchResult? = DESCRIPTION_TERM_REGEX.find(descriptionGroup.value)
+      val term: String? = termMatch?.groupValues?.get(2)
+
+      if (!term.isNullOrEmpty()) {
+        val leadingWsLen: Int = termMatch.groupValues[1].length
+        val termStart: Int = descriptionGroup.range.first + leadingWsLen
+        val termEnd: Int = termStart + term.length
+        addMarkup(matchValue.substring(0, termStart), "\n")
+        addText(term)
+        addMarkup(matchValue.substring(termEnd), "\n")
+        return
+      }
+    }
+
+    addMarkup(matchValue, "\n")
+  }
+
   private fun isNextLineItemContinuation(): Boolean {
     var p: Int = this.pos + 1
     var indent = 0
@@ -621,6 +648,15 @@ class OrgAnnotatedTextBuilder(
       Regex(
         "^(\\*|-|\\+|([0-9]+|[A-Za-z])[.)])(?=[ \t]|$)([ \t]+\\[@([0-9]+|[A-Za-z])])?" +
           "([ \t]+\\[[- \tX]])?([ \t]+[^\r\n]*?[ \t]+::)?[ \t]*",
+        RegexOption.IGNORE_CASE,
+      )
+
+    // Capture-group index in ITEM_REGEX of the optional description term
+    // (the "<term> ::" portion of "- term :: body").
+    private const val ITEM_DESCRIPTION_TERM_GROUP = 6
+    private val DESCRIPTION_TERM_REGEX =
+      Regex(
+        "^([ \t]+)(.*?)([ \t]+)::$",
         RegexOption.IGNORE_CASE,
       )
 

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilder.kt
@@ -16,6 +16,7 @@ class OrgAnnotatedTextBuilder(
 ) : CharacterBasedCodeAnnotatedTextBuilder(codeLanguageId) {
   private var indentation = -1
   private var appendAtEndOfLine = ""
+  private var itemBodyIndent = -1
   private val elementTypeStack: ArrayDeque<ElementType> = ArrayDeque(listOf(ElementType.Paragraph))
   private var latexEnvironmentName: String? = null
   private val objectTypeStack = ArrayDeque<ObjectType>()
@@ -198,6 +199,9 @@ class OrgAnnotatedTextBuilder(
       this.appendAtEndOfLine = "\n"
       addMarkup(matchResult?.value, "\n")
     } else if (matchFromPosition(ITEM_REGEX)?.also { matchResult = it } != null) {
+      val bulletGroup: MatchGroup? = matchResult?.groups?.get(1)
+      val bulletLength: Int = bulletGroup?.value?.length ?: 1
+      this.itemBodyIndent = this.indentation + bulletLength + 1
       this.appendAtEndOfLine = "\n"
       addMarkup(matchResult?.value, "\n")
     } else if (matchFromPosition(BABEL_CALL_REGEX)?.also { matchResult = it } != null) {
@@ -229,7 +233,7 @@ class OrgAnnotatedTextBuilder(
     return elementFound
   }
 
-  @Suppress("ComplexMethod", "LongMethod")
+  @Suppress("ComplexMethod", "LongMethod", "NestedBlockDepth")
   private fun processCharacterInternal() {
     var matchResult: MatchResult? = null
 
@@ -365,6 +369,17 @@ class OrgAnnotatedTextBuilder(
         addText(textMarkupMarker)
       }
     } else if (this.curChar == '\n') {
+      if (this.itemBodyIndent >= 0) {
+        if (isNextLineItemContinuation()) {
+          // Wrapped continuation of the current list item: don't insert a
+          // paragraph break, otherwise LanguageTool sees the continuation as a
+          // fresh sentence and flags it (e.g., for not starting with uppercase).
+          this.appendAtEndOfLine = ""
+        } else {
+          this.itemBodyIndent = -1
+          if (this.appendAtEndOfLine.isEmpty()) this.appendAtEndOfLine = "\n"
+        }
+      }
       addMarkup("\n", "\n" + this.appendAtEndOfLine)
       this.appendAtEndOfLine = ""
       if (this.elementTypeStack.contains(ElementType.Headline)) popElementType()
@@ -422,6 +437,29 @@ class OrgAnnotatedTextBuilder(
     } else {
       null
     }
+  }
+
+  private fun isNextLineItemContinuation(): Boolean {
+    var p: Int = this.pos + 1
+    var indent = 0
+
+    while (p < this.code.length) {
+      val c: Char = this.code[p]
+      if ((c == ' ') || (c == '\t')) {
+        indent++
+        p++
+      } else if ((c == '\n') || (c == '\r')) {
+        return false
+      } else {
+        if (indent < this.itemBodyIndent) return false
+        // A new bullet on the next line starts a fresh item (possibly nested),
+        // not a wrapped continuation.
+        val matchResult: MatchResult? = ITEM_REGEX.find(this.code.substring(p))
+        return (matchResult == null) || (matchResult.range.first != 0)
+      }
+    }
+
+    return false
   }
 
   private fun isInIgnoredElementType(): Boolean =

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilderTest.kt
@@ -266,6 +266,77 @@ class OrgAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("org") {
   }
 
   @Test
+  fun testWrappedListItems() {
+    // Continuation lines indented to the bullet's body column belong to the
+    // same item — they must not be split into a new paragraph, otherwise
+    // LanguageTool flags the wrapped sentence as not starting with uppercase.
+    assertPlainText(
+      """
+      + A long sentence that wraps. A long sentence
+        that wraps.
+
+      """.trimIndent(),
+      "\nA long sentence that wraps. A long sentence\nthat wraps.\n\n",
+    )
+    assertPlainText(
+      """
+      + first
+        continuation
+      + second
+
+      """.trimIndent(),
+      "\nfirst\ncontinuation\n\n\nsecond\n\n",
+    )
+    assertPlainText(
+      """
+      + first
+        continuation
+
+      after
+
+      """.trimIndent(),
+      "\nfirst\ncontinuation\n\n\nafter\n",
+    )
+    // Same wrap behaviour must hold for every bullet type org accepts.
+    // "-" (1-char body, continuation indent 2):
+    assertPlainText(
+      """
+      - first
+        continuation
+
+      """.trimIndent(),
+      "\nfirst\ncontinuation\n\n",
+    )
+    // Indented "*" (1-char body, continuation indent 4 because the bullet
+    // itself is indented at column 2). Cannot use trimIndent here because it
+    // would strip the leading whitespace and turn "  * first" into "* first",
+    // which the parser would correctly classify as a headline rather than an
+    // (indented) list item.
+    assertPlainText(
+      "  * first\n    continuation\n",
+      "\nfirst\ncontinuation\n\n",
+    )
+    // Numbered bullet "1." (2-char body, continuation indent 3):
+    assertPlainText(
+      """
+      1. first
+         continuation
+
+      """.trimIndent(),
+      "\nfirst\ncontinuation\n\n",
+    )
+    // Alphabetical bullet "a)" (2-char body, continuation indent 3):
+    assertPlainText(
+      """
+      a) first
+         continuation
+
+      """.trimIndent(),
+      "\nfirst\ncontinuation\n\n",
+    )
+  }
+
+  @Test
   fun testTables() {
     assertPlainText(
       """

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/org/OrgAnnotatedTextBuilderTest.kt
@@ -11,6 +11,7 @@ package org.bsplines.ltexls.parsing.org
 import org.bsplines.ltexls.parsing.CodeAnnotatedTextBuilderTest
 import kotlin.test.Test
 
+@Suppress("LargeClass")
 class OrgAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("org") {
   @Test
   fun testHeadlinesAndSections() {
@@ -261,7 +262,44 @@ class OrgAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("org") {
          - Test tag :: Test 3.
 
       """.trimIndent(),
-      "\nTest 1.\n\n\nTest 2.\n\n\nTest 3.\n\n",
+      "\nTest 1.\n\n\nTest 2.\n\n\nTest tag\nTest 3.\n\n",
+    )
+  }
+
+  @Test
+  fun testDescriptionListTerm() {
+    // The term in "- Term :: body" must reach LanguageTool as text so that
+    // typos in the term get caught.
+    assertPlainText(
+      "- Apple :: a red fruit\n",
+      "\nApple\na red fruit\n\n",
+    )
+    assertPlainText(
+      "- [X] Mitochondria :: the powerhouse of the cell\n",
+      "\nMitochondria\nthe powerhouse of the cell\n\n",
+    )
+    // Bullet without a description term still works.
+    assertPlainText(
+      "- a plain bullet\n",
+      "\na plain bullet\n\n",
+    )
+    // The same fix must apply to every other bullet type org accepts:
+    // "+", indented "*", numbered, and alphabetical bullets.
+    assertPlainText(
+      "+ Apple :: a red fruit\n",
+      "\nApple\na red fruit\n\n",
+    )
+    assertPlainText(
+      "  * Apple :: a red fruit\n",
+      "\nApple\na red fruit\n\n",
+    )
+    assertPlainText(
+      "1. Apple :: a red fruit\n",
+      "\nApple\na red fruit\n\n",
+    )
+    assertPlainText(
+      "a) Apple :: a red fruit\n",
+      "\nApple\na red fruit\n\n",
     )
   }
 


### PR DESCRIPTION
# Org: two fixes for how list items reach LanguageTool

## Summary

This PR fixes two separate-but-related issues with how org-mode list
items are handed to LanguageTool. Both issues produced the same kind of
unhappy outcome — false positives or silent misses on prose that users
reasonably expect to be checked correctly — and both turned out to be
small mistakes in how the parser converts org's list syntax into the
plain text LanguageTool sees.

The two fixes are kept as separate commits so each one is reviewable on
its own:

1. **Wrapped list-item continuation lines no longer get a spurious
   paragraph break** — fixes a false positive where a bullet whose text
   wraps onto the next line was flagged for "first letter not
   uppercase" on the wrapped half.
2. **Description-list terms are now spell-checked** — fixes a silent
   miss where the term part of `- Term :: explanation` was dropped on
   the floor instead of being checked.

## Fix 1 — wrapped list-item continuation lines

### What was wrong

Take the kind of bullet that wraps in a normal text editor:

```org
+ A long sentence that will be filled across lines. A long sentence
  that will be filled across lines.
```

Until now, LanguageTool would dutifully flag the `t` in the second
line's "that…" with:

> *This sentence does not start with an uppercase letter.*

That's incorrect: the second line is a continuation of the bullet on
the first line. There's no new sentence; it's a wrap.

The bug was in the parser's end-of-line handling for list-item lines.
Every list-item line was unconditionally emitting a paragraph break
(`\n\n`) at end-of-line, which makes LanguageTool treat whatever comes
next as a fresh paragraph. A real continuation line, indented to match
the bullet's body, was therefore being seen as a brand-new paragraph
that suspiciously began with a lowercase letter.

### The fix

The parser now tracks the bullet body's column when it sees a list item
opening, and at end-of-line it peeks at the next line. The new helper
`isNextLineItemContinuation()` decides whether what follows is a true
wrap. It applies two checks, in this order:

1. **Indentation.** The next line must be indented to or past the
   bullet body's column. If it's less indented (or the line is blank),
   the item is over — emit the usual paragraph break.
2. **Not itself a new bullet.** Even when the indentation lines up, the
   next line might be a *fresh sub-item* rather than a wrap. The
   helper handles this by trying `ITEM_REGEX` against the start of the
   next line; if the regex matches, it's a new (sub-)item and the
   parent item is over.

Why the second check is needed: consider a nested sub-list,

```org
+ Outer item
  - Sub item
```

The sub-item line is indented to column 2, which is exactly "Outer
item"'s bullet body. By indentation *alone* it would look like a
wrapped continuation — but it isn't, it's a fresh (sub-)item that
happens to live underneath. The `ITEM_REGEX` check catches this: the
line begins with `-`, the regex matches, and the helper correctly
reports "not a continuation".

When both checks pass, the helper returns `true`, the parser emits a
single `\n` (instead of `\n\n`), and the wrap stays in the same
LanguageTool paragraph.

### Tests

A new test method `testWrappedListItems` covers seven cases. The first
three pin down the core wrap behaviour using the original `+` bullet:

- A simple wrap: `+ first line\n  continuation` flows as one paragraph.
- A wrap followed by a new bullet on the next line: the bullet
  correctly ends the wrapped item and starts a new one.
- A wrap followed by a blank line and an unrelated paragraph: the
  blank line correctly ends the wrapped item.

The remaining four exercise every other bullet type org accepts —
`-`, indented `*`, numbered `1.`, alphabetical `a)` — to lock down the
claim that the fix is bullet-agnostic. (The `*` case is special: it
must be indented, otherwise it would be parsed as a headline; the
test uses a literal string rather than `trimIndent` so the leading
whitespace survives.)

## Fix 2 — description-list terms

### What was wrong

Org-mode has a compact little syntax for description lists — the kind
of list you'd use for a glossary, a definitions section, or a
meeting-notes "who is doing what":

```org
- Apple :: a red fruit
- Mitochondria :: the powerhouse of the cell
- Andrea :: writes the integration tests
```

The bit before `::` is the **term**, the bit after is the
**description**.

Until this PR, LTeX+ silently ignored the term. Spell-check ran on the
description ("a red fruit"), but if you wrote `Aplpe` or `Mtiochondria`
or `Anrea`, nothing flagged it. That's the kind of silent miss that
makes people lose trust in their spell-checker.

Internally, every list-item line is matched by a single regex that
captures the bullet, the optional checkbox, and — for description
lists — the term plus the trailing `::` as one big "prefix". The whole
captured prefix was then handed to LanguageTool as one chunk of
*markup*, with a single `\n` standing in for it. That's correct for
the mechanical pieces (`-`, ` :: `, surrounding whitespace) but it's
wrong for the term itself: the term is real text and should be
checked.

So `- Aplpe :: a red fruit` reached LanguageTool as just `a red fruit`,
and the typo in `Aplpe` was invisible.

### Why it matters

In real-world org-mode use — notes, blog posts, manuscripts,
glossaries, class hand-outs — the term is almost always a
natural-language word: "Apple", "Mitochondria", "Inflation",
"Andrea". The "term is a label or keyword" case (API docs, config
keys) does exist, but it's the minority, and even there typos in the
term are usually mistakes worth catching.

A spell-checker that quietly skips a chunk of every description list
is a worse default than one that occasionally flags an intentional
acronym.

### The fix

When the parser sees a description-list item, it now splits the prefix
into three pieces and emits them separately:

1. The bullet and any leading whitespace before the term — markup,
   replaced by a single `\n` (preserves the existing paragraph
   behaviour between list items).
2. The term itself — emitted as plain text, so LanguageTool sees and
   checks it.
3. The ` ::` and trailing whitespace after the term — markup, replaced
   by a single `\n`.

The choice of a *single* `\n` (instead of the more obvious `\n\n`) on
the separator is deliberate: it keeps term and description in the same
LanguageTool paragraph, so LanguageTool doesn't fire its "first letter
of a sentence should be uppercase" rule on a description that
legitimately starts with a lowercase article (`a red fruit`,
`the powerhouse of the cell`, …).

Before / after, in terms of what LanguageTool actually receives for
`- Apple :: a red fruit`:

```
before:   "a red fruit"
after:    "Apple\na red fruit"
```

Both spell-checks now work, and neither produces a false-positive
capitalisation flag.

For ordinary bullets without a `::` (the vast majority of list items),
nothing changes — the regex's description-term group simply doesn't
match, and the original single-piece markup path is taken.

### Tests

- One existing test (`testLists`) had its expected plain text adjusted
  to include the term `Test tag`, which is what the fix is asserting:
  the term must reach the plain-text stream.
- A new test method `testDescriptionListTerm` covers seven cases:
  - A simple description-list item: `- Apple :: a red fruit`.
  - A description-list item with a checkbox in front:
    `- [X] Mitochondria :: the powerhouse of the cell`. (Confirms the
    splitter handles the optional checkbox between bullet and term.)
  - A plain bullet with no `::`: `- a plain bullet`. (Confirms the
    non-description path still works exactly as before.)
  - The same `Apple :: a red fruit` term with each of the other bullet
    types org accepts: `+`, indented `*`, numbered `1.`, and
    alphabetical `a)`. (Locks down the claim that the fix is
    bullet-agnostic — the `::` syntax is what makes a list
    descriptive, not the bullet character.)

## Why this is safe

- Both fixes are surgical changes to the org parser and don't touch
  any other language.
- The full test suite passes (220 tests across all languages, 38 in
  the org parser — including the two new test methods added here,
  which together hold 14 assertions covering both fixes across every
  bullet type org accepts).
- For ordinary bullets without `::` and without wrapping, the parser
  behaves exactly as before. The fixes only kick in for the two
  specific patterns they target.

## References

- Org-mode reference for plain lists, including description lists and
  list-item continuation rules:
  <https://orgmode.org/manual/Plain-Lists.html#Plain-Lists>
