### PR TITLE
Fix StringIndexOutOfBoundsException when checking source files with code comments

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -14,6 +14,9 @@
   </properties>
   <body>
     <release version="18.7.0" date="upcoming">
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Fix `StringIndexOutOfBoundsException` crash when checking comments inside source files with CRLF line endings or certain multi-line content. Two independent off-by-one bugs in `MarkdownAnnotatedTextBuilder` — a stray trailing `\n` in `addComment`'s reconstructed `clearCode`, and `removeComment` only detecting `\n` boundaries while ignoring `\r` — combined to push a substring index two characters past the end of the source comment, aborting the whole document's check. Applies to every programming language routed through `ProgramAnnotatedTextBuilder` (C, Java, Kotlin, Rust, Go, JS/TS, Lisp/Clojure, Lua, Haskell, …); Python comments go through a different path and were not affected. Plain Markdown, LaTeX, BibTeX, etc. were never affected.
+      </action>
       <action type="add" due-to="Andrea Alberti (@alberti42)">
         Accept `elisp` and `emacs-lisp` as `codeLanguageId`s alongside the existing `lisp`. Editors and LSP clients that natively label `.el` buffers with one of these names (modern `lsp-mode`, Neovim's built-in LSP, some VS Code Elisp extensions) now work out of the box without users having to remap to `lisp`. Behavior is identical to `lisp` — same `;` / `;;` line-comment regex, no block comments — so this is purely an ergonomic alias. The standalone CLI (`lsp-cli-plus`) also maps the `.el` file extension to `elisp` when checking files by path.
       </action>

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
@@ -151,7 +151,10 @@ class MarkdownAnnotatedTextBuilder(
 
     for ((index, markup) in markups.withIndex()) {
       fullCode += markup.first + code[index]
-      clearCode += code[index] + "\n"
+      clearCode += code[index]
+      if (index < markups.lastIndex) {
+        clearCode += "\n"
+      }
     }
 
     this.code = fullCode
@@ -224,9 +227,10 @@ class MarkdownAnnotatedTextBuilder(
         super.addMarkup(shadowMarkup.first, "\n")
 
         val offset = shadowMarkup.third - shadowMarkup.second
+        val firstChar = shadowMarkup.first.firstOrNull()
         // we add new line in markdown code
         shadowOffset +=
-          if (shadowMarkup.first.firstOrNull() == '\n') {
+          if (firstChar == '\n' || firstChar == '\r') {
             offset - 1
           } else {
             offset

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/program/ProgramAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/program/ProgramAnnotatedTextBuilderTest.kt
@@ -256,6 +256,47 @@ class ProgramAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("") {
   }
 
   @Test
+  fun testJavaCrlf() {
+    val lfInput =
+      """
+      Sentence 1 - no check // Sentence 2 - no check
+      //Sentence 3 - no check
+      // Sentence 4 -
+      // check
+
+      Sentence 5 - no check /* Sentence 6 - no check */
+      /* Sentence 7 - no check */ Sentence 8 - no check
+      /*Sentence 9 - no check */
+      /* Sentence 10 - check */
+      /** Sentence 11 -
+        * check */
+
+      """.trimIndent()
+    assertPlainText(
+      lfInput.replace("\n", "\r\n"),
+      "\n\n\nSentence 4 -\ncheck\n\n\nSentence 10 - check\n\n\nSentence 11 -\ncheck",
+      "java",
+    )
+  }
+
+  @Test
+  fun testLispCrlf() {
+    val lfInput =
+      """
+      Sentence 1 - no check ; Sentence 2 - no check
+      ;Sentence 3 - no check
+      ;; Sentence 4 -
+      ;; check
+
+      """.trimIndent()
+    assertPlainText(
+      lfInput.replace("\n", "\r\n"),
+      "\n\n\nSentence 4 -\ncheck",
+      "lisp",
+    )
+  }
+
+  @Test
   fun testRust() {
     assertPlainText(
       """

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -468,6 +468,34 @@ class DocumentCheckerTest {
   }
 
   @Test
+  fun testJavaCrlfCommentProducesDiagnostic() {
+    val code =
+      "public class Foo {\r\n" +
+        "  /** This is an test.\r\n" +
+        "    * Second line of comment.\r\n" +
+        "    */\r\n" +
+        "  void bar() {}\r\n" +
+        "}\r\n"
+    val document = createDocument("java", code)
+    val matches = checkDocument(document, Settings(_enabled = setOf("java"))).first
+    assertEquals(1, matches.size)
+    assertEquals("EN_A_VS_AN", matches[0].ruleId)
+    assertEquals("an", code.substring(matches[0].fromPos, matches[0].toPos))
+  }
+
+  @Test
+  fun testLispCrlfCommentProducesDiagnostic() {
+    val code =
+      ";; This is an test.\r\n" +
+        ";; Second line of comment.\r\n"
+    val document = createDocument("lisp", code)
+    val matches = checkDocument(document, Settings(_enabled = setOf("lisp"))).first
+    assertEquals(1, matches.size)
+    assertEquals("EN_A_VS_AN", matches[0].ruleId)
+    assertEquals("an", code.substring(matches[0].fromPos, matches[0].toPos))
+  }
+
+  @Test
   fun testCodeActionGenerator() {
     val document: LtexTextDocumentItem =
       createDocument(


### PR DESCRIPTION
## What this PR does

Fixes a server crash that can occur when LTeX+ is asked to spell- and
grammar-check **comments inside source code files** (any supported
programming language — C, Java, Kotlin, Rust, Go, JavaScript/TypeScript,
Lisp/Clojure, Lua, Haskell, and so on). On affected files, the server
throws:

```
java.lang.StringIndexOutOfBoundsException: Range [N, N+2) out of bounds for length N
```

…and the whole check fails — the user sees no diagnostics for that file,
and the editor's LSP log fills with the stack trace.

After this PR, those files check normally.

## Symptoms a user would see

- Opening certain source files (often, but not exclusively, ones with
  CRLF / Windows line endings) produces no LTeX+ diagnostics at all.
- The editor's LSP client log shows a `StringIndexOutOfBoundsException`
  originating in `MarkdownAnnotatedTextBuilder`.
- Other file types (plain Markdown, LaTeX, plain text) are unaffected.
- Restarting the server doesn't help — the same file crashes again.

## What was actually wrong

LTeX+ checks code-comment prose by re-feeding the comment text into its
internal Markdown parser and then mapping the parser's positions back to
positions in the original source file. Two small bookkeeping mistakes in
that mapping layer combined to push one of the resulting positions two
characters past the end of the string it was used to index into,
producing the crash.

In short: an off-by-one in how the comment text was assembled, plus an
off-by-one in how Windows-style line endings (`\r\n`) were counted. Each
on its own was usually invisible; together they consistently overshot by
exactly two characters and crashed.

Both fixes are tiny (≈5 lines in one file) and don't change any
externally visible behavior other than "doesn't crash anymore."

## Who this affects

Anyone using LTeX+ to check **comments inside source code**, in any
language except Python. (Python comments go through a different code
path that doesn't have this bug.)

Plain documents — Markdown, LaTeX, BibTeX, plain text, etc. — were never
affected.

Files with CRLF line endings are disproportionately likely to have
triggered the crash, but it can occur on LF-only files too if the
comment content happens to line up the wrong way with the parser's
internal offsets.

## How it was found

A user editing Emacs Lisp (`.el`) files through an LSP client that
forces `codeLanguageId="lisp"` hit the crash reliably on real-world
files. Reducing the case confirmed the bug is not Lisp-specific — it's
in the shared comment-handling layer, so the fix benefits every
non-Python language equally.

## Risk

Low. The change is local to one file (`MarkdownAnnotatedTextBuilder.kt`),
the new behavior strictly fixes an over-count / mis-count in two places,
and no test that previously passed should start failing. There are no
API changes, no configuration changes, and no behavior change on the
happy path.

## Test plan

Four regression tests are added across two layers, each verified
empirically to fail on the pre-fix code and pass with the fix.

**Parser layer** — `ProgramAnnotatedTextBuilderTest.kt`:

- `testJavaCrlf` — Java source with `//` and `/* … */` comments, run
  with CRLF line endings. On pre-fix code: crashes inside
  `MarkdownAnnotatedTextBuilder.addText` with
  `StringIndexOutOfBoundsException` (the bug-report failure mode). On
  fixed code: extracted plain text matches the LF-equivalent output.
- `testLispCrlf` — same shape with `;` / `;;` line comments (the
  user-reported scenario, encountered via Emacs Lisp through an LSP
  client that forces `codeLanguageId="lisp"`).

**End-to-end layer** — `DocumentCheckerTest.kt`:

- `testJavaCrlfCommentProducesDiagnostic` — multi-line Javadoc-style
  CRLF comment containing `"an test"`. Asserts that the full
  `DocumentChecker` pipeline emits exactly one `EN_A_VS_AN`
  diagnostic and that its `fromPos`..`toPos` maps back to `"an"` in
  the original source. On pre-fix code this produces **two** matches
  (silent shadow-offset corruption fragments the prose) — a failure
  mode the parser-layer test alone would miss.
- `testLispCrlfCommentProducesDiagnostic` — same end-to-end check
  with multi-line `;;` Lisp comments. On pre-fix code: crashes with
  `StringIndexOutOfBoundsException`.

The full `mvn test` suite (237 tests, 2 pre-existing skipped) is
green — so Python (`testPython`), Markdown
(`MarkdownAnnotatedTextBuilderTest`), and the LaTeX/BibTeX paths are
covered automatically and unaffected. No manual end-to-end check is
needed for this fix; the four new tests cover both the crash and the
silent-corruption modes through the real `DocumentChecker` pipeline.
