### PR TITLE
Improve Emacs Lisp checking: docstrings and inline comments

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -15,6 +15,9 @@
   <body>
     <release version="18.7.0" date="upcoming">
       <action type="add" due-to="Andrea Alberti (@alberti42)">
+        Spell- and grammar-check Emacs Lisp docstrings (in `defun`, `defcustom`, `defvar`, `define-minor-mode` and similar definition forms), not just comments. Docstring markup directives such as `\\[command]` and `` `symbol' `` are ignored so they do not cause false positives. Applies to `elisp` / `emacs-lisp`.
+      </action>
+      <action type="add" due-to="Andrea Alberti (@alberti42)">
         Check trailing/inline Emacs Lisp comments (`(some code) ; comment`), not only standalone comment lines. Applies to `elisp` / `emacs-lisp`.
       </action>
       <action type="update" due-to="Andrea Alberti (@alberti42)">

--- a/changelog.xml
+++ b/changelog.xml
@@ -14,6 +14,9 @@
   </properties>
   <body>
     <release version="18.7.0" date="upcoming">
+      <action type="add" due-to="Andrea Alberti (@alberti42)">
+        Check trailing/inline Emacs Lisp comments (`(some code) ; comment`), not only standalone comment lines. Applies to `elisp` / `emacs-lisp`.
+      </action>
       <action type="update" due-to="Andrea Alberti (@alberti42)">
         Disable LanguageTool's internal per-sentence result cache by default: the `ltex.sentenceCacheSize` default changes from `2000` to `0`. The new per-paragraph fragment cache supersedes it for the edit loop and, unlike the in-process cache, also covers the remote HTTP backend — so keeping the sentence cache around only added CPU/memory overhead and another point of failure. A value of `0` is the natural floor of the capacity setting (`2000` → … → `1` sentence → `0` = nothing cached), not a separate on/off flag; internally any non-positive value maps to a `null` `ResultCache`, so LanguageTool takes its genuine no-cache code path rather than allocating a zero-capacity cache that would still run its eviction machinery on every lookup. Set `ltex.sentenceCacheSize` to a positive value to re-enable it.
       </action>

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
@@ -16,6 +16,7 @@ import org.bsplines.ltexls.parsing.markdown.MarkdownAnnotatedTextBuilder
 import org.bsplines.ltexls.parsing.nop.NopAnnotatedTextBuilder
 import org.bsplines.ltexls.parsing.org.OrgAnnotatedTextBuilder
 import org.bsplines.ltexls.parsing.plaintext.PlaintextAnnotatedTextBuilder
+import org.bsplines.ltexls.parsing.program.ElispAnnotatedTextBuilder
 import org.bsplines.ltexls.parsing.program.ProgramAnnotatedTextBuilder
 import org.bsplines.ltexls.parsing.program.ProgramCommentRegexs
 import org.bsplines.ltexls.parsing.restructuredtext.RestructuredtextAnnotatedTextBuilder
@@ -142,6 +143,12 @@ abstract class CodeAnnotatedTextBuilder(
         "tex",
         -> {
           LatexAnnotatedTextBuilder(codeLanguageId)
+        }
+
+        "elisp",
+        "emacs-lisp",
+        -> {
+          ElispAnnotatedTextBuilder(codeLanguageId)
         }
 
         "markdown",

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
@@ -45,6 +45,17 @@ class MarkdownAnnotatedTextBuilder(
   // pure Markdown documents leave it false so a literal `` `foo' `` keeps
   // its original meaning.
   private val enableEmacsQuoteRewriting: Boolean = false,
+  // When true, `addComment` additionally neutralises Emacs *docstring* markup
+  // directives so they do not surface as grammar/spelling false positives:
+  // key substitutions (`\\[command]`, `\\{keymap}`, `\\<keymap>`), the
+  // self-quoting escape `\\=` (including the `` `symbol\\=' `` form), and a
+  // leading `*` user-variable marker handled by the caller. Every replacement
+  // is length-preserving, so the shadow-markup offset arithmetic that maps
+  // matches back to the original source stays valid. Opt-in: only
+  // ElispAnnotatedTextBuilder sets this true (for elisp / emacs-lisp); it is
+  // independent of `enableEmacsQuoteRewriting` and both may be enabled
+  // together.
+  private val enableElispDocstringDirectives: Boolean = false,
 ) : CodeAnnotatedTextBuilder(codeLanguageId) {
   private val parser: Parser = Parser.builder(PARSER_OPTIONS).build()
   private var code = ""
@@ -193,11 +204,49 @@ class MarkdownAnnotatedTextBuilder(
   // or whitespace, matching the Emacs convention of using this form only
   // around bare symbol names (`lsp-mode'`, `pp-buffer'`, …) and not around
   // longer phrases.
-  private fun rewriteEmacsQuotesIfEnabled(segment: String): String =
+  private fun rewriteEmacsQuotesIfEnabled(segment: String): String {
+    var result: String = segment
+
     if (this.enableEmacsQuoteRewriting) {
-      segment.replace(EMACS_QUOTED_IDENTIFIER_REGEX, "`$1`")
-    } else {
-      segment
+      result = result.replace(EMACS_QUOTED_IDENTIFIER_REGEX, "`$1`")
+    }
+
+    if (this.enableElispDocstringDirectives) {
+      result = neutralizeElispDocstringDirectives(result)
+    }
+
+    return result
+  }
+
+  // Length-preserving neutralisation of Emacs docstring markup directives. Each
+  // directive is rewritten to the same number of characters so the shadow-
+  // markup mapping (which assumes `clearCode` and the original source share a
+  // length) keeps pointing at the right source offsets. Key substitutions and
+  // `` `symbol\\=' `` become flexmark inline code (collapsed to a Dummy token
+  // downstream); a bare `\\=` becomes whitespace.
+  private fun neutralizeElispDocstringDirectives(segment: String): String {
+    var result: String = segment
+    result =
+      result.replace(ELISP_KEY_SUBSTITUTION_REGEX) {
+        lengthPreservingInlineCode(it.value.length)
+      }
+    result =
+      result.replace(ELISP_QUOTED_IDENTIFIER_WITH_ESCAPE_REGEX) {
+        lengthPreservingInlineCode(it.value.length)
+      }
+    result =
+      result.replace(ELISP_QUOTE_ESCAPE_REGEX) {
+        " ".repeat(it.value.length)
+      }
+    return result
+  }
+
+  private fun lengthPreservingInlineCode(length: Int): String =
+    when {
+      length <= 0 -> ""
+      length == 1 -> "`"
+      length == 2 -> "``"
+      else -> "`" + "x".repeat(length - 2) + "`"
     }
 
   private fun visit(node: Node) {
@@ -315,6 +364,19 @@ class MarkdownAnnotatedTextBuilder(
     // straight apostrophe. The body group is captured so the rewrite can
     // wrap it in matched backticks for flexmark.
     private val EMACS_QUOTED_IDENTIFIER_REGEX: Regex = Regex("`([^`'\\s]+)'")
+
+    // Emacs docstring key substitutions `\\[command]`, `\\{keymap}` and
+    // `\\<keymap>`. In source the backslash is doubled (the elisp string holds
+    // a single backslash), so the pattern matches two literal backslashes.
+    private val ELISP_KEY_SUBSTITUTION_REGEX: Regex = Regex("""\\\\[\[{<][^\]}>\n]*[\]}>]""")
+
+    // The `` `symbol\\=' `` form: a quoted identifier whose closing apostrophe
+    // is preceded by the self-quoting `\\=` escape. Handled before the bare
+    // `\\=` rule so the whole construct collapses to a single inline-code span.
+    private val ELISP_QUOTED_IDENTIFIER_WITH_ESCAPE_REGEX: Regex = Regex("""`[^`'\s]+\\\\='""")
+
+    // A bare self-quoting escape `\\=` (two source backslashes plus `=`).
+    private val ELISP_QUOTE_ESCAPE_REGEX: Regex = Regex("""\\\\=""")
 
     private val PARSER_OPTIONS: DataHolder =
       MutableDataSet()

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilder.kt
@@ -41,29 +41,12 @@ class ElispAnnotatedTextBuilder(
       enableElispDocstringDirectives = true,
     )
 
-  private val commentRegexs = ProgramCommentRegexs.fromCodeLanguageId(codeLanguageId)
-  private val commentBlockRegex: Regex = commentRegexs.commentBlockRegex
-  private val lineCommentPatternString: String? = commentRegexs.lineCommentRegexString
-
   override fun addCode(code: String): CodeAnnotatedTextBuilder {
     val reader = ElispReader(code)
     reader.read()
 
     val segments: MutableList<Segment> = ArrayList()
-
-    for (matchResult: MatchResult in commentBlockRegex.findAll(code)) {
-      val isLineComment: Boolean = (matchResult.groups["lineComment"] != null)
-      val commentGroupName: String = (if (isLineComment) "lineComment" else "blockComment")
-      val commentGroup: MatchGroup = matchResult.groups[commentGroupName] ?: continue
-      val start: Int = commentGroup.range.first
-      val endExclusive: Int = commentGroup.range.last + 1
-
-      // A `;` inside a string literal is not a comment. The reader knows every
-      // string span, so keep only comment matches that overlap no string.
-      if (reader.stringSpans.none { rangesOverlap(start, endExclusive, it) }) {
-        segments += CommentSegment(start, endExclusive, isLineComment)
-      }
-    }
+    segments += buildCommentSegments(code, reader.commentSpans)
 
     for (docstring: ElispReader.DocstringSpan in reader.docstringSpans) {
       segments += DocstringSegment(docstring)
@@ -97,6 +80,55 @@ class ElispAnnotatedTextBuilder(
 
     if (curPos < code.length) annotatedTextBuilder.addMarkup(code.substring(curPos))
     return this
+  }
+
+  // Turns the reader's raw comment spans into checked segments. Consecutive
+  // standalone (line-leading) comment lines are coalesced into a single block so
+  // a sentence wrapping across `;;` lines is checked as one unit; trailing/inline
+  // comments (code before the `;`) become individual single-line segments.
+  // Non-checkable comments (`;text`, `;;;sections`, …) are dropped here and so
+  // remain inert markup.
+  private fun buildCommentSegments(
+    code: String,
+    comments: List<ElispReader.CommentSpan>,
+  ): List<CommentSegment> {
+    val result: MutableList<CommentSegment> = ArrayList()
+    var blockStart = -1
+    var blockEnd = -1
+
+    fun flushBlock() {
+      if (blockStart >= 0) {
+        result += CommentSegment(blockStart, blockEnd, isLineComment = true)
+        blockStart = -1
+      }
+    }
+
+    for (comment: ElispReader.CommentSpan in comments) {
+      when {
+        !comment.checkable -> {
+          flushBlock()
+        }
+
+        !comment.lineLeading -> {
+          flushBlock()
+          result += CommentSegment(comment.start, comment.end, isLineComment = true)
+        }
+
+        (blockStart >= 0) &&
+          BETWEEN_COMMENT_LINES_REGEX.matches(code.substring(blockEnd, comment.start)) -> {
+          blockEnd = comment.end
+        }
+
+        else -> {
+          flushBlock()
+          blockStart = comment.start
+          blockEnd = comment.end
+        }
+      }
+    }
+
+    flushBlock()
+    return result
   }
 
   private fun addDocstring(
@@ -133,13 +165,7 @@ class ElispAnnotatedTextBuilder(
     val lineContentsRegex =
       Regex(
         "[ \t]*" +
-          (
-            if (isLineComment && (lineCommentPatternString != null)) {
-              lineCommentPatternString
-            } else {
-              ""
-            }
-          ) +
+          (if (isLineComment) LINE_COMMENT_MARKER else "") +
           "(?:" + Regex.escape(commonFirstCharacter) + ")?[ \t]*(.*?)(?:\r?\n|$)",
       )
     var curPos = 0
@@ -213,28 +239,32 @@ class ElispAnnotatedTextBuilder(
     private val LINE_SEPARATOR_REGEX = Regex("\r?\n")
     private val FIRST_CHARACTER_REGEX = Regex("^[ \t]*(?:([#$%*+\\-/])|(.))")
 
-    private fun rangesOverlap(
-      start: Int,
-      endExclusive: Int,
-      span: IntRange,
-    ): Boolean = (start <= span.last) && (span.first < endExclusive)
+    // Emacs Lisp comment markers are any run of semicolons (`;`, `;;`, `;;;`
+    // section headings, `;;;;` file headers, …); all leading semicolons are
+    // stripped before the prose is checked.
+    private const val LINE_COMMENT_MARKER = ";+"
+
+    // Matches the gap between two standalone comment lines that should coalesce:
+    // exactly one line terminator followed by the next line's indentation.
+    private val BETWEEN_COMMENT_LINES_REGEX = Regex("\r?\n[ \t]*")
   }
 }
 
 /**
  * Minimal s-expression reader that records, for an Emacs Lisp source string,
- * every string literal span and the subset of those that are docstrings.
+ * every `;` comment span and the string literals that are docstrings.
  *
  * It is intentionally a *scanner*, not a full reader: it tracks parenthesis
  * nesting, string/char-literal/comment lexical state, and the head symbol plus
  * element index of each list, which is everything needed to apply the
  * [DOCSTRING_FORMS] position table. It does not build an AST or evaluate
- * anything.
+ * anything. Because comments are recognised lexically, a `;` inside a string or
+ * character literal is never reported as a comment.
  */
 internal class ElispReader(
   private val code: String,
 ) {
-  val stringSpans: MutableList<IntRange> = ArrayList()
+  val commentSpans: MutableList<CommentSpan> = ArrayList()
   val docstringSpans: MutableList<DocstringSpan> = ArrayList()
 
   /** A docstring string literal, with delimiter-inclusive and content ranges. */
@@ -243,6 +273,23 @@ internal class ElispReader(
     val contentStart: Int,
     val contentEnd: Int,
     val fullEnd: Int,
+  )
+
+  /**
+   * A `;`-introduced comment. [start] is the first `;`; [end] is the line
+   * terminator (or end of input), excluding any `\r`/`\n`. [checkable] is true
+   * when the comment's run of leading semicolons is followed by whitespace or
+   * end-of-line (the convention for prose comments — `;`, `;;`, `;;;` headings
+   * and `;;;;` file headers all qualify; `;text` with no space does not).
+   * [lineLeading] is true when only
+   * whitespace precedes the comment on its line (a standalone comment, as
+   * opposed to a trailing/inline comment after code).
+   */
+  class CommentSpan(
+    val start: Int,
+    val end: Int,
+    val checkable: Boolean,
+    val lineLeading: Boolean,
   )
 
   private class Form {
@@ -273,7 +320,8 @@ internal class ElispReader(
       when {
         c == ';' -> {
           var j: Int = i + 1
-          while ((j < n) && (code[j] != '\n')) j++
+          while ((j < n) && (code[j] != '\n') && (code[j] != '\r')) j++
+          recordComment(i, j)
           i = j
         }
 
@@ -366,8 +414,6 @@ internal class ElispReader(
     val contentEnd: Int = if (j < n) j else n
     val fullEnd: Int = if (j < n) j + 1 else n
 
-    stringSpans += fullStart until fullEnd
-
     val top: Form? = stack.lastOrNull()
     if (top != null) {
       val elementIndex: Int = top.childCount
@@ -385,6 +431,38 @@ internal class ElispReader(
     val index: Int = top.childCount
     top.childCount++
     return index
+  }
+
+  /**
+   * Records the comment spanning [start] (the first `;`) up to [end] (the line
+   * terminator or end of input), classifying it as checkable and line-leading.
+   * Reached only from the reader's lexical comment branch, so a `;` inside a
+   * string or character literal never gets here.
+   */
+  private fun recordComment(
+    start: Int,
+    end: Int,
+  ) {
+    var semicolons = 0
+    while ((start + semicolons < end) && (code[start + semicolons] == ';')) semicolons++
+
+    // Any run of semicolons is a valid comment marker (`;;;` headings, `;;;;`
+    // file headers, …); it is prose only when followed by whitespace or EOL.
+    val afterMarker: Int = start + semicolons
+    val checkable: Boolean =
+      (afterMarker >= end) || (code[afterMarker] == ' ') || (code[afterMarker] == '\t')
+
+    var lineLeading = true
+    var b: Int = start - 1
+    while ((b >= 0) && (code[b] != '\n')) {
+      if ((code[b] != ' ') && (code[b] != '\t') && (code[b] != '\r')) {
+        lineLeading = false
+        break
+      }
+      b--
+    }
+
+    commentSpans += CommentSpan(start, end, checkable, lineLeading)
   }
 
   private fun detectDocstring(form: Form) {

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilder.kt
@@ -1,0 +1,455 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.parsing.program
+
+import org.bsplines.ltexls.parsing.CodeAnnotatedTextBuilder
+import org.bsplines.ltexls.parsing.markdown.MarkdownAnnotatedTextBuilder
+import org.languagetool.markup.AnnotatedText
+
+/**
+ * Annotated-text builder for Emacs Lisp.
+ *
+ * Beyond the `;` / `;;` line comments that [ProgramAnnotatedTextBuilder] already
+ * extracts for the Lisp family, this builder also spell-/grammar-checks
+ * **docstrings** — the string literal that appears at a fixed position inside a
+ * definition form such as `defun`, `defcustom`, `defvar` or
+ * `define-minor-mode`. Locating those strings requires a structural scan of the
+ * source (a minimal s-expression reader, [ElispReader]) rather than a regex,
+ * because the docstring position is form-specific and string boundaries depend
+ * on escape and character-literal syntax.
+ *
+ * Comments keep the exact behaviour of [ProgramAnnotatedTextBuilder] by reusing
+ * the same [ProgramCommentRegexs] line-comment regex; comment matches that fall
+ * inside a string literal are discarded so a `;` inside a docstring is never
+ * mistaken for a comment. The contents of comments and docstrings are
+ * interpreted as Markdown, with Emacs quote rewriting and docstring-directive
+ * neutralisation enabled (see [MarkdownAnnotatedTextBuilder]).
+ */
+class ElispAnnotatedTextBuilder(
+  codeLanguageId: String,
+) : CodeAnnotatedTextBuilder(codeLanguageId) {
+  private val annotatedTextBuilder =
+    MarkdownAnnotatedTextBuilder(
+      "markdown",
+      enableEmacsQuoteRewriting = true,
+      enableElispDocstringDirectives = true,
+    )
+
+  private val commentRegexs = ProgramCommentRegexs.fromCodeLanguageId(codeLanguageId)
+  private val commentBlockRegex: Regex = commentRegexs.commentBlockRegex
+  private val lineCommentPatternString: String? = commentRegexs.lineCommentRegexString
+
+  override fun addCode(code: String): CodeAnnotatedTextBuilder {
+    val reader = ElispReader(code)
+    reader.read()
+
+    val segments: MutableList<Segment> = ArrayList()
+
+    for (matchResult: MatchResult in commentBlockRegex.findAll(code)) {
+      val isLineComment: Boolean = (matchResult.groups["lineComment"] != null)
+      val commentGroupName: String = (if (isLineComment) "lineComment" else "blockComment")
+      val commentGroup: MatchGroup = matchResult.groups[commentGroupName] ?: continue
+      val start: Int = commentGroup.range.first
+      val endExclusive: Int = commentGroup.range.last + 1
+
+      // A `;` inside a string literal is not a comment. The reader knows every
+      // string span, so keep only comment matches that overlap no string.
+      if (reader.stringSpans.none { rangesOverlap(start, endExclusive, it) }) {
+        segments += CommentSegment(start, endExclusive, isLineComment)
+      }
+    }
+
+    for (docstring: ElispReader.DocstringSpan in reader.docstringSpans) {
+      segments += DocstringSegment(docstring)
+    }
+
+    segments.sortBy { it.start }
+
+    var curPos = 0
+
+    for (segment: Segment in segments) {
+      // Defensive: a malformed reader/regex result could in principle yield an
+      // out-of-order or overlapping segment; skip it rather than slice badly.
+      if (segment.start < curPos) continue
+
+      // Always emit the preceding code as markup (even an empty gap), mirroring
+      // ProgramAnnotatedTextBuilder so the leading paragraph break is identical.
+      annotatedTextBuilder.addMarkup(code.substring(curPos, segment.start), "\n\n")
+
+      when (segment) {
+        is CommentSegment -> {
+          addComment(code.substring(segment.start, segment.endExclusive), segment.isLineComment)
+        }
+
+        is DocstringSegment -> {
+          addDocstring(code, segment.span)
+        }
+      }
+
+      curPos = segment.endExclusive
+    }
+
+    if (curPos < code.length) annotatedTextBuilder.addMarkup(code.substring(curPos))
+    return this
+  }
+
+  private fun addDocstring(
+    code: String,
+    span: ElispReader.DocstringSpan,
+  ) {
+    // Opening delimiter (`"`).
+    annotatedTextBuilder.addMarkup(code.substring(span.fullStart, span.contentStart))
+
+    val content: String = code.substring(span.contentStart, span.contentEnd)
+    // A leading `*` is the historical user-variable marker, not prose.
+    val skipLength: Int = (if (content.startsWith("*")) 1 else 0)
+
+    // Feed the whole docstring as one Markdown comment chunk. Directive
+    // neutralisation happens length-preservingly inside the Markdown builder,
+    // so source offsets stay intact without splitting the text into fragments.
+    annotatedTextBuilder.addComment(
+      arrayOf(content.substring(skipLength)),
+      arrayOf(Triple(content.substring(0, skipLength), 0, skipLength)),
+    )
+
+    // Closing delimiter (`"`).
+    annotatedTextBuilder.addMarkup(code.substring(span.contentEnd, span.fullEnd))
+  }
+
+  // --- Comment handling, kept byte-for-byte compatible with --------------
+  // --- ProgramAnnotatedTextBuilder so existing elisp behaviour is unchanged.
+
+  private fun addComment(
+    comment: String,
+    isLineComment: Boolean,
+  ) {
+    val commonFirstCharacter: String = getCommonFirstCharacterInComment(comment)
+    val lineContentsRegex =
+      Regex(
+        "[ \t]*" +
+          (
+            if (isLineComment && (lineCommentPatternString != null)) {
+              lineCommentPatternString
+            } else {
+              ""
+            }
+          ) +
+          "(?:" + Regex.escape(commonFirstCharacter) + ")?[ \t]*(.*?)(?:\r?\n|$)",
+      )
+    var curPos = 0
+
+    var code = arrayOf<String>()
+    var markups = arrayOf<Triple<String, Int, Int>>()
+
+    for (matchResult: MatchResult in lineContentsRegex.findAll(comment)) {
+      val matchGroup: MatchGroup = matchResult.groups[1] ?: continue
+
+      markups +=
+        Triple(
+          comment.substring(curPos, matchGroup.range.first),
+          curPos,
+          matchGroup.range.first,
+        )
+
+      curPos = matchGroup.range.last + 1
+
+      code += comment.substring(matchGroup.range.first, curPos)
+    }
+
+    annotatedTextBuilder.addComment(code, markups)
+
+    if (curPos < comment.length) annotatedTextBuilder.addMarkup(comment.substring(curPos))
+  }
+
+  private fun getCommonFirstCharacterInComment(comment: String): String {
+    var commonFirstCharacter = ""
+
+    for (line: String in comment.split(LINE_SEPARATOR_REGEX)) {
+      val firstCharacterMatchResult: MatchResult = FIRST_CHARACTER_REGEX.find(line) ?: continue
+
+      if (firstCharacterMatchResult.groups[1] == null) {
+        return ""
+      }
+
+      val firstCharacter: String = firstCharacterMatchResult.groupValues[1]
+
+      if (commonFirstCharacter.isEmpty()) {
+        commonFirstCharacter = firstCharacter
+      } else if (firstCharacter != commonFirstCharacter) {
+        return ""
+      }
+    }
+
+    return commonFirstCharacter
+  }
+
+  override fun build(): AnnotatedText = annotatedTextBuilder.build()
+
+  private sealed class Segment {
+    abstract val start: Int
+    abstract val endExclusive: Int
+  }
+
+  private class CommentSegment(
+    override val start: Int,
+    override val endExclusive: Int,
+    val isLineComment: Boolean,
+  ) : Segment()
+
+  private class DocstringSegment(
+    val span: ElispReader.DocstringSpan,
+  ) : Segment() {
+    override val start: Int get() = span.fullStart
+    override val endExclusive: Int get() = span.fullEnd
+  }
+
+  companion object {
+    private val LINE_SEPARATOR_REGEX = Regex("\r?\n")
+    private val FIRST_CHARACTER_REGEX = Regex("^[ \t]*(?:([#$%*+\\-/])|(.))")
+
+    private fun rangesOverlap(
+      start: Int,
+      endExclusive: Int,
+      span: IntRange,
+    ): Boolean = (start <= span.last) && (span.first < endExclusive)
+  }
+}
+
+/**
+ * Minimal s-expression reader that records, for an Emacs Lisp source string,
+ * every string literal span and the subset of those that are docstrings.
+ *
+ * It is intentionally a *scanner*, not a full reader: it tracks parenthesis
+ * nesting, string/char-literal/comment lexical state, and the head symbol plus
+ * element index of each list, which is everything needed to apply the
+ * [DOCSTRING_FORMS] position table. It does not build an AST or evaluate
+ * anything.
+ */
+internal class ElispReader(
+  private val code: String,
+) {
+  val stringSpans: MutableList<IntRange> = ArrayList()
+  val docstringSpans: MutableList<DocstringSpan> = ArrayList()
+
+  /** A docstring string literal, with delimiter-inclusive and content ranges. */
+  class DocstringSpan(
+    val fullStart: Int,
+    val contentStart: Int,
+    val contentEnd: Int,
+    val fullEnd: Int,
+  )
+
+  private class Form {
+    var head: String? = null
+    var childCount: Int = 0
+    val childStrings: MutableList<ChildString> = ArrayList()
+  }
+
+  private class ChildString(
+    val elementIndex: Int,
+    val fullStart: Int,
+    val contentStart: Int,
+    val contentEnd: Int,
+    val fullEnd: Int,
+    val quoted: Boolean,
+  )
+
+  @Suppress("CyclomaticComplexMethod")
+  fun read() {
+    val n: Int = code.length
+    val stack = ArrayDeque<Form>()
+    var i = 0
+    var pendingPrefix = false
+
+    while (i < n) {
+      val c: Char = code[i]
+
+      when {
+        c == ';' -> {
+          var j: Int = i + 1
+          while ((j < n) && (code[j] != '\n')) j++
+          i = j
+        }
+
+        c == '"' -> {
+          i = readString(i, stack, pendingPrefix)
+          pendingPrefix = false
+        }
+
+        c == '?' -> {
+          // Character literal, e.g. `?a`, `?\n`, `?\(`, `?\;`, `?\"`. Consume the
+          // (optionally backslash-escaped) char so its content is never mistaken
+          // for a string/comment delimiter, then run on through the rest of the
+          // atom.
+          registerElement(stack)
+          pendingPrefix = false
+          i++
+          if ((i < n) && (code[i] == '\\')) i++
+          if (i < n) i++
+          while ((i < n) && isSymbolChar(code[i])) i++
+        }
+
+        (c == '(') || (c == '[') -> {
+          registerElement(stack)
+          pendingPrefix = false
+          val form = Form()
+          if (c == '[') form.head = VECTOR_SENTINEL
+          stack.addLast(form)
+          i++
+        }
+
+        (c == ')') || (c == ']') -> {
+          val form: Form? = stack.removeLastOrNull()
+          if (form != null) detectDocstring(form)
+          pendingPrefix = false
+          i++
+        }
+
+        (c == '\'') || (c == '`') || (c == ',') -> {
+          pendingPrefix = true
+          i++
+          if ((c == ',') && (i < n) && (code[i] == '@')) i++
+        }
+
+        c == '#' -> {
+          pendingPrefix = true
+          i++
+        }
+
+        c.isWhitespace() -> {
+          i++
+        }
+
+        else -> {
+          val start: Int = i
+          val top: Form? = stack.lastOrNull()
+          val elementIndex: Int = registerElement(stack)
+          pendingPrefix = false
+          i++
+          while ((i < n) && isSymbolChar(code[i])) i++
+          if ((top != null) && (elementIndex == 0) && (top.head == null)) {
+            top.head = code.substring(start, i)
+          }
+        }
+      }
+    }
+  }
+
+  private fun readString(
+    quoteIndex: Int,
+    stack: ArrayDeque<Form>,
+    pendingPrefix: Boolean,
+  ): Int {
+    val n: Int = code.length
+    val fullStart: Int = quoteIndex
+    val contentStart: Int = quoteIndex + 1
+    var j: Int = contentStart
+
+    while (j < n) {
+      val cj: Char = code[j]
+      when {
+        // A backslash escapes the next character (e.g. `\"`), so skip both.
+        cj == '\\' -> j += 2
+
+        cj == '"' -> break
+
+        else -> j++
+      }
+    }
+
+    val contentEnd: Int = if (j < n) j else n
+    val fullEnd: Int = if (j < n) j + 1 else n
+
+    stringSpans += fullStart until fullEnd
+
+    val top: Form? = stack.lastOrNull()
+    if (top != null) {
+      val elementIndex: Int = top.childCount
+      top.childCount++
+      top.childStrings +=
+        ChildString(elementIndex, fullStart, contentStart, contentEnd, fullEnd, pendingPrefix)
+    }
+
+    return fullEnd
+  }
+
+  /** Registers the start of a direct child datum of the current list, returning its index. */
+  private fun registerElement(stack: ArrayDeque<Form>): Int {
+    val top: Form = stack.lastOrNull() ?: return -1
+    val index: Int = top.childCount
+    top.childCount++
+    return index
+  }
+
+  private fun detectDocstring(form: Form) {
+    val head: String = form.head ?: return
+    val spec: DocSpec = DOCSTRING_FORMS[head] ?: return
+
+    for (childString: ChildString in form.childStrings) {
+      if (childString.quoted || (childString.elementIndex != spec.index)) continue
+
+      // For function-like forms a string in the docstring slot is only a
+      // docstring if a body follows it; otherwise it is the return value.
+      if (spec.requireBody && (form.childCount <= spec.index + 1)) return
+
+      docstringSpans +=
+        DocstringSpan(
+          childString.fullStart,
+          childString.contentStart,
+          childString.contentEnd,
+          childString.fullEnd,
+        )
+      return
+    }
+  }
+
+  private data class DocSpec(
+    val index: Int,
+    val requireBody: Boolean,
+  )
+
+  companion object {
+    private const val VECTOR_SENTINEL: String = " vector"
+
+    private fun isSymbolChar(c: Char): Boolean = !c.isWhitespace() && (c !in SYMBOL_DELIMITERS)
+
+    private const val SYMBOL_DELIMITERS: String = "()[]\"';`,"
+
+    // Definition forms whose docstring sits at a fixed element index (the head
+    // symbol is element 0). `requireBody` marks function-like forms where a
+    // trailing string is the return value rather than a docstring. Restricted to
+    // forms whose docstring position is unambiguous from the head symbol alone.
+    private val DOCSTRING_FORMS: Map<String, DocSpec> =
+      mapOf(
+        // (head name arglist DOC . body)
+        "defun" to DocSpec(3, requireBody = true),
+        "defmacro" to DocSpec(3, requireBody = true),
+        "defsubst" to DocSpec(3, requireBody = true),
+        "define-inline" to DocSpec(3, requireBody = true),
+        "cl-defun" to DocSpec(3, requireBody = true),
+        "cl-defmacro" to DocSpec(3, requireBody = true),
+        "cl-defsubst" to DocSpec(3, requireBody = true),
+        "ert-deftest" to DocSpec(3, requireBody = true),
+        // (head name value DOC ...)
+        "defvar" to DocSpec(3, requireBody = false),
+        "defvar-local" to DocSpec(3, requireBody = false),
+        "defconst" to DocSpec(3, requireBody = false),
+        "defcustom" to DocSpec(3, requireBody = false),
+        "defparameter" to DocSpec(3, requireBody = false),
+        "defconstant" to DocSpec(3, requireBody = false),
+        "defgroup" to DocSpec(3, requireBody = false),
+        "defface" to DocSpec(3, requireBody = false),
+        "defalias" to DocSpec(3, requireBody = false),
+        // (define-minor-mode name DOC ...)
+        "define-minor-mode" to DocSpec(2, requireBody = false),
+        // (define-derived-mode child parent name DOC ...)
+        "define-derived-mode" to DocSpec(4, requireBody = false),
+      )
+  }
+}

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilderTest.kt
@@ -1,0 +1,158 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.parsing.program
+
+import org.bsplines.ltexls.parsing.CodeAnnotatedTextBuilderTest
+import kotlin.test.Test
+
+class ElispAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("elisp") {
+  @Test
+  fun testComments() {
+    // Comment behaviour matches ProgramAnnotatedTextBuilder: only standalone
+    // comment lines with a space after the delimiter are checked.
+    assertPlainText(
+      """
+      Sentence 1 - no check ; Sentence 2 - no check
+      ;Sentence 3 - no check
+      ;; Sentence 4 -
+      ;; check
+
+      """.trimIndent(),
+      "\n\n\nSentence 4 -\ncheck",
+    )
+  }
+
+  @Test
+  fun testDefunDocstring() {
+    assertPlainText(
+      "(defun foo ()\n  \"This is a docstring.\"\n  nil)\n",
+      "\n\n\nThis is a docstring.",
+    )
+  }
+
+  @Test
+  fun testDefcustomDocstring() {
+    assertPlainText(
+      "(defcustom foo nil\n  \"A short docstring.\"\n  :type 'boolean)\n",
+      "\n\n\nA short docstring.",
+    )
+  }
+
+  @Test
+  fun testEmacsLispLanguageId() {
+    assertPlainText(
+      "(defun foo ()\n  \"This is a docstring.\"\n  nil)\n",
+      "\n\n\nThis is a docstring.",
+      "emacs-lisp",
+    )
+  }
+
+  @Test
+  fun testDocstringDirectivesNeutralized() {
+    // `symbol\\=' (Emacs quoted identifier with self-quoting escape) and the
+    // \\[command] key substitution are both collapsed to Dummy tokens so they
+    // never become spelling/grammar false positives.
+    assertPlainText(
+      "(defun foo ()\n  \"Activate `foo-mode\\\\=' using \\\\[execute-command] now.\"\n  nil)\n",
+      "\n\n\nActivate Dummy0 using Dummy1 now.",
+    )
+  }
+
+  @Test
+  fun testDefvarValueStringNotChecked() {
+    // The string in the value slot (element 2) is not a docstring; only the
+    // docstring slot (element 3) is checked.
+    assertPlainText(
+      "(defvar foo \"not a docstring\" \"The real docstring.\")\n",
+      "\n\n\nThe real docstring.",
+    )
+  }
+
+  @Test
+  fun testReturnValueStringIsNotDocstring() {
+    // A lone string body in a function form is the return value, not a
+    // docstring, so nothing is checked.
+    assertPlainText(
+      "(defun foo () \"just returned\")\n",
+      "",
+    )
+  }
+
+  @Test
+  fun testPlainStringLiteralNotChecked() {
+    // Arbitrary string literals (e.g. a setq value) are not docstrings.
+    assertPlainText(
+      "(setq foo \"plain string value\")\n",
+      "",
+    )
+  }
+
+  @Test
+  fun testDefineMinorModeDocstring() {
+    assertPlainText(
+      "(define-minor-mode foo-mode\n  \"Toggle Foo mode.\"\n  :init-value nil)\n",
+      "\n\n\nToggle Foo mode.",
+    )
+  }
+
+  @Test
+  fun testDefineDerivedModeDocstring() {
+    // The mode-line name ("Foo", element 3) is skipped; the docstring is
+    // element 4.
+    assertPlainText(
+      "(define-derived-mode foo-mode prog-mode \"Foo\"\n  \"Major mode for Foo.\"\n  nil)\n",
+      "\n\n\nMajor mode for Foo.",
+    )
+  }
+
+  @Test
+  fun testCommentAndDocstring() {
+    assertPlainText(
+      ";; A leading comment sentence.\n(defun foo ()\n  \"A docstring sentence.\"\n  nil)\n",
+      "\n\n\nA leading comment sentence.\n\n\nA docstring sentence.",
+    )
+  }
+
+  @Test
+  fun testLeadingStarMarker() {
+    // A leading `*` is the historical user-variable marker, not prose.
+    assertPlainText(
+      "(defvar foo nil \"*User option docstring.\")\n",
+      "\n\n\nUser option docstring.",
+    )
+  }
+
+  @Test
+  fun testMultiParagraphDocstring() {
+    assertPlainText(
+      "(defun foo ()\n  \"First paragraph here.\n\nSecond paragraph here.\"\n  nil)\n",
+      "\n\n\nFirst paragraph here.\n\nSecond paragraph here.",
+    )
+  }
+
+  @Test
+  fun testSemicolonInsideStringIsNotComment() {
+    // A `;` at line start inside a string literal must not be treated as a
+    // comment. Here the string is a plain value (not a docstring), so nothing
+    // is checked at all.
+    assertPlainText(
+      "(setq foo \"line one\n;; looks like a comment but is not\")\n",
+      "",
+    )
+  }
+
+  @Test
+  fun testEmacsQuotedIdentifierInDocstring() {
+    // The plain `symbol' form (without escape) is recognised as inline code.
+    assertPlainText(
+      "(defun foo ()\n  \"See `bar' for details.\"\n  nil)\n",
+      "\n\n\nSee Dummy0 for details.",
+    )
+  }
+}

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilderTest.kt
@@ -14,17 +14,79 @@ import kotlin.test.Test
 class ElispAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("elisp") {
   @Test
   fun testComments() {
-    // Comment behaviour matches ProgramAnnotatedTextBuilder: only standalone
-    // comment lines with a space after the delimiter are checked.
+    // Trailing/inline comments after code (line 1) ARE checked for elisp.
+    // `;text` with no space after the marker (line 2) is not checked.
+    // Consecutive standalone `;;` lines (3-4) coalesce into one block.
     assertPlainText(
       """
-      Sentence 1 - no check ; Sentence 2 - no check
+      Sentence 1 - no check ; Sentence 2 - check
       ;Sentence 3 - no check
       ;; Sentence 4 -
       ;; check
 
       """.trimIndent(),
-      "\n\n\nSentence 4 -\ncheck",
+      "\n\n\nSentence 2 - check\n\n\nSentence 4 -\ncheck",
+    )
+  }
+
+  @Test
+  fun testTrailingCommentAfterCode() {
+    assertPlainText(
+      "(setq foo 1) ; increment the counter later\n",
+      "\n\n\nincrement the counter later",
+    )
+  }
+
+  @Test
+  fun testTrailingCommentEmacsQuotedIdentifier() {
+    assertPlainText(
+      "(foo) ; see `bar' for details\n",
+      "\n\n\nsee Dummy0 for details",
+    )
+  }
+
+  @Test
+  fun testSemicolonInStringIsNotInlineComment() {
+    // The `;` inside the string is not a comment; the trailing `;` after the
+    // closing paren is.
+    assertPlainText(
+      "(setq x \"a ; not a comment\") ; but this is\n",
+      "\n\n\nbut this is",
+    )
+  }
+
+  @Test
+  fun testSectionHeadingsChecked() {
+    // `;;;` section headings and `;;;;` file headers are prose and checked;
+    // `;text` (no space after the marker) is not.
+    assertPlainText(
+      ";;; Code:\n;nospace\n;; Real comment here.\n",
+      "\n\n\nCode:\n\n\nReal comment here.",
+    )
+  }
+
+  @Test
+  fun testFourSemicolonHeadingChecked() {
+    assertPlainText(
+      ";;;; File header summary.\n",
+      "\n\n\nFile header summary.",
+    )
+  }
+
+  @Test
+  fun testBlankCommentLineSeparatesParagraphs() {
+    // A bare `;;` line inside a coalesced comment block must survive as a blank
+    // line so the two paragraphs are not merged into one (the checker would
+    // otherwise run a sentence across the paragraph boundary). Lines within a
+    // paragraph are joined with a single newline; the blank line becomes `\n\n`.
+    assertPlainText(
+      ";; First line\n" +
+        ";; second line of the same paragraph\n" +
+        ";;\n" +
+        ";; New line of new paragraph\n" +
+        ";; second line of second paragraph\n",
+      "\n\n\nFirst line\nsecond line of the same paragraph" +
+        "\n\nNew line of new paragraph\nsecond line of second paragraph",
     )
   }
 

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/program/ProgramAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/program/ProgramAnnotatedTextBuilderTest.kt
@@ -160,15 +160,19 @@ class ProgramAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("") {
 
   @Test
   fun testElisp() {
+    // Unlike "lisp"/"clojure" (testLisp), elisp routes through
+    // ElispAnnotatedTextBuilder, which also checks trailing/inline comments
+    // (line 1's "Sentence 2 - check"). See ElispAnnotatedTextBuilderTest for the
+    // full elisp coverage.
     assertPlainText(
       """
-      Sentence 1 - no check ; Sentence 2 - no check
+      Sentence 1 - no check ; Sentence 2 - check
       ;Sentence 3 - no check
       ;; Sentence 4 -
       ;; check
 
       """.trimIndent(),
-      "\n\n\nSentence 4 -\ncheck",
+      "\n\n\nSentence 2 - check\n\n\nSentence 4 -\ncheck",
       "elisp",
     )
   }
@@ -177,13 +181,13 @@ class ProgramAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("") {
   fun testEmacsLisp() {
     assertPlainText(
       """
-      Sentence 1 - no check ; Sentence 2 - no check
+      Sentence 1 - no check ; Sentence 2 - check
       ;Sentence 3 - no check
       ;; Sentence 4 -
       ;; check
 
       """.trimIndent(),
-      "\n\n\nSentence 4 -\ncheck",
+      "\n\n\nSentence 2 - check\n\n\nSentence 4 -\ncheck",
       "emacs-lisp",
     )
   }


### PR DESCRIPTION
## Summary

Until now, `elisp` / `emacs-lisp` files were checked the same way as any other
programming language: only standalone `;` / `;;` comment lines reached
LanguageTool. This PR makes Emacs Lisp a first-class case by also checking:

1. **Docstrings** — the string literal in `defun`, `defcustom`, `defvar`,
   `define-minor-mode`, and similar definition forms.
2. **Trailing / inline comments** — comments after code on the same line,
   e.g. `(setq foo 1) ; explain the value`.

Both are driven by a small Emacs Lisp lexer rather than a regex, which is what
makes them reliable.

## Motivation

Docstrings are where most human-readable prose in an Elisp file lives, so not
checking them missed the majority of the text worth proofreading. Trailing
comments are common in real configs and were silently skipped. Detecting either
correctly is impossible with the existing line-anchored comment regex, because
it cannot tell a real `;` from one inside a string (`"a ; b"`) or a character
literal (`?\;`), nor find a docstring at a form-specific argument position.

## What changed

- **New `ElispAnnotatedTextBuilder`** (`parsing/program/`), selected for
  `codeLanguageId` `elisp` / `emacs-lisp` in `CodeAnnotatedTextBuilder.create`.
  It runs a minimal s-expression reader (`ElispReader`) that tracks
  string / char-literal / comment lexical state and records:
  - **comment spans** (with "is this prose?" and "is it line-leading?" flags), and
  - **docstring spans**, located via a per-form argument-position table
    (`defun`-family after the arg list, `defvar`-family after the value,
    `define-minor-mode` after the name, `define-derived-mode` after the
    mode-line name, …).
- **`MarkdownAnnotatedTextBuilder`** gains an opt-in
  `enableElispDocstringDirectives` flag that neutralizes Emacs docstring markup
  length-preservingly (so source offsets stay valid): key substitutions
  (`\\[command]`, `\\{keymap}`, `\\<keymap>`) and the `` `symbol\\=' `` form
  collapse to a Dummy token, a bare `\\=` becomes whitespace, and a leading `*`
  user-variable marker is dropped.

Comment/docstring content is interpreted as Markdown, with the existing
Emacs `` `symbol' `` quote rewriting enabled.

## Behavior details

- A comment is checked when its run of leading semicolons is followed by
  whitespace or end-of-line. This covers `;`, `;;`, `;;;` section headings and
  `;;;;`+ file headers / sub-sections at any depth (per the Emacs Lisp comment
  conventions); all leading semicolons are stripped before the prose is checked.
  `;text` with no space after the marker is not treated as prose.
- Consecutive standalone comment lines coalesce into one block, so a sentence
  wrapping across lines is checked as a unit; trailing comments are checked as
  individual single-line segments.
- A bare `;;` line inside such a block is itself an empty checkable comment, so
  it is preserved as a blank line — multi-paragraph comment blocks keep their
  paragraph breaks instead of collapsing into one.
- A value-position string (e.g. a `defvar` initial value) and a function's
  lone-string return value are correctly **not** treated as docstrings.
- A `;` or `"` inside a string or character literal is never mistaken for a
  comment or docstring boundary.

## Scope / limitations

Limited to `elisp` / `emacs-lisp`, which is where the reader applies. Common
Lisp (`lisp`) and Clojure keep comment-only checking — their docstring
conventions differ — and other comment-based languages (C, Java, Python, …)
keep checking only standalone comment lines, since trailing-comment detection
there would require a per-language lexer.

## Testing

- New `ElispAnnotatedTextBuilderTest` covering docstrings of each supported
  form, directive neutralization, value/return strings correctly skipped,
  multi-paragraph docstrings, trailing comments, `;` inside strings, `;;;` /
  `;;;;` headings checked, `;text` (no space) excluded, and blank `;;` lines
  preserving paragraph breaks.
- `ProgramAnnotatedTextBuilderTest` `testElisp` / `testEmacsLisp` updated to
  assert the trailing comment **is** checked, explicitly contrasting `testLisp`,
  where it is not.
- Full `parsing.**` and `server.**` suites pass; detekt and ktlint clean.
- Verified end-to-end on a real `init.el` through the `DocumentChecker` pipeline
  (with `elisp` in `ltex.enabled`, as the `lsp-ltex-plus` client sends): only
  comment and docstring prose is checked, code tokens are excluded, and quoted
  identifiers / directives become Dummy tokens.

## Commits

- `Check Emacs Lisp docstrings, not just comments`
- `Check trailing/inline Emacs Lisp comments`
