### PR TITLE
Resolve LanguageTool Premium credentials from `${ENV_VAR}` references

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -15,6 +15,9 @@
   <body>
     <release version="18.7.0" date="upcoming">
       <action type="add" due-to="Andrea Alberti (@alberti42)">
+        Resolve `ltex.languageToolOrg.username` and `ltex.languageToolOrg.apiKey` from an environment variable when the whole setting value is a reference of the form `${ENV_VAR}` (e.g. `"ltex.languageToolOrg.apiKey": "${LANGUAGETOOL_API_KEY}"`). This lets LanguageTool Premium credentials stay out of shared/synced configuration files: the public config references a variable, and the secret lives only in the environment of the process that launches the server. Resolution is a plain `System.getenv` lookup at the point the value is consumed — never a shell, so there is no command-injection surface — and the match is whole-value only, so a literal credential that merely contains `${` is never altered. A reference to an unset or empty variable resolves to the empty string (degrading to anonymous checking) and logs a warning, rather than sending the literal placeholder to the server. Requested in ltex-plus/ltex-ls-plus#112.
+      </action>
+      <action type="add" due-to="Andrea Alberti (@alberti42)">
         Spell- and grammar-check Emacs Lisp docstrings (in `defun`, `defcustom`, `defvar`, `define-minor-mode` and similar definition forms), not just comments. Docstring markup directives such as `\\[command]` and `` `symbol' `` are ignored so they do not cause false positives. Applies to `elisp` / `emacs-lisp`.
       </action>
       <action type="add" due-to="Andrea Alberti (@alberti42)">

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
@@ -327,6 +327,7 @@ class MarkdownAnnotatedTextBuilder(
   }
 
   override fun setSettings(settings: Settings) {
+    super.setSettings(settings)
     this.language = settings.languageShortCode
 
     for ((nodeName: String, actionString: String) in settings.markdownNodes) {

--- a/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
@@ -84,9 +84,9 @@ data class Settings(
   val languageToolHttpServerUri: String
     get() = (this._languageToolHttpServerUri ?: "")
   val languageToolOrgUsername: String
-    get() = (this._languageToolOrgUsername ?: "")
+    get() = resolveEnvironmentVariableReference(this._languageToolOrgUsername ?: "")
   val languageToolOrgApiKey: String
-    get() = (this._languageToolOrgApiKey ?: "")
+    get() = resolveEnvironmentVariableReference(this._languageToolOrgApiKey ?: "")
   val logLevel: Level
     get() = (this._logLevel ?: Level.FINE)
   val sentenceCacheSize: Long
@@ -485,6 +485,36 @@ data class Settings(
 
     private val LANGUAGE_TAG_REGEX: Regex =
       Regex("""^([A-Za-z]{2,3})(?:-([A-Za-z]{2}))?(-.*)?$""")
+
+    // Matches a setting whose *entire* value is a single environment-variable
+    // reference, e.g. "${LANGUAGETOOL_API_KEY}". Whole-value only (no inline
+    // interpolation) so there is nothing to escape and a literal value that
+    // merely contains "${" is never mangled. The captured name is restricted
+    // to the POSIX-portable identifier charset.
+    private val ENVIRONMENT_VARIABLE_REFERENCE_REGEX: Regex =
+      Regex("""^\$\{([A-Za-z_][A-Za-z0-9_]*)}$""")
+
+    /**
+     * Resolves a setting value of the form `${ENV_VAR}` to the value of that
+     * environment variable, looked up via [System.getenv] (never a shell, so
+     * there is no injection surface). Any other value is returned verbatim.
+     * A reference to an unset/empty variable resolves to the empty string and
+     * logs a warning, so a misconfiguration degrades to "no credentials"
+     * (anonymous checking) rather than sending the literal placeholder to the
+     * LanguageTool server.
+     */
+    private fun resolveEnvironmentVariableReference(value: String): String {
+      val name: String =
+        ENVIRONMENT_VARIABLE_REFERENCE_REGEX.matchEntire(value)?.groupValues?.get(1) ?: return value
+      val resolved: String? = System.getenv(name)
+
+      if (resolved.isNullOrEmpty()) {
+        Logging.LOGGER.warning(I18n.format("environmentVariableNotSet", name))
+        return ""
+      }
+
+      return resolved
+    }
 
     private fun getEnabledFromJson(jsonSettings: JsonElement): Set<String>? {
       val jsonElement: JsonElement? = getSettingFromJsonAsJsonElement(jsonSettings, "enabled")

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -47,6 +47,8 @@ demotedLanguageToBase = Language '{0}' is not registered in the local LanguageTo
     this is the expected mapping and both spelling and grammar are checked normally.
 disableAllRulesWithMatchesInSelection = Disable all rules with matches in selection
 disableRule = Disable rule
+environmentVariableNotSet = Environment variable '{0}' referenced by an ltex.languageToolOrg \
+    setting is not set or empty; treating the setting as unset (anonymous checking)
 exitingLtexLs = Exiting ltex-ls...
 followingExceptionOccurred = The following exception occurred:
 fragmentCacheStats = Fragment cache for "{0}": {1} slices, {2} new; cached {3} slices / {4} chars (doc), {5} slices / {6} chars (total); sent {7} chars to LanguageTool in {8} requests

--- a/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
@@ -15,6 +15,7 @@ import java.util.logging.Level
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class SettingsTest {
@@ -148,6 +149,35 @@ class SettingsTest {
     val expandedDirPath = settings.languageModelRulesDirectory
     assertTrue(expandedDirPath.endsWith("tildeExpansion"))
     assertNotEquals(originalDirPath, expandedDirPath)
+  }
+
+  @Test
+  fun testResolveEnvironmentVariableReference() {
+    // Pick an environment variable that is actually set and whose name matches
+    // the reference grammar, so the test does not depend on a hard-coded name.
+    val setEntry: Map.Entry<String, String>? =
+      System.getenv().entries.firstOrNull {
+        Regex("""^[A-Za-z_][A-Za-z0-9_]*$""").matches(it.key) && it.value.isNotEmpty()
+      }
+    assertNotNull(setEntry, "expected at least one usable environment variable")
+    val name: String = setEntry.key
+
+    // Whole-value reference resolves to the variable's value, in both getters.
+    var settings = Settings().copy(_languageToolOrgApiKey = "\${$name}")
+    assertEquals(setEntry.value, settings.languageToolOrgApiKey)
+    settings = Settings().copy(_languageToolOrgUsername = "\${$name}")
+    assertEquals(setEntry.value, settings.languageToolOrgUsername)
+
+    // A reference to an unset variable degrades to the empty string (anonymous).
+    settings = Settings().copy(_languageToolOrgApiKey = "\${LTEX_DEFINITELY_UNSET_VAR_XYZ}")
+    assertEquals("", settings.languageToolOrgApiKey)
+
+    // Non-reference values are returned verbatim: a plain literal, and a value
+    // that merely contains "${" without being a whole-value reference.
+    settings = Settings().copy(_languageToolOrgApiKey = "literal-key")
+    assertEquals("literal-key", settings.languageToolOrgApiKey)
+    settings = Settings().copy(_languageToolOrgApiKey = "prefix-\${$name}")
+    assertEquals("prefix-\${$name}", settings.languageToolOrgApiKey)
   }
 
   @Test


### PR DESCRIPTION
## Problem

LanguageTool Premium credentials are configured via the `ltex.languageToolOrg.username` and `ltex.languageToolOrg.apiKey` settings. Today these are consumed as **literal strings**: whatever value the editor sends in its settings JSON is forwarded verbatim to the LanguageTool server (`LanguageToolHttpInterface.kt:153-158`).

That forces users who keep their editor configuration in a public/synced repository to either embed their secret API key in a shared file or set the credentials per project by hand. Requested in [ltex-plus/ltex-ls-plus#112](https://github.com/ltex-plus/ltex-ls-plus/issues/112):

> It would be really useful to have something like `usernameCommand` and `apiKeyCommand` that run a command or pull from an environment variable to get the values at runtime. That way I can keep my configs public without exposing secrets.

There was no server-side substitution point for this. `Settings.kt` parsed the credentials straight from JSON with no expansion, so exporting an environment variable in the shell that launched the editor had no effect — the server had no code that looked at it.

## Solution

Allow either credential setting to be written as a **whole-value environment-variable reference** of the form `${ENV_VAR}`:

```jsonc
{
  "ltex.languageToolOrg.username": "${LANGUAGETOOL_USERNAME}",
  "ltex.languageToolOrg.apiKey":   "${LANGUAGETOOL_API_KEY}"
}
```

The public config references a variable name; the secret itself lives only in the environment of the process that launches the server. The user chooses the variable name — nothing is hardcoded.

### Design notes

- **Explicit reference, not an implicit fallback.** The server touches the environment *only* when a setting value is itself a `${...}` reference. There is no "if the setting is empty, secretly read `$SOME_FIXED_NAME`" behavior, so an unrelated variable that happens to be exported can never silently authenticate the server.
- **No shell, no injection surface.** Resolution is a plain `System.getenv(name)` lookup — never `sh -c` or any form of command evaluation. Unlike a `*Command` runner, there is nothing to escape and nothing to inject.
- **Whole-value match only.** The reference must be the *entire* setting value (`^\$\{([A-Za-z_][A-Za-z0-9_]*)}$`). There is no inline interpolation, so a literal credential that merely contains the characters `${` is never altered, and there are no partial-expansion edge cases.
- **Graceful degradation.** A reference to an unset or empty variable resolves to the empty string — degrading to anonymous checking — and logs a warning, rather than sending the literal `${...}` placeholder to the LanguageTool server (which would produce a confusing auth failure).
- **Hook point: the getters.** Resolution happens in the `languageToolOrgUsername` / `languageToolOrgApiKey` getters, so every consumer sees the resolved value consistently: the HTTP interface, the `FragmentCache` content fingerprint (which is SHA-256 hashed — the resolved secret is never stored or logged in cleartext), and the settings-equality check that decides when to rebuild the LanguageTool interface. The credential value is not emitted to any log, so resolving in the getter introduces no leak.

## ⚠️ Not to be confused with the test-unit environment variables

This feature is **unrelated to, and must not be conflated with**, the `LANGUAGETOOL_USERNAME` / `LANGUAGETOOL_API_KEY` environment variables already used by the test suite.

Before this change, the *only* place in the entire tree that read an environment variable for credentials was the **test code** — `LanguageToolPremiumIntegrationTest.kt:132-133` — which calls `System.getenv("LANGUAGETOOL_USERNAME")` / `System.getenv("LANGUAGETOOL_API_KEY")` to build a `Settings` object for the Premium integration test (and the matching `RequirePremiumCredentials` gate that skips the test cleanly when they are absent). Those names are also wired into CI as GitHub secrets (`.github/workflows/ci.yml`, `nightly.yml`).

That test-only mechanism:

- reads **fixed, hardcoded** variable names (`LANGUAGETOOL_USERNAME` / `LANGUAGETOOL_API_KEY`),
- exists purely to feed the integration test, and
- has **no effect on the production server**, which never read those variables.

This PR's mechanism, by contrast:

- lets the **user choose any variable name** via an explicit `${...}` reference in their settings,
- operates in the **production settings path** consumed by every editor client, and
- does **not** introduce any fixed-name fallback — so it does not, and is not meant to, give the running server access to the credentials the test harness uses.

In short: the test variables are an internal CI/test detail; this feature is a user-facing settings capability that happens to also read the environment. They share the idea of "credentials from the environment" but are otherwise separate code paths with separate semantics.

## Changes

- **`src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt`** — `languageToolOrgUsername` / `languageToolOrgApiKey` getters route through a new private `resolveEnvironmentVariableReference(...)`; whole-value `${NAME}` regex + `System.getenv`; empty-string + warning on unset.
- **`src/main/resources/LtexLsMessagesBundle.properties`** — new `environmentVariableNotSet` warning message.
- **`src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt`** — new `testResolveEnvironmentVariableReference`: resolution in both getters, unset → empty, plain literal passed through verbatim, and a `prefix-${VAR}` value left untouched (proving whole-value-only matching).
- **`changelog.xml`** — `add` entry citing #112.

## Testing

`mvn -Dtest=SettingsTest test` → 9/9 pass, including the new test. The existing literal round-trip assertions for both credential settings are unaffected (literal values do not match the `${...}` grammar and pass through unchanged).
