### PR TITLE
Fix word-completion silently failing for non VS Code users

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -101,7 +101,7 @@ class LtexLanguageServer :
 
     serverCapabilities.codeActionProvider =
       Either.forRight(CodeActionOptions(CodeActionProvider.getCodeActionKinds()))
-    serverCapabilities.completionProvider = CompletionOptions()
+    serverCapabilities.completionProvider = CompletionOptions().apply { resolveProvider = false }
     serverCapabilities.executeCommandProvider =
       ExecuteCommandOptions(LtexWorkspaceService.getCommandNames())
     serverCapabilities.textDocumentSync = Either.forLeft(TextDocumentSyncKind.Full)

--- a/src/test/resources/LtexLanguageServerTestLog.txt
+++ b/src/test/resources/LtexLanguageServerTestLog.txt
@@ -271,7 +271,9 @@ Params: {
 Result: {
     "capabilities": {
         "textDocumentSync": 1,
-        "completionProvider": {},
+        "completionProvider": {
+            "resolveProvider": false
+        },
         "codeActionProvider": {
             "codeActionKinds": [
                 "quickfix.ltex.acceptSuggestions"


### PR DESCRIPTION
## What this changes

When ltex-ls-plus starts up, it tells the editor what features it supports as a JSON object. For word completion, the current advertisement is `"completionProvider": {}` — an empty object, valid JSON, meaning *"yes, supported, no extra details."*

This PR changes it to `"completionProvider": { "resolveProvider": false }` — a non-empty object meaning *"yes, supported; you don't need to call back for extra information on each suggestion."*

The added statement is not new information. Per the LSP specification, `resolveProvider` is an optional boolean that defaults to `false` when omitted—so `{}` already meant `{ "resolveProvider": false }` implicitly. The PR just makes that default explicit. `ltex-ls-plus` has no `completionItem/resolve` handler in its source, so this matches what the server actually does.

## Why

Some Emacs users have been hitting a confusing error when they trigger word completion in a document checked by `ltex-ls-plus`:

> *The connected server(s) does not support method textDocument/completion.*

The cause is a quirk in how Emacs's JSON parser handles `{}`: in one of its two operating modes (`lsp-use-plists`, increasingly common because it's faster), an empty `{}` is parsed to `nil` — the same value the parser uses when a field is absent entirely. So Emacs can't tell *"server said `{}`"* (supported, no extras) from *"server didn't mention completion at all"* (not supported), and it picks the second interpretation. The completion feature is silently disabled.

A non-empty object like `{ "resolveProvider": false }` parses to a non-nil value, so the ambiguity disappears. Emacs sees a clear *"yes, supported"* and word completion works again.

## Why this is the right fix

- **Honest:** the change describes ltex-ls-plus accurately. It says *"don't bother calling me back to fill in extra details on each suggestion"* — and indeed, no such follow-up handler exists in the code.
- **Backwards-compatible:** clients that already handled `{}` correctly (VS Code, and Emacs in its other operating mode) see no semantic difference, since the new form just spells out the spec-defined default.
- **Small:** one line in the server code, plus a matching line in a test fixture so the recorded log still matches.

## Why not fix it on the client side instead?

There's a parallel fix being proposed for Emacs's lsp-mode itself so that `{}` stops being ambiguous in `lsp-use-plists` mode. That fix would benefit any LSP server, not just ltex-ls-plus. **But:**

- It will take time to land and propagate to users' Emacs installs.
- Users running older versions of lsp-mode will still hit the bug until they upgrade.
- Sending `{}` was always slightly less informative than the equivalent explicit form anyway.

So the two fixes are complementary, not redundant. This one removes the ambiguity at the source; the lsp-mode one removes it at the destination.

## Risk

Minimal. The change only affects what ltex-ls-plus advertises during startup. Behavior during actual document checking, completion, code actions, etc. is untouched. The single test fixture that recorded the previous startup output has been updated to match the new wording.

## Changelog

No changelog entry — this is an internal protocol-shape adjustment with no user-visible behavior change for clients that were already working. Happy to add one if you'd prefer.
