### PR TITLE
Stamp the build version from Git and expose it via LSP `serverInfo`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@v6"
+        with:
+          # Full history + tags so git-commit-id can stamp the version during the build.
+          fetch-depth: 0
 
       - name: "Set up Java"
         uses: "actions/setup-java@v5"
@@ -161,7 +164,8 @@ jobs:
           fi
 
       - name: "Build LTeX+ LS"
-        run: "mvn -B -e package"
+        # -Prelease stamps the clean ${project.version} (the release tag) into the manifest.
+        run: "mvn -B -e -Prelease package"
         env:
           LANGUAGETOOL_USERNAME: ${{ secrets.LANGUAGETOOL_USERNAME }}
           LANGUAGETOOL_API_KEY: ${{ secrets.LANGUAGETOOL_API_KEY }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: "actions/checkout@v6"
+        with:
+          # Full history + tags so git-commit-id can count commits since the last release tag.
+          fetch-depth: 0
 
       - name: "Set up Java"
         uses: "actions/setup-java@v5"
@@ -52,8 +55,21 @@ jobs:
       - name: "Install Python Dependencies"
         run: "python -u -m pip install --upgrade pip && pip install semver"
 
+      # Semver nightly version, identical to the JAR's stamped serverInfo.version:
+      #   <release-label>.<commits since last X.Y.Z release tag>+<commit date>.g<hash>
+      #   e.g. 18.7.0-alpha.93+2026-05-20.gfcf2fb76
+      # The commit count (prerelease) is the comparison key; everything after '+' is build
+      # metadata (commit date + hash), ignored in semver precedence. Must match the
+      # git-commit-id-maven-plugin stamp in pom.xml (same count, UTC commit date, 8-char hash).
       - name: "Set LTEX_LS_VERSION"
-        run: "echo \"LTEX_LS_VERSION=$(python -u -c \"import datetime; import re; print('{}.nightly.{}'.format(re.search(r'<version>(.*?)(?:\\\\.develop)?</version>', open('pom.xml', 'r').read()).group(1), datetime.datetime.today().strftime('%Y-%m-%d')), end='')\")\" >> $GITHUB_ENV"
+        run: |
+          LABEL="$(python -u -c "import re; print(re.search(r'<version>(.*?)(?:\.develop)?</version>', open('pom.xml').read()).group(1), end='')")"
+          COUNT="$(git describe --tags --long --match '[0-9]*.[0-9]*.[0-9]*' | sed -E 's/.*-([0-9]+)-g[0-9a-f]+$/\1/')"
+          DATE="$(TZ=UTC0 git log -1 --date=format-local:'%Y-%m-%d' --format='%cd')"
+          HASH="$(git rev-parse --short=8 HEAD)"
+          echo "LTEX_LS_VERSION=${LABEL}.${COUNT}+${DATE}.g${HASH}" >> "$GITHUB_ENV"
+          # Clean base for the manifest stamp, since "Bump Version" rewrites <version> below.
+          echo "LTEX_RELEASE_LABEL=${LABEL}" >> "$GITHUB_ENV"
 
       - name: "Check LTEX_LS_VERSION"
         run: "if [[ -z \"$LTEX_LS_VERSION\" ]]; then echo 'Error: LTEX_LS_VERSION not set!'; (exit 1); fi; echo \"LTEX_LS_VERSION set to '$LTEX_LS_VERSION'\""
@@ -62,7 +78,9 @@ jobs:
         run: "python -u -c \"import re\nfile = open('pom.xml', 'r+'); pom = file.read(); file.seek(0); file.truncate(); file.write(re.sub(r'<version>(.*?)</version>', '<version>${{ env.LTEX_LS_VERSION }}</version>', pom, 1))\""
 
       - name: "Build LTeX+ LS"
-        run: "mvn -B -e package"
+        # <version> was rewritten to the full build string above, so pass the clean base
+        # explicitly; otherwise the stamp would double-append the count/date/hash.
+        run: "mvn -B -e -Dltex.release.label=\"$LTEX_RELEASE_LABEL\" package"
         env:
           LANGUAGETOOL_USERNAME: ${{ secrets.LANGUAGETOOL_USERNAME }}
           LANGUAGETOOL_API_KEY: ${{ secrets.LANGUAGETOOL_API_KEY }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ WORKDIR /ltex-ls-plus-src
 
 # Generate completion lists
 RUN python -u tools/createCompletionLists.py
-# Build
-RUN mvn --quiet --errors package -DskipTests
+# Build (-Prelease: source tarball has no .git, so report the clean ${project.version})
+RUN mvn --quiet --errors -Prelease package -DskipTests
 # Package binary
 RUN tar -xzf target/ltex-ls-plus-${LTEX_VERSION}.tar.gz \
     && mv -v ltex-ls-plus-${LTEX_VERSION} /ltex-ls-plus

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,15 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.jupiter.version>6.0.3</junit.jupiter.version>
     <languagetool.version>6.8</languagetool.version>
+    <!-- Base version for the stamped Implementation-Version, e.g.
+         ${ltex.release.label}.<commitsSinceLastReleaseTag>+<commitDate>.g<hash>
+         (see git-commit-id-maven-plugin and the maven-jar-plugin manifestEntries below);
+         tagged releases use the clean ${project.version} via the "release" profile.
+         Defaults to ${project.version} so it needs no manual upkeep: dev/release builds
+         pick up the artifact version automatically. The nightly CI job rewrites <version>
+         to the full build string, so it passes -Dltex.release.label=<clean base> to keep
+         this from double-stamping. -->
+    <ltex.release.label>${project.version}</ltex.release.label>
   </properties>
   <dependencies>
     <dependency>
@@ -266,6 +275,41 @@
         </executions>
       </plugin>
       <plugin>
+        <!-- Exposes Git metadata (git.closest.tag.commit.count, git.commit.id.abbrev, ...) as
+             Maven properties so the JAR manifest can self-stamp the version at build time.
+             Anchored to release tags via gitDescribe.match so the moving "nightly" tag is
+             ignored and the count reflects commits since the last X.Y.Z release. -->
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>9.0.1</version>
+        <executions>
+          <execution>
+            <id>get-the-git-infos</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <offline>true</offline>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+          <generateGitPropertiesFile>false</generateGitPropertiesFile>
+          <!-- Use the git binary: the bundled JGit backend does not populate
+               git.closest.tag.commit.count when gitDescribe.match is a glob. -->
+          <useNativeGit>true</useNativeGit>
+          <abbrevLength>8</abbrevLength>
+          <!-- git.commit.time as a plain UTC date for the build-metadata field. -->
+          <dateFormat>yyyy-MM-dd</dateFormat>
+          <dateFormatTimeZone>UTC</dateFormatTimeZone>
+          <gitDescribe>
+            <tags>true</tags>
+            <match>[0-9]*.[0-9]*.[0-9]*</match>
+          </gitDescribe>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.5.0</version>
@@ -275,6 +319,16 @@
               <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
               <mainClass>${main.class}</mainClass>
             </manifest>
+            <manifestEntries>
+              <!-- Self-stamped nightly/dev version, e.g. 18.7.0-alpha.93+2026-05-20.gfcf2fb76:
+                   <label>.<commits since last release tag> is the comparison key, and the
+                   build metadata after '+' (commit date and hash) is provenance ignored in
+                   semver precedence. Overridden to the clean ${project.version} by the
+                   "release" profile. Read at runtime via Package.implementationVersion and
+                   surfaced through the version CLI option and the LSP initialize
+                   serverInfo.version. -->
+              <Implementation-Version>${ltex.release.label}.${git.closest.tag.commit.count}+${git.commit.time}.g${git.commit.id.abbrev}</Implementation-Version>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>
@@ -441,4 +495,40 @@ if %ERROR_CODE% EQU 0 set ERROR_CODE=1</replacevalue>
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <!-- Activated for tagged releases and source-tarball builds (CI deploy job, Dockerfile)
+         with `mvn -Prelease ...`. Reports the clean ${project.version} (the release tag)
+         instead of the nightly/dev <label>.<count>+g<hash> string, and needs no Git checkout. -->
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <!-- Release/Docker builds run without a Git checkout (or git binary), so skip the
+                 stamping plugin entirely; the version comes from ${project.version} below. -->
+            <groupId>io.github.git-commit-id</groupId>
+            <artifactId>git-commit-id-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <configuration>
+              <archive>
+                <manifest>
+                  <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                  <mainClass>${main.class}</mainClass>
+                </manifest>
+                <manifestEntries>
+                  <Implementation-Version>${project.version}</Implementation-Version>
+                </manifestEntries>
+              </archive>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -22,6 +22,7 @@ import org.eclipse.lsp4j.ExecuteCommandOptions
 import org.eclipse.lsp4j.InitializeParams
 import org.eclipse.lsp4j.InitializeResult
 import org.eclipse.lsp4j.ServerCapabilities
+import org.eclipse.lsp4j.ServerInfo
 import org.eclipse.lsp4j.TextDocumentSyncKind
 import org.eclipse.lsp4j.WindowClientCapabilities
 import org.eclipse.lsp4j.WorkspaceFoldersOptions
@@ -149,7 +150,12 @@ class LtexLanguageServer :
     workspaceFoldersOptions.setChangeNotifications(Either.forRight(true))
     serverCapabilities.workspace = WorkspaceServerCapabilities(workspaceFoldersOptions)
 
-    return CompletableFuture.completedFuture(InitializeResult(serverCapabilities))
+    // Advertise the server's identity and version to the client via serverInfo so it can,
+    // e.g., gate features on a minimum version. The version is the JAR manifest's
+    // Implementation-Version, stamped at build time as <label>.<commitsSinceReleaseTag>+g<hash>
+    // for nightlies (see pom.xml / git-commit-id-maven-plugin) and the plain release for releases.
+    val serverInfo = ServerInfo("ltex-ls-plus", ltexLsPackage?.implementationVersion)
+    return CompletableFuture.completedFuture(InitializeResult(serverCapabilities, serverInfo))
   }
 
   override fun shutdown(): CompletableFuture<Any> {

--- a/src/test/resources/LtexLanguageServerTestLog.txt
+++ b/src/test/resources/LtexLanguageServerTestLog.txt
@@ -291,6 +291,9 @@ Result: {
                 "changeNotifications": true
             }
         }
+    },
+    "serverInfo": {
+        "name": "ltex-ls-plus"
     }
 }
 


### PR DESCRIPTION
## Summary

The server never told clients which version it was: the `initialize` result
carried no `serverInfo`, and nightly builds were stamped with a coarse,
date-only string. This PR:

1. Stamps a precise, **SemVer 2.0.0**–compliant version into the JAR at build
   time, and
2. Reports it to clients through the LSP `initialize` response's
   `serverInfo.version`, so a client can read the server version and, e.g.,
   gate features on a minimum version.

One identical string is now used for `serverInfo.version`, the `--version` CLI
output, and the nightly artifact filename.

## Version format

```
18.7.0-alpha.93+2026-05-20.gfcf2fb76
│            │  └──────────┬───────┘
│            │             └─ build metadata: commit date + short hash
│            └─ prerelease counter: commits since the last X.Y.Z release tag
└─ release being worked toward
```

This is by-the-book SemVer 2.0.0:

- The **prerelease counter** (`.93`) is the comparison key. SemVer orders
  prerelease identifiers, so `18.6.1 < 18.7.0-alpha.5 < 18.7.0-alpha.93 <
  18.7.0 < 18.8.0-alpha.3` all compare correctly with any SemVer comparator
  (e.g., in Emacs using `version<`).
- Everything after **`+` is build metadata** (commit date + hash) — provenance
  for "where did this build come from", and **ignored in precedence** per spec
  §10, exactly as intended for non-ordering data.

Tagged releases report the clean `${project.version}` (e.g. `18.7.0`), with no
build metadata.

## How it works

- **`git-commit-id-maven-plugin`** exposes the commit count (anchored to
  `X.Y.Z` release tags via `gitDescribe.match`, so the moving `nightly` tag is
  ignored), the commit date (formatted as a UTC `yyyy-MM-dd`), and the short
  hash as Maven properties.
- **`maven-jar-plugin`** stamps `Implementation-Version` from
  `${ltex.release.label}.${git.closest.tag.commit.count}+${git.commit.time}.g${git.commit.id.abbrev}`.
- **`VersionProvider`** already reads `Implementation-Version` for `--version`;
  **`LtexLanguageServer.initialize`** now also returns it via
  `serverInfo.version`.
- A **`release` profile** (`mvn -Prelease`) reports the clean
  `${project.version}` and skips the Git plugin, for tagged releases and
  source-tarball builds that have no `.git`.

## CI / build changes

- **`nightly.yml`**: computes the same canonical string for the artifact name
  (commit count, UTC commit date, 8-char hash) instead of the old
  `…nightly.<date>` form; fetches full history + tags.
- **`ci.yml`**: the verify job fetches full history so stamping works; the
  deploy (release) job builds with `-Prelease`.
- **`Dockerfile`**: builds with `-Prelease` (the image is built from a source
  tarball with no Git history).

## Testing

- `mvn package` and `--version` both emit the stamped string
  (`18.7.0-alpha.<n>+<date>.g<hash>`); `-Prelease` emits the clean version.
- The nightly CI filename formula produces a string **byte-identical** to the
  JAR's stamped `Implementation-Version`, and Maven accepts the `+` in
  `<version>` and names the asset accordingly (reproduce below).
- `VersionProviderTest` and both launcher integration tests
  (`LtexLanguageServerLauncherStandardStreamTest`,
  `…TcpSocketTest`) pass; the `initialize`-response fixture was updated
  for the new `serverInfo` field.

### Reproduce

The stamp reflects the commit being built, so build with `mvn clean` — an
incremental build can leave a stale version in the manifest (Maven sees no
source change and skips re-jarring). CI is unaffected: every run is a fresh
checkout + clean build.

1. Manifest string == the CI nightly filename formula:

   ```sh
   mvn -q clean -DskipTests package
   unzip -p target/ltexls-plus-*.jar META-INF/MANIFEST.MF | grep -i Implementation-Version

   # the exact formula nightly.yml uses for the artifact name:
   LABEL=18.7.0-alpha
   COUNT=$(git describe --tags --long --match '[0-9]*.[0-9]*.[0-9]*' | sed -E 's/.*-([0-9]+)-g[0-9a-f]+$/\1/')
   DATE=$(TZ=UTC0 git log -1 --date=format-local:'%Y-%m-%d' --format='%cd')
   HASH=$(git rev-parse --short=8 HEAD)
   echo "${LABEL}.${COUNT}+${DATE}.g${HASH}"
   ```

   The `Implementation-Version:` value and the `echo` output should be identical.

2. Maven accepts `+` in `<version>` and names the asset:

   ```sh
   cp pom.xml /tmp/pom.bak
   python3 -c "import re; p=open('pom.xml').read(); open('pom.xml','w').write(re.sub(r'<version>.*?</version>', '<version>18.7.0-alpha.99+2026-01-01.gdeadbe0</version>', p, 1))"
   mvn -q clean -DskipTests package
   ls target/ltex-ls-plus-18.7.0-alpha.99+2026-01-01.gdeadbe0.tar.gz   # should exist
   cp /tmp/pom.bak pom.xml && rm /tmp/pom.bak                          # restore
   ```

## Notes

- `serverInfo` per the LSP spec is just `{ name, version }` — there is no
  dedicated build-number field, so the build number lives inside the SemVer
  `version` string (the standard approach).
- The Docker image, built from a tarball without `.git`, reports the clean
  release version (no build metadata). All other distributions (dev builds,
  nightlies, release tarballs) carry the full string.
- Bumping the target release stays a **single edit** — `<version>` in
  `pom.xml`. `ltex.release.label` defaults to `${project.version}`, so the
  stamp's base follows automatically (no second field to keep in sync). Only the
  nightly job overrides it, via `-Dltex.release.label`, since it rewrites
  `<version>` to the full build string before building.
