### PR TITLE
Make Emacs Lisp fragmentization self-standing and regex-free

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeFragmentizer.kt
@@ -17,6 +17,7 @@ import org.bsplines.ltexls.parsing.markdown.MarkdownFragmentizer
 import org.bsplines.ltexls.parsing.nop.NopFragmentizer
 import org.bsplines.ltexls.parsing.org.OrgFragmentizer
 import org.bsplines.ltexls.parsing.plaintext.PlaintextFragmentizer
+import org.bsplines.ltexls.parsing.program.ElispFragmentizer
 import org.bsplines.ltexls.parsing.program.ProgramCommentRegexs
 import org.bsplines.ltexls.parsing.program.ProgramFragmentizer
 import org.bsplines.ltexls.parsing.restructuredtext.RestructuredtextFragmentizer
@@ -59,6 +60,12 @@ abstract class CodeFragmentizer(
         "bibtex",
         -> {
           BibtexFragmentizer(codeLanguageId)
+        }
+
+        "elisp",
+        "emacs-lisp",
+        -> {
+          ElispFragmentizer(codeLanguageId)
         }
 
         "git-commit",

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/RegexCodeFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/RegexCodeFragmentizer.kt
@@ -22,17 +22,9 @@ open class RegexCodeFragmentizer(
     code: String,
     originalSettings: Settings,
   ): List<CodeFragment> {
-    val codeFragments = ArrayList<CodeFragment>()
-    val settingsOverride = SettingsOverride(originalSettings)
-    var curSettings: Settings = settingsOverride.toSettings()
-    var curPos = 0
+    val magicComments = ArrayList<MagicComment>()
 
     for (matchResult: MatchResult in this.regex.findAll(code)) {
-      var lastPos: Int = curPos
-      curPos = matchResult.range.first
-      var lastCode: String = code.substring(lastPos, curPos)
-      codeFragments.add(CodeFragment(codeLanguageId, lastCode, lastPos, curSettings))
-
       var settingsLine: String? = null
 
       for (groupIndex in 1 until matchResult.groups.size) {
@@ -42,24 +34,75 @@ open class RegexCodeFragmentizer(
         }
       }
 
-      if (settingsLine == null) {
-        Logging.LOGGER.warning(I18n.format("couldNotFindSettingsInMatch"))
-        continue
-      }
-
-      SettingsParser.updateSettingsOverride(settingsLine, settingsOverride)
-      curSettings = settingsOverride.toSettings()
-
-      lastPos = curPos
-      curPos = matchResult.range.last + 1
-      lastCode = code.substring(lastPos, curPos)
-      codeFragments.add(CodeFragment("nop", lastCode, lastPos, curSettings))
+      magicComments.add(
+        MagicComment(matchResult.range.first, matchResult.range.last + 1, settingsLine),
+      )
     }
 
-    codeFragments.add(
-      CodeFragment(codeLanguageId, code.substring(curPos), curPos, curSettings),
-    )
+    return buildFragments(codeLanguageId, code, originalSettings, magicComments)
+  }
 
-    return codeFragments
+  /**
+   * A located `ltex:` magic comment: the source span to excise (from [start] to
+   * [endExclusive]) and the settings text it carries ([settingsLine], or null
+   * when a magic comment was matched but its settings group could not be
+   * isolated).
+   */
+  class MagicComment(
+    val start: Int,
+    val endExclusive: Int,
+    val settingsLine: String?,
+  )
+
+  companion object {
+    /**
+     * Splits [code] at the given [magicComments], threading the cumulative
+     * `ltex:` settings overrides through the resulting fragments. Magic comments
+     * must be supplied in source order and must not overlap.
+     *
+     * Shared by regex-driven fragmentizers and scanner-driven ones (e.g. Emacs
+     * Lisp via [org.bsplines.ltexls.parsing.program.ElispFragmentizer]) so the
+     * fragment/settings bookkeeping has a single implementation; only the way
+     * magic comments are *located* differs.
+     */
+    fun buildFragments(
+      codeLanguageId: String,
+      code: String,
+      originalSettings: Settings,
+      magicComments: List<MagicComment>,
+    ): List<CodeFragment> {
+      val codeFragments = ArrayList<CodeFragment>()
+      val settingsOverride = SettingsOverride(originalSettings)
+      var curSettings: Settings = settingsOverride.toSettings()
+      var curPos = 0
+
+      for (magicComment: MagicComment in magicComments) {
+        var lastPos: Int = curPos
+        curPos = magicComment.start
+        var lastCode: String = code.substring(lastPos, curPos)
+        codeFragments.add(CodeFragment(codeLanguageId, lastCode, lastPos, curSettings))
+
+        val settingsLine: String? = magicComment.settingsLine
+
+        if (settingsLine == null) {
+          Logging.LOGGER.warning(I18n.format("couldNotFindSettingsInMatch"))
+          continue
+        }
+
+        SettingsParser.updateSettingsOverride(settingsLine, settingsOverride)
+        curSettings = settingsOverride.toSettings()
+
+        lastPos = curPos
+        curPos = magicComment.endExclusive
+        lastCode = code.substring(lastPos, curPos)
+        codeFragments.add(CodeFragment("nop", lastCode, lastPos, curSettings))
+      }
+
+      codeFragments.add(
+        CodeFragment(codeLanguageId, code.substring(curPos), curPos, curSettings),
+      )
+
+      return codeFragments
+    }
   }
 }

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilder.kt
@@ -24,12 +24,12 @@ import org.languagetool.markup.AnnotatedText
  * because the docstring position is form-specific and string boundaries depend
  * on escape and character-literal syntax.
  *
- * Comments keep the exact behaviour of [ProgramAnnotatedTextBuilder] by reusing
- * the same [ProgramCommentRegexs] line-comment regex; comment matches that fall
- * inside a string literal are discarded so a `;` inside a docstring is never
- * mistaken for a comment. The contents of comments and docstrings are
- * interpreted as Markdown, with Emacs quote rewriting and docstring-directive
- * neutralisation enabled (see [MarkdownAnnotatedTextBuilder]).
+ * Comments are detected structurally by [ElispReader], not by the
+ * [ProgramCommentRegexs] line-comment regex: a `;` inside a string or character
+ * literal is recognised lexically and never reported as a comment. The contents
+ * of comments and docstrings are interpreted as Markdown, with Emacs quote
+ * rewriting and docstring-directive neutralisation enabled (see
+ * [MarkdownAnnotatedTextBuilder]).
  */
 class ElispAnnotatedTextBuilder(
   codeLanguageId: String,

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/program/ElispFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/program/ElispFragmentizer.kt
@@ -1,0 +1,109 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.parsing.program
+
+import org.bsplines.ltexls.parsing.CodeFragment
+import org.bsplines.ltexls.parsing.CodeFragmentizer
+import org.bsplines.ltexls.parsing.RegexCodeFragmentizer
+import org.bsplines.ltexls.settings.Settings
+
+/**
+ * Fragmentizer for Emacs Lisp. It locates `; ltex: …` / `;; ltex: …` magic
+ * comments **structurally** via [ElispReader] rather than with a line-comment
+ * regex, so a `; ltex:` sequence inside a string or character literal is never
+ * mistaken for a settings directive. This keeps Emacs Lisp self-standing: it no
+ * longer relies on the shared Lisp-family entry in [ProgramCommentRegexs].
+ *
+ * The fragment/settings bookkeeping ([RegexCodeFragmentizer.buildFragments]) and
+ * the source-code comment defaults ([ProgramFragmentizer.augmentFragments]) are
+ * reused, so toggling behaviour and the programmer-jargon defaults are identical
+ * to the regex path for ordinary standalone comments.
+ */
+class ElispFragmentizer(
+  codeLanguageId: String,
+) : CodeFragmentizer(codeLanguageId) {
+  override fun fragmentize(
+    code: String,
+    originalSettings: Settings,
+  ): List<CodeFragment> =
+    ProgramFragmentizer.augmentFragments(
+      RegexCodeFragmentizer.buildFragments(
+        codeLanguageId,
+        code,
+        originalSettings,
+        findMagicComments(code),
+      ),
+    )
+
+  private fun findMagicComments(code: String): List<RegexCodeFragmentizer.MagicComment> {
+    val reader = ElispReader(code)
+    reader.read()
+    return reader.commentSpans.mapNotNull { comment -> toMagicComment(code, comment) }
+  }
+
+  private fun toMagicComment(
+    code: String,
+    comment: ElispReader.CommentSpan,
+  ): RegexCodeFragmentizer.MagicComment? {
+    // Only standalone comments can carry settings, mirroring the `^[ \t]*` anchor
+    // of the former regex; a trailing/inline `; ltex:` after code is not a
+    // directive.
+    if (!comment.lineLeading) return null
+
+    val settingsLine: String = parseMagicComment(code, comment) ?: return null
+
+    // Extend the excised span back to the start of the line so the leading
+    // indentation is consumed together with the directive, exactly as the
+    // `^[ \t]*` regex did. `lineLeading` guarantees only blanks precede it.
+    var lineStart: Int = comment.start
+    while ((lineStart > 0) && (code[lineStart - 1] != '\n') && (code[lineStart - 1] != '\r')) {
+      lineStart--
+    }
+
+    return RegexCodeFragmentizer.MagicComment(lineStart, comment.end, settingsLine)
+  }
+
+  // Mirrors the former magic-comment regex `^[ \t]*;;?[ \t]*(?i)ltex(?-i):(.*?)[ \t]*$`
+  // applied to a single comment span: one or two leading semicolons, optional
+  // blanks, then a case-insensitive `ltex:`. Returns the directive text (with
+  // trailing blanks stripped, leading blanks kept as the regex did) or null when
+  // the comment is not a magic comment.
+  private fun parseMagicComment(
+    code: String,
+    comment: ElispReader.CommentSpan,
+  ): String? {
+    val end: Int = comment.end
+    var i: Int = comment.start
+
+    var semicolons = 0
+    while ((i < end) && (code[i] == ';')) {
+      semicolons++
+      i++
+    }
+    if (semicolons !in 1..2) return null
+
+    while ((i < end) && ((code[i] == ' ') || (code[i] == '\t'))) i++
+
+    if (!code.regionMatches(i, MAGIC_KEYWORD, 0, MAGIC_KEYWORD.length, ignoreCase = true)) {
+      return null
+    }
+    i += MAGIC_KEYWORD.length
+
+    var contentEnd: Int = end
+    while ((contentEnd > i) && ((code[contentEnd - 1] == ' ') || (code[contentEnd - 1] == '\t'))) {
+      contentEnd--
+    }
+
+    return code.substring(i, contentEnd)
+  }
+
+  companion object {
+    private const val MAGIC_KEYWORD = "ltex:"
+  }
+}

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/program/ProgramCommentRegexs.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/program/ProgramCommentRegexs.kt
@@ -124,7 +124,10 @@ data class ProgramCommentRegexs(
           lineCommentRegexString = "---?"
         }
 
-        "clojure", "elisp", "emacs-lisp", "lisp" -> {
+        // Emacs Lisp ("elisp"/"emacs-lisp") is intentionally absent: it is
+        // handled structurally by ElispAnnotatedTextBuilder/ElispFragmentizer
+        // (a real s-expression scanner), not by this line-comment regex.
+        "clojure", "lisp" -> {
           lineCommentRegexString = ";;?"
         }
 

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/program/ProgramFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/program/ProgramFragmentizer.kt
@@ -21,37 +21,7 @@ class ProgramFragmentizer(
   override fun fragmentize(
     code: String,
     originalSettings: Settings,
-  ): List<CodeFragment> {
-    val oldCodeFragments: List<CodeFragment> = super.fragmentize(code, originalSettings)
-    val result = ArrayList<CodeFragment>()
-
-    for (oldCodeFragment: CodeFragment in oldCodeFragments) {
-      val settings: Settings = oldCodeFragment.settings
-
-      val dictionary = HashSet<String>(settings.dictionary)
-      dictionary.addAll(DICTIONARY)
-
-      val disabledRules = HashSet<String>(settings.disabledRules)
-
-      for (ruleId: String in DISABLED_RULES) {
-        if (!settings.enabledRules.contains(ruleId)) {
-          disabledRules.add(ruleId)
-        }
-      }
-
-      result.add(
-        oldCodeFragment.copy(
-          settings =
-            settings.copy(
-              _allDictionaries = settings.getModifiedDictionary(dictionary),
-              _allDisabledRules = settings.getModifiedDisabledRules(disabledRules),
-            ),
-        ),
-      )
-    }
-
-    return result
-  }
+  ): List<CodeFragment> = augmentFragments(super.fragmentize(code, originalSettings))
 
   companion object {
     val DICTIONARY =
@@ -69,5 +39,43 @@ class ProgramFragmentizer(
         "UPPERCASE_SENTENCE_START",
         "WHITESPACE_RULE",
       )
+
+    /**
+     * Applies the source-code comment defaults to already-split [fragments]:
+     * adds the programmer-jargon [DICTIONARY] entries and disables the prose
+     * [DISABLED_RULES] that misfire on code comments (unless the user explicitly
+     * enabled them). Shared with [ElispFragmentizer] so Emacs Lisp gets the same
+     * defaults as the regex-driven program languages.
+     */
+    fun augmentFragments(fragments: List<CodeFragment>): List<CodeFragment> {
+      val result = ArrayList<CodeFragment>()
+
+      for (oldCodeFragment: CodeFragment in fragments) {
+        val settings: Settings = oldCodeFragment.settings
+
+        val dictionary = HashSet<String>(settings.dictionary)
+        dictionary.addAll(DICTIONARY)
+
+        val disabledRules = HashSet<String>(settings.disabledRules)
+
+        for (ruleId: String in DISABLED_RULES) {
+          if (!settings.enabledRules.contains(ruleId)) {
+            disabledRules.add(ruleId)
+          }
+        }
+
+        result.add(
+          oldCodeFragment.copy(
+            settings =
+              settings.copy(
+                _allDictionaries = settings.getModifiedDictionary(dictionary),
+                _allDisabledRules = settings.getModifiedDisabledRules(disabledRules),
+              ),
+          ),
+        )
+      }
+
+      return result
+    }
   }
 }

--- a/src/main/kotlin/org/bsplines/ltexls/server/DocumentChecker.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/DocumentChecker.kt
@@ -104,13 +104,19 @@ class DocumentChecker(
     }
 
     val hasRange: Boolean = (rangeStartPos != null)
+    val codeLanguageId: String = codeFragment.codeLanguageId
+    // Languages whose builder extracts comments/docstrings from source: a
+    // sub-range of such a document is bare prose, so it is checked as plaintext.
+    // Emacs Lisp belongs here too but is no longer in the ProgramCommentRegexs
+    // table, so it is matched explicitly.
+    val extractsCommentsFromSource: Boolean =
+      ProgramCommentRegexs.isSupportedCodeLanguageId(codeLanguageId) ||
+        (codeLanguageId == "elisp") || (codeLanguageId == "emacs-lisp")
     val builder: CodeAnnotatedTextBuilder =
-      if (
-        hasRange && ProgramCommentRegexs.isSupportedCodeLanguageId(codeFragment.codeLanguageId)
-      ) {
-        PlaintextAnnotatedTextBuilder(codeFragment.codeLanguageId)
+      if (hasRange && extractsCommentsFromSource) {
+        PlaintextAnnotatedTextBuilder(codeLanguageId)
       } else {
-        CodeAnnotatedTextBuilder.create(codeFragment.codeLanguageId)
+        CodeAnnotatedTextBuilder.create(codeLanguageId)
       }
 
     builder.setSettings(codeFragment.settings)

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispFragmentizerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispFragmentizerTest.kt
@@ -1,0 +1,104 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.parsing.program
+
+import org.bsplines.ltexls.parsing.CodeFragment
+import org.bsplines.ltexls.parsing.CodeFragmentizer
+import org.bsplines.ltexls.parsing.restructuredtext.RestructuredtextFragmentizerTest
+import org.bsplines.ltexls.settings.Settings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ElispFragmentizerTest {
+  @Test
+  fun testStandaloneMagicComments() {
+    // Same five-fragment contract as the Lisp regex path (ProgramFragmentizerTest
+    // .testLisp): standalone `;` comments carrying `ltex:` toggle settings
+    // identically, even though Emacs Lisp now uses the structural scanner.
+    RestructuredtextFragmentizerTest.assertFragmentizer(
+      "elisp",
+      """
+      Sentence 1
+
+      ;  ltex: language=de-DE
+
+      Sentence 2
+
+      ;		ltex:	language=en-US
+
+      Sentence 3
+
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testEmacsLispLanguageId() {
+    RestructuredtextFragmentizerTest.assertFragmentizer(
+      "emacs-lisp",
+      """
+      Sentence 1
+
+      ;  ltex: language=de-DE
+
+      Sentence 2
+
+      ;		ltex:	language=en-US
+
+      Sentence 3
+
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testDoubleSemicolonMagicComment() {
+    // `;;` headings carry directives just like `;`, matching the former `;;?`.
+    val fragmentizer: CodeFragmentizer = CodeFragmentizer.create("elisp")
+    val fragments: List<CodeFragment> =
+      fragmentizer.fragmentize("Sentence 1\n;; ltex: language=de-DE\nSentence 2\n", Settings())
+    assertEquals(3, fragments.size)
+    assertEquals("en-US", fragments[0].settings.languageShortCode)
+    assertEquals("de-DE", fragments[2].settings.languageShortCode)
+  }
+
+  @Test
+  fun testTripleSemicolonIsNotADirective() {
+    // `;;;` (three semicolons) is a section heading, not a magic comment, just
+    // as `;;?` only matched one or two semicolons.
+    val fragmentizer: CodeFragmentizer = CodeFragmentizer.create("elisp")
+    val fragments: List<CodeFragment> =
+      fragmentizer.fragmentize("Sentence 1\n;;; ltex: language=de-DE\nSentence 2\n", Settings())
+    assertEquals(1, fragments.size)
+    assertEquals("en-US", fragments[0].settings.languageShortCode)
+  }
+
+  @Test
+  fun testMagicCommentInStringIsNotADirective() {
+    // The `; ltex:` sequence here is inside a string literal; the scanner
+    // recognises that lexically and does not treat it as a directive (the old
+    // line-comment regex would have).
+    val fragmentizer: CodeFragmentizer = CodeFragmentizer.create("elisp")
+    val fragments: List<CodeFragment> =
+      fragmentizer.fragmentize("(setq x \"; ltex: language=de-DE\")\n", Settings())
+    assertEquals(1, fragments.size)
+    assertEquals("en-US", fragments[0].settings.languageShortCode)
+  }
+
+  @Test
+  fun testTrailingMagicCommentIsNotADirective() {
+    // An inline/trailing comment after code is not standalone, so it cannot
+    // carry settings (mirroring the regex's `^[ \t]*` anchor).
+    val fragmentizer: CodeFragmentizer = CodeFragmentizer.create("elisp")
+    val fragments: List<CodeFragment> =
+      fragmentizer.fragmentize("(foo) ; ltex: language=de-DE\n(bar)\n", Settings())
+    assertEquals(1, fragments.size)
+    assertEquals("en-US", fragments[0].settings.languageShortCode)
+  }
+}


### PR DESCRIPTION
## Summary

Emacs Lisp no longer depends on the shared `;;?` line-comment entry that
`ProgramCommentRegexs` defines for the Lisp family (`clojure`, `lisp`). It is now
handled **end-to-end by its dedicated s-expression scanner**:

- `ElispAnnotatedTextBuilder` already extracted comments and docstrings
  structurally (via `ElispReader`), not via the regex.
- This PR completes the split on the **fragmentizer** side: the new
  `ElispFragmentizer` locates `; ltex:` / `;; ltex:` magic comments from
  `ElispReader`'s comment spans instead of a line-comment regex.

As a result a `; ltex:` sequence inside a string/character literal, or trailing
after code on the same line, is no longer mistaken for a settings directive —
something the regex path could not distinguish.

## Motivation

Elisp had a qualitatively superior, scanner-based path for comment/docstring
*extraction*, but still rode the generic regex group for two things:
`isSupportedCodeLanguageId("elisp")` returning `true` gated (1) fragmentization
(`ProgramFragmentizer` + its `magicCommentRegex`) and (2) the range-check
fast-path in `DocumentChecker`. That meant a single edit to the `lisp` regex
entry could silently change elisp behaviour. This PR removes that coupling so
elisp is fully self-standing and regex-free, and serves as the template for how
the other Lisp-family languages could eventually be promoted.

## Changes

- **`ProgramCommentRegexs`** — remove `"elisp"`/`"emacs-lisp"` from the `;;?`
  group (now just `"clojure", "lisp"`); `isSupportedCodeLanguageId` returns
  `false` for elisp.
- **`ElispFragmentizer`** (new) — locates magic comments structurally from
  `ElispReader`. Only standalone (`lineLeading`) comments with one or two
  leading semicolons count, mirroring the former `^[ \t]*;;?…` anchor.
- **`CodeFragmentizer.create`** — routes `elisp`/`emacs-lisp` to
  `ElispFragmentizer`, mirroring the existing builder-side routing.
- **`RegexCodeFragmentizer`** — extract the fragment/settings split loop into a
  reusable `buildFragments(...)` plus a `MagicComment` holder; the regex path now
  just locates matches and delegates. Behaviour of all existing regex-driven
  fragmentizers is unchanged.
- **`ProgramFragmentizer`** — extract the programmer-jargon dictionary and
  prose-rule-disabling logic into `augmentFragments(...)`, reused by
  `ElispFragmentizer` so elisp keeps identical source-code comment defaults.
- **`DocumentChecker`** — preserve the range → `PlaintextAnnotatedTextBuilder`
  fast-path for elisp, which previously relied on `isSupportedCodeLanguageId`.
- **`ElispAnnotatedTextBuilder`** — fix a stale class doc comment that claimed
  comments are detected via the `ProgramCommentRegexs` regex (they are detected
  structurally by `ElispReader`).

## Behavioural compatibility

For ordinary standalone comments, toggling behaviour is identical to the old
regex path — the shared `buildFragments`/`augmentFragments` keep the
fragment/settings bookkeeping and defaults the same. The only intentional
differences are improvements the scanner makes possible:

- `; ltex:` inside a string or character literal is **not** a directive.
- A trailing/inline `; ltex:` after code is **not** a directive.
- `;;;` section headings remain non-directives (`;;?` matched only one or two
  semicolons).

## Tests

New `ElispFragmentizerTest` (6 cases):

- regex-path parity for `elisp` and `emacs-lisp` (same five-fragment contract as
  `ProgramFragmentizerTest.testLisp`),
- `;;` directives accepted,
- `;;;` headings rejected,
- `; ltex:` inside a string literal not treated as a directive,
- trailing/inline `; ltex:` not treated as a directive.

Verified locally (offline): `ElispFragmentizerTest` (6),
`ProgramFragmentizerTest` (12), `ElispAnnotatedTextBuilderTest` (21),
`ProgramAnnotatedTextBuilderTest` (20), `DocumentCheckerTest` (14) — all green.
The full `verify`/JaCoCo coverage gate (which needs LanguageTool Premium
credentials and a local server) was left to CI.