### PR TITLE
Support multi-word dictionary entries via pre-LanguageTool masking

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolInterface.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolInterface.kt
@@ -13,27 +13,15 @@ import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 abstract class LanguageToolInterface {
   // Per-language buckets, keyed by `<lang>` or `<lang>-<REGION>`. The match-time
   // filter looks these up using `annotatedTextFragment.codeFragment.languageShortCode`
-  // so that dictionary / disabled-rule suppression keys correctly under the
-  // *detected* language when ltex.language="auto" — including the HTTP path,
-  // where detection happens server-side and the session-wide
-  // settings.languageShortCode stays at the literal "auto".
+  // so that disabled-rule suppression keys correctly under the *detected*
+  // language when ltex.language="auto" — including the HTTP path, where
+  // detection happens server-side and the session-wide settings.languageShortCode
+  // stays at the literal "auto".
   //
-  // The user dictionary buckets are stored verbatim. The add path
-  // (CodeActionProvider) sends bare words to the client in the "Add to
-  // dictionary" command — for matches from rule families that emit
-  // punctuation-adjacent spans (Premium QB_NEW_* / AI_*) the matched
-  // substring is stripped via DictionaryWord.normalize before being persisted,
-  // so the on-disk entry is the bare word. For every other rule family the
-  // substring is already bare and is persisted as-is. The server cannot
-  // enforce what the client actually writes to disk, but the reference
-  // clients write what we send.
-  //
-  // Hand-edited entries are intentionally left untouched at load time: the
-  // file on disk is the user's data and may carry punctuation or whitespace
-  // by deliberate choice. Normalization on the check side happens only when
-  // the match's rule id falls into the Premium punctuation-adjacent family —
-  // see isCoveredByDictionary below.
-  var allDictionaries: Map<String, Set<String>> = emptyMap()
+  // Note: the user dictionary is no longer consulted here. Dictionary words are
+  // masked out of the text before it reaches LanguageTool (see
+  // CodeAnnotatedTextBuilder / DictionaryMasker), so no match is ever produced
+  // for them and there is nothing to suppress after the fact.
   var allDisabledRules: Map<String, Set<String>> = emptyMap()
 
   var languageToolOrgUsername = ""
@@ -54,51 +42,8 @@ abstract class LanguageToolInterface {
     match: LanguageToolRuleMatch,
   ): Boolean {
     val fragmentLanguage: String = annotatedTextFragment.codeFragment.languageShortCode
-    val dictionary: Set<String> = this.allDictionaries[fragmentLanguage] ?: emptySet()
     val disabledRules: Set<String> = this.allDisabledRules[fragmentLanguage] ?: emptySet()
-    return !disabledRules.contains(match.ruleId) &&
-      (
-        !match.isUnknownWordRule() ||
-          !isCoveredByDictionary(annotatedTextFragment, match, dictionary)
-      )
-  }
-
-  // Suppress a match if the per-language dictionary contains the flagged word.
-  //
-  // The lookup key depends on which rule family fired the match. Premium's
-  // QB_NEW_* / AI_* families sometimes emit spans that include adjacent
-  // punctuation, e.g. `amazng!` (length 7) or `"amazng"` (length 8); for
-  // those rules we strip leading/trailing non-letter-non-digit characters
-  // via DictionaryWord.normalize so a single stored entry `amazng` suppresses
-  // every punctuation-context variant.
-  //
-  // For every other rule family (Morfologik / Hunspell / *_SPELLER_RULE /
-  // Slovak gender rules / _SIMPLE_REPLACE_) the span is already bare and we
-  // look it up literally — gaining a stronger no-behavior-change guarantee
-  // for free-LT and local-Java users: not just a no-op normalize call but
-  // no normalize call at all on those code paths.
-  //
-  // Multi-word phrase entries (e.g. a hand-typed `"LTEX LS"`, or the local
-  // Java backend's all-caps Morfologik collapse on `LTEX LS`) still suppress:
-  // those matches fall in the literal branch, and the dictionary holds the
-  // phrase verbatim.
-  //
-  // An entirely-punctuation span normalizes to "" (Premium branch) and is
-  // treated as not covered; the diagnostic stays visible. The user can
-  // disable the rule or fix the text in that exotic case.
-  private fun isCoveredByDictionary(
-    annotatedTextFragment: AnnotatedTextFragment,
-    match: LanguageToolRuleMatch,
-    dictionary: Set<String>,
-  ): Boolean {
-    val span: String = annotatedTextFragment.getSubstringOfPlainText(match.fromPos, match.toPos)
-    val lookupKey: String =
-      if (LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)) {
-        DictionaryWord.normalize(span)
-      } else {
-        span
-      }
-    return lookupKey.isNotEmpty() && dictionary.contains(lookupKey)
+    return !disabledRules.contains(match.ruleId)
   }
 
   abstract fun isInitialized(): Boolean

--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolJavaInterface.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolJavaInterface.kt
@@ -37,7 +37,6 @@ class LanguageToolJavaInterface(
   languageShortCode: String,
   motherTongueShortCode: String,
   sentenceCacheSize: Long,
-  dictionary: Set<String>,
 ) : LanguageToolInterface() {
   // null when sentenceCacheSize <= 0, which disables LanguageTool's internal
   // per-sentence ResultCache. LTeX's own per-paragraph FragmentCache supersedes
@@ -61,7 +60,10 @@ class LanguageToolJavaInterface(
         } else {
           null
         }
-      val userConfig = UserConfig(dictionary.toList())
+      // The user dictionary is masked out of the text upstream (DictionaryMasker),
+      // so LanguageTool needs no acceptedWords list here — masking is the single,
+      // backend-agnostic mechanism (the HTTP backend has no UserConfig at all).
+      val userConfig = UserConfig(emptyList<String>())
 
       this.languageTool = JLanguageTool(language, motherTongue, this.resultCache, userConfig)
     } else {

--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.kt
@@ -203,11 +203,13 @@ data class LanguageToolRuleMatch(
     // already matches verbatim and no normalization is needed.
     //
     // The dictionary add path (CodeActionProvider.getAddWordToDictionaryCodeAction)
-    // and check path (LanguageToolInterface.isCoveredByDictionary) consult this
-    // predicate to decide whether to normalize the span before persisting or
-    // looking up. Mirrors the rule-family allowlist convention used by
-    // isUnknownWordRule above; if Premium adds new rule families that include
-    // adjacent punctuation, extend this allowlist accordingly.
+    // consults this predicate to decide whether to normalize the span before
+    // persisting, so the on-disk entry is the bare word. (The former check-path
+    // lookup is gone: dictionary words are now masked out of the text before
+    // LanguageTool sees them — see DictionaryMasker.) Mirrors the rule-family
+    // allowlist convention used by isUnknownWordRule above; if Premium adds new
+    // rule families that include adjacent punctuation, extend this allowlist
+    // accordingly.
     fun isPremiumPunctuationAdjacentSpanRule(ruleId: String?): Boolean =
       (ruleId != null) &&
         (ruleId.startsWith("QB_NEW_") || ruleId.startsWith("AI_"))

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CharacterBasedCodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CharacterBasedCodeAnnotatedTextBuilder.kt
@@ -8,7 +8,6 @@
 
 package org.bsplines.ltexls.parsing
 
-import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
 
@@ -24,22 +23,12 @@ abstract class CharacterBasedCodeAnnotatedTextBuilder(
     protected set
   val codeMode = CodeModeHandler()
 
-  protected var dummyGenerator = DummyGenerator.getInstance()
-  protected var dummyCounter = 0
-
-  protected var language: String = "en-US"
-
   var isPreventingInfiniteLoops = false
 
   var curString = ""
     protected set
   var isStartOfLine = false
     protected set
-
-  override fun setSettings(settings: Settings) {
-    super.setSettings(settings)
-    this.language = settings.languageShortCode
-  }
 
   override fun addText(text: String?): CharacterBasedCodeAnnotatedTextBuilder {
     if (text?.isNotEmpty() == true) {

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
@@ -36,6 +36,18 @@ abstract class CodeAnnotatedTextBuilder(
   protected var curInterpretAs = StringBuilder()
   protected var curType: TextPart.Type? = null
 
+  // Dummy-token state, shared by every subclass so that markup dummies (e.g.
+  // inline math `$x$`) and dictionary-masking dummies draw from one monotonic
+  // counter — two identical adjacent dummy tokens would otherwise trip
+  // LanguageTool's repeated-word rule.
+  protected var language: String = "en-US"
+  protected var dummyGenerator: DummyGenerator = DummyGenerator.getInstance()
+  protected var dummyCounter = 0
+
+  // null when the per-language dictionary is empty (the common case), so the
+  // TEXT fast path stays a single super.addText() with zero overhead.
+  protected var dictionaryMasker: DictionaryMasker? = null
+
   abstract fun addCode(code: String): CodeAnnotatedTextBuilder
 
   open fun addComment(
@@ -50,8 +62,23 @@ abstract class CodeAnnotatedTextBuilder(
     return this
   }
 
-  @Suppress("UNUSED_PARAMETER")
   open fun setSettings(settings: Settings) {
+    this.language = settings.languageShortCode
+    // Normally mask only the current language's dictionary. Under
+    // ltex.language="auto" the language is resolved later (server-side on the
+    // HTTP path), so settings.dictionary — keyed on the literal "auto" — is
+    // empty at build time; fall back to masking the union of every language's
+    // entries so a user-added word is still honoured on the first check.
+    val dictionary: Set<String> =
+      if (settings.languageShortCode == "auto") {
+        settings.allDictionaries.values
+          .flatten()
+          .toSet()
+      } else {
+        settings.dictionary
+      }
+    val masker = DictionaryMasker(dictionary)
+    this.dictionaryMasker = if (masker.isEmpty) null else masker
   }
 
   override fun addText(text: String?): CodeAnnotatedTextBuilder {
@@ -108,8 +135,34 @@ abstract class CodeAnnotatedTextBuilder(
       curInterpretAs.clear()
     }
     if (curType == TextPart.Type.TEXT) {
-      super.addText(curText.toString())
+      emitTextWithDictionaryMasking(curText.toString())
       curText.clear()
+    }
+  }
+
+  // Emit a finalized TEXT part, masking any user-dictionary occurrences as
+  // markup with a dummy interpretation (the same mechanism inline math `$x$`
+  // uses), so LanguageTool never sees the dictionary word — single- and
+  // multi-word entries alike — while a real typo after a masked span still
+  // reprojects to the correct source position (the dummy contributes plain-text
+  // length but zero source offset).
+  private fun emitTextWithDictionaryMasking(text: String) {
+    val masker: DictionaryMasker? = this.dictionaryMasker
+
+    if (masker == null) {
+      super.addText(text)
+      return
+    }
+
+    for (segment: DictionaryMasker.Segment in masker.split(text)) {
+      if (segment.masked) {
+        super.addMarkup(
+          segment.text,
+          this.dummyGenerator.generate(this.language, this.dummyCounter++),
+        )
+      } else {
+        super.addText(segment.text)
+      }
     }
   }
 

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
@@ -1,0 +1,92 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.parsing
+
+// Splits a run of plain text into verbatim and "masked" segments based on the
+// user dictionary, so that masked segments can be replaced by a dummy token
+// before the text reaches LanguageTool. This is what gives LTeX+ multi-word
+// dictionary support: LanguageTool checks the text per token and never sees a
+// phrase like `GreenTeam Penciltest` as a unit, so a phrase entry can only be
+// honoured by removing its occurrences from the text up front.
+//
+// A dictionary entry matches only as a whole token sequence: the characters
+// immediately before and after the matched span must not be letters or digits
+// (Unicode-aware, via Char.isLetterOrDigit() — not a regex `\b`, whose `\w` is
+// ASCII-only and mishandles accented letters). So `GreenTeam` is not masked
+// inside `GreenTeamer`, and surrounding punctuation (`(GreenTeam Penciltest).`)
+// is left untouched. Matching is case-sensitive, preserving the exact semantics
+// of the former `dictionary.contains(span)` suppression. On overlap the longest
+// entry wins, so a lone `GreenTeam` is masked only when `GreenTeam` is itself an
+// entry — not as a by-product of the phrase entry `GreenTeam Penciltest`.
+class DictionaryMasker(
+  dictionary: Set<String>,
+) {
+  data class Segment(
+    val text: String,
+    val masked: Boolean,
+  )
+
+  // Longest first so the longest matching entry wins on overlap; blank entries
+  // dropped (a whitespace-only entry would otherwise try to mask runs of space).
+  private val entries: List<String> =
+    dictionary.filter { it.isNotBlank() }.sortedByDescending { it.length }
+
+  val isEmpty: Boolean = entries.isEmpty()
+
+  fun split(text: String): List<Segment> {
+    if (entries.isEmpty() || text.isEmpty()) return listOf(Segment(text, false))
+
+    val segments = ArrayList<Segment>()
+    var emittedUpTo = 0
+    var pos = 0
+
+    while (pos < text.length) {
+      val matchEnd: Int = matchAt(text, pos)
+
+      if (matchEnd < 0) {
+        pos++
+      } else {
+        if (pos > emittedUpTo) segments.add(Segment(text.substring(emittedUpTo, pos), false))
+        segments.add(Segment(text.substring(pos, matchEnd), true))
+        emittedUpTo = matchEnd
+        pos = matchEnd
+      }
+    }
+
+    if (emittedUpTo < text.length) segments.add(Segment(text.substring(emittedUpTo), false))
+    return segments
+  }
+
+  // Exclusive end offset of the longest entry matching [text] at [start] on
+  // whole-token boundaries, or -1 if none matches there. `entries` is sorted
+  // longest-first, so the first match found is the longest one.
+  private fun matchAt(
+    text: String,
+    start: Int,
+  ): Int {
+    if ((start > 0) && text[start - 1].isLetterOrDigit()) return -1
+    val entry: String? = entries.firstOrNull { entryMatchesAt(text, start, it) }
+    return if (entry != null) (start + entry.length) else -1
+  }
+
+  // Does [entry] occur literally at [start] in [text] with a trailing token
+  // boundary? (The leading boundary is already guaranteed by the caller.)
+  private fun entryMatchesAt(
+    text: String,
+    start: Int,
+    entry: String,
+  ): Boolean {
+    val end: Int = start + entry.length
+    if (end > text.length) return false
+    val matchesLiterally: Boolean =
+      text.regionMatches(start, entry, 0, entry.length, ignoreCase = false)
+    val trailingBoundaryOk: Boolean = (end >= text.length) || !text[end].isLetterOrDigit()
+    return matchesLiterally && trailingBoundaryOk
+  }
+}

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
@@ -60,10 +60,8 @@ class MarkdownAnnotatedTextBuilder(
   private val parser: Parser = Parser.builder(PARSER_OPTIONS).build()
   private var code = ""
   private var pos = 0
-  private var dummyCounter = 0
   private var firstCellInTableRow = false
   private val nodeTypeStack = ArrayDeque<String>()
-  private var language: String = "en-US"
   private var shadowMarkups = listOf<Triple<String, Int, Int>>()
   private var shadowOffset = 0
   private val nodeSignatures: MutableList<MarkdownNodeSignature> =
@@ -328,7 +326,6 @@ class MarkdownAnnotatedTextBuilder(
 
   override fun setSettings(settings: Settings) {
     super.setSettings(settings)
-    this.language = settings.languageShortCode
 
     for ((nodeName: String, actionString: String) in settings.markdownNodes) {
       var dummyGenerator: DummyGenerator = DummyGenerator.getInstance()

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/program/ProgramAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/program/ProgramAnnotatedTextBuilder.kt
@@ -43,10 +43,12 @@ class ProgramAnnotatedTextBuilder(
   private val commentBlockRegex: Regex = commentRegexs.commentBlockRegex
   private val lineCommentPatternString: String? = commentRegexs.lineCommentRegexString
 
-  // This builder only wraps the inner Markdown/reStructuredText builder (addCode
-  // and build delegate to it), so settings must be forwarded there — otherwise
-  // the inner builder never receives ltex.language (used to pick dummy tokens)
-  // or ltex.markdownNodes for prose inside comments/docstrings.
+  // This builder is a pure wrapper: addCode/build delegate to the inner
+  // Markdown/reStructuredText builder, so settings must be configured on that
+  // inner builder, not on this outer shell whose own AnnotatedTextBuilder state
+  // is never used. Otherwise the inner builder never receives ltex.language
+  // (used to pick dummy tokens), ltex.markdownNodes, or the dictionary masker
+  // for prose inside comments/docstrings.
   override fun setSettings(settings: Settings) {
     annotatedTextBuilder.setSettings(settings)
   }

--- a/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
@@ -218,12 +218,11 @@ class CodeActionProvider(
       // Strip leading/trailing punctuation only when the match's rule family
       // is known to emit punctuation-adjacent spans (Premium's QB_NEW_* /
       // AI_*); for everyone else the span is already bare and we persist it
-      // verbatim. Same gate runs on the check path
-      // (LanguageToolInterface.isCoveredByDictionary) so the round-trip is
-      // symmetric — a word added under one rule family looks up correctly
-      // when seen again under the same family. Skip the match if the
-      // normalized form is empty (entirely-punctuation span — should never
-      // happen for a real spell-check rule).
+      // verbatim. Persisting the bare word is what lets DictionaryMasker mask
+      // it back out of the text on the next check (whole-token, case-sensitive
+      // matching). Skip the match if the normalized form is empty
+      // (entirely-punctuation span — should never happen for a real
+      // spell-check rule).
       val word: String =
         if (LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)) {
           DictionaryWord.normalize(matchedText)

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsManager.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsManager.kt
@@ -45,7 +45,6 @@ class SettingsManager {
           this.languageToolInterface
         }
 
-      languageToolInterface?.allDictionaries = value.allDictionaries
       languageToolInterface?.allDisabledRules = value.allDisabledRules
       languageToolInterface?.languageToolOrgUsername = value.languageToolOrgUsername
       languageToolInterface?.languageToolOrgApiKey = value.languageToolOrgApiKey
@@ -78,7 +77,6 @@ class SettingsManager {
           this.settings.languageShortCode,
           this.settings.motherTongueShortCode,
           this.settings.sentenceCacheSize,
-          this.settings.dictionary,
         )
       } else {
         LanguageToolHttpInterface(

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
@@ -1,0 +1,145 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.parsing
+
+import org.bsplines.ltexls.settings.Settings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DictionaryMaskerTest {
+  private fun split(
+    dictionary: Set<String>,
+    text: String,
+  ): List<Pair<String, Boolean>> =
+    DictionaryMasker(dictionary).split(text).map { Pair(it.text, it.masked) }
+
+  @Test
+  fun emptyDictionaryIsNoOp() {
+    val masker = DictionaryMasker(emptySet())
+    assertTrue(masker.isEmpty)
+    assertEquals(listOf(Pair("hello world", false)), split(emptySet(), "hello world"))
+  }
+
+  @Test
+  fun blankEntriesAreDropped() {
+    assertTrue(DictionaryMasker(setOf("", "  ", "\t")).isEmpty)
+  }
+
+  @Test
+  fun singleWordIsMaskedOnWholeTokenBoundaries() {
+    assertEquals(
+      listOf(Pair("I met ", false), Pair("GreenTeam", true), Pair(" today.", false)),
+      split(setOf("GreenTeam"), "I met GreenTeam today."),
+    )
+  }
+
+  @Test
+  fun singleWordNotMaskedInsideLongerWord() {
+    // "GreenTeam" must not match inside "GreenTeamer" / "aGreenTeam".
+    assertEquals(
+      listOf(Pair("a GreenTeamer b", false)),
+      split(setOf("GreenTeam"), "a GreenTeamer b"),
+    )
+    assertEquals(listOf(Pair("a aGreenTeam b", false)), split(setOf("GreenTeam"), "a aGreenTeam b"))
+  }
+
+  @Test
+  fun multiWordPhraseIsMaskedWhenAdjacent() {
+    assertEquals(
+      listOf(Pair("the ", false), Pair("GreenTeam Penciltest", true), Pair(" firm", false)),
+      split(setOf("GreenTeam Penciltest"), "the GreenTeam Penciltest firm"),
+    )
+  }
+
+  @Test
+  fun loneFirstWordNotMaskedWhenOnlyPhraseIsAnEntry() {
+    // The whole point of multi-word support: a bare "GreenTeam" stays visible
+    // unless "GreenTeam" is itself an entry.
+    assertEquals(
+      listOf(Pair("a GreenTeam here", false)),
+      split(setOf("GreenTeam Penciltest"), "a GreenTeam here"),
+    )
+  }
+
+  @Test
+  fun longestEntryWinsOnOverlap() {
+    // Both "GreenTeam" and the phrase are entries; the phrase wins where present.
+    assertEquals(
+      listOf(Pair("GreenTeam Penciltest", true)),
+      split(setOf("GreenTeam", "GreenTeam Penciltest"), "GreenTeam Penciltest"),
+    )
+    // ...but a lone "GreenTeam" is still masked because it is also an entry.
+    assertEquals(
+      listOf(Pair("GreenTeam", true), Pair(" alone", false)),
+      split(setOf("GreenTeam", "GreenTeam Penciltest"), "GreenTeam alone"),
+    )
+  }
+
+  @Test
+  fun matchingIsCaseSensitive() {
+    assertEquals(
+      listOf(Pair("greenteam penciltest", false)),
+      split(setOf("GreenTeam Penciltest"), "greenteam penciltest"),
+    )
+  }
+
+  @Test
+  fun surroundingPunctuationIsPreserved() {
+    assertEquals(
+      listOf(Pair("(", false), Pair("GreenTeam Penciltest", true), Pair(").", false)),
+      split(setOf("GreenTeam Penciltest"), "(GreenTeam Penciltest)."),
+    )
+  }
+
+  @Test
+  fun unicodeWordBoundariesAreRespected() {
+    // Accented letters are word characters (Char.isLetterOrDigit, not ASCII \b),
+    // so "café" is not masked inside "cafés", but a standalone accented entry is.
+    assertEquals(listOf(Pair("les cafés ici", false)), split(setOf("café"), "les cafés ici"))
+    assertEquals(
+      listOf(Pair("un ", false), Pair("café", true), Pair(" noir", false)),
+      split(setOf("café"), "un café noir"),
+    )
+  }
+
+  // --- builder-level wiring (PlaintextAnnotatedTextBuilder is verbatim, so the
+  // plain text shows the dummy substituted for the masked span) ---
+
+  private fun plainTextWithDictionary(
+    code: String,
+    dictionary: Set<String>,
+  ): String {
+    val builder: CodeAnnotatedTextBuilder = CodeAnnotatedTextBuilder.create("plaintext")
+    builder.setSettings(Settings(_allDictionaries = mapOf(Pair("en-US", dictionary))))
+    return builder.addCode(code).build().plainText
+  }
+
+  @Test
+  fun builderMasksMultiWordEntryWithDummy() {
+    assertEquals(
+      "I met Dummy0 today.\n",
+      plainTextWithDictionary("I met GreenTeam Penciltest today.\n", setOf("GreenTeam Penciltest")),
+    )
+  }
+
+  @Test
+  fun builderLeavesLoneWordUnmasked() {
+    assertEquals(
+      "I met GreenTeam today.\n",
+      plainTextWithDictionary("I met GreenTeam today.\n", setOf("GreenTeam Penciltest")),
+    )
+  }
+
+  @Test
+  fun builderWithoutDictionaryIsUnchanged() {
+    assertFalse(plainTextWithDictionary("I met GreenTeam today.\n", emptySet()).contains("Dummy"))
+  }
+}

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilderTest.kt
@@ -9,9 +9,38 @@
 package org.bsplines.ltexls.parsing.program
 
 import org.bsplines.ltexls.parsing.CodeAnnotatedTextBuilderTest
+import org.bsplines.ltexls.settings.Settings
 import kotlin.test.Test
 
 class ElispAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("elisp") {
+  @Test
+  fun testDictionaryEntriesAreMaskedInCommentsAndDocstrings() {
+    // User-dictionary words are masked (replaced by a dummy) before the prose
+    // reaches LanguageTool. This exercises the elisp path end to end: it only
+    // works because ElispAnnotatedTextBuilder forwards setSettings to its inner
+    // Markdown builder, which builds the masker. Multi-word entries work because
+    // the phrase is contiguous in the comment/docstring text; longest-match-wins
+    // masks the whole "GreenTeam Penciltest" rather than the bare "GreenTeam".
+    val dictionary =
+      Settings(_allDictionaries = mapOf("en-US" to setOf("GreenTeam Penciltest", "GreenTeam")))
+
+    // Multi-word entry inside a line comment.
+    assertPlainText(
+      ";; The GreenTeam Penciltest audit was thorough.\n",
+      "\n\n\nThe Dummy0 audit was thorough.",
+      "elisp",
+      dictionary,
+    )
+
+    // Single-word entry inside a defun docstring.
+    assertPlainText(
+      "(defun foo ()\n  \"Run the GreenTeam audit now.\"\n  nil)\n",
+      "\n\n\nRun the Dummy0 audit now.",
+      "elisp",
+      dictionary,
+    )
+  }
+
   @Test
   fun testComments() {
     // Trailing/inline comments after code (line 1) ARE checked for elisp.

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -574,13 +574,22 @@ class DocumentCheckerTest {
     checkingResult = checkDocument(document, settings)
     assertEquals(0, checkingResult.first.size)
 
-    document = createDocument("markdown", "This is LT<sub>E</sub>X LS.\n")
+    // Multi-word dictionary entry: the phrase is masked out before LanguageTool
+    // sees it, so a contiguous phrase is accepted as a unit, while a lone first
+    // word stays flagged. (A phrase split by markup in the source — e.g.
+    // `LT<sub>E</sub>X LS` — is not covered by this plain-text masking; matching
+    // verbatim source-form entries is handled separately.)
+    document = createDocument("markdown", "This is GreenTeam Penciltest here.\n")
     settings = Settings()
     checkingResult = checkDocument(document, settings)
-    assertEquals(1, checkingResult.first.size)
-    settings = settings.copy(_allDictionaries = mapOf(Pair("en-US", setOf("LTEX LS"))))
+    assertTrue(checkingResult.first.isNotEmpty())
+    settings = settings.copy(_allDictionaries = mapOf(Pair("en-US", setOf("GreenTeam Penciltest"))))
     checkingResult = checkDocument(document, settings)
     assertEquals(0, checkingResult.first.size)
+
+    document = createDocument("markdown", "This is GreenTeam here.\n")
+    checkingResult = checkDocument(document, settings)
+    assertEquals(1, checkingResult.first.size)
   }
 
   @Test


### PR DESCRIPTION
Closes #141.

## Problem

Users want multi-word dictionary entries — e.g. a company/product name like
`GreenTeam Penciltest` should be accepted only when the words appear **together**,
while a lone `GreenTeam` is still flagged.

This didn't work before: LanguageTool tokenises the text and checks each word on
its own, flagging `GreenTeam` and `Penciltest` as two independent spelling
mistakes. LTeX+ suppressed dictionary words by comparing each match's span
against the dictionary, so a multi-word entry never equalled a single-word span
and the second word stayed flagged.

(We deliberately do **not** use LanguageTool's per-account premium dictionary:
it is premium-only, has no local equivalent, and would require syncing words to
a remote server — a lot of new code for divergent behaviour across backends.)

## Approach

Mask user-dictionary occurrences as **dummy markup before the text reaches
LanguageTool** — the same mechanism already used for inline LaTeX math (`$x$`).
A new `DictionaryMasker` scans each finalized text run and replaces dictionary
entries (single- or multi-word) with a dummy interpretation token, so
LanguageTool never sees them and emits no match to suppress.

This collapses three previous, partial mechanisms (the post-LT filter, the Java
backend's `UserConfig` dictionary, and the would-be premium sync) into **one
client-side mechanism that behaves identically on the local and HTTP backends**.

## Advantages

- **Multi-word entries work:** `GreenTeam Penciltest` is accepted as a unit, while
  a lone `GreenTeam` is still flagged.
- **One mechanism, all backends:** local Java, free HTTP and premium HTTP behave
  identically; no dependence on the premium per-account dictionary, no remote sync.
- **Single words keep working,** case-sensitively, matching the previous
  `dictionary.contains` semantics.
- **Simpler:** one masking path instead of a post-LT filter plus `UserConfig`.

## Known limitations

### 1. A multi-word entry whose words are split by markup in the *source* is not masked

To see why, follow what happens to `This is LT<sub>E</sub>X LS.` in a Markdown
document. (`LT<sub>E</sub>X LS` renders as "LTEX LS" with a subscript E — the kind
of inline-markup-inside-a-word case this limitation is about.)

1. **Parse** — the parser separates markup from text. The `<sub>` / `</sub>` tags
   become *markup*; the letters become *text*. Because the tags sit **inside** the
   word, the text is split into three fragments:
   `This is LT` · *(markup `<sub>`)* · `E` · *(markup `</sub>`)* · `X LS.`
2. **Mask** — the dictionary scanner runs on each text fragment **independently**,
   as the parser finalizes it. None of the three fragments contains `LTEX LS`, so
   there is nothing to mask.
3. **Assemble & check** — only now are the fragments joined, with markup dropped,
   into the plain text sent to LanguageTool: `This is LTEX LS.`. LanguageTool
   collapses the consecutive all-caps tokens into one span and flags `LTEX LS`.

The contiguous string `LTEX LS` therefore exists only *after* assembly, which is
downstream of the scanner. Consequently:

- Adding `LTEX LS` to the dictionary does **not** help — the scanner never sees
  that string as a unit (it only appears post-assembly, which the scanner doesn't
  re-scan).
- Adding the raw source form `LT<sub>E</sub>X LS` does **not** help either — the
  scanner runs on the *plain-text output* produced by the parser flexmark-java,
  not the raw source.

**Consequence:** multi-word entries are honoured only when their words are
**contiguous in the source** — no markup, command, or comment break between them.
This is the normal case for prose names like `GreenTeam Penciltest`. Covering the
split case would require matching the raw source verbatim *before* parsing
(a per-parser, structure-blind pre-pass), judged too narrow to justify here.

### 2. Under `ltex.language=auto`, the union of all configured dictionaries is masked

Masking happens *before* the text is sent to LanguageTool, but in `auto` mode the
language is only decided *afterwards* (the LanguageTool server detects it from the
text). At masking time we don't yet know which per-language dictionary applies, so
we mask the **union** of entries across all configured languages.

This is robust: whichever language LanguageTool ends up choosing, that language's
entries are already in the union, so suppression works on the very first check.
The trade-off is that it is slightly broader than per-language suppression — a word
added under `de-DE` is also accepted in text detected as `en-US`. For a dictionary
(a list of words the user wants accepted) this is normally the desired behaviour.

### Key changes

- `DictionaryMasker`: whole-word, case-sensitive, longest-match-wins matcher.
  Boundaries use `Char.isLetterOrDigit` (Unicode-correct) rather than regex `\b`,
  whose `\w` is ASCII-only and mishandles accented letters.
- Hooked into the single chokepoint `CodeAnnotatedTextBuilder.finalizeCurrentPart`,
  reusing the existing `DummyGenerator`. The shared `language`/`dummyGenerator`/
  `dummyCounter` were lifted to the base builder so masked-word and markup (`$x$`)
  dummies draw from one counter and can't produce two identical adjacent tokens
  that trip the repeated-word rule.
- Offsets are preserved: the dummy contributes plain-text length but zero source
  length, so a real typo after a masked phrase is still reported at the correct
  position.
- Retired `isCoveredByDictionary` and `UserConfig(dictionary)`. `DictionaryWord`
  is kept — it is still used by the "Add to dictionary" code action.

## Testing

- New `DictionaryMaskerTest`: matcher unit tests (single/multi-word, boundaries,
  case sensitivity, punctuation, Unicode, longest-match-wins) plus builder-level
  plain-text assertions.
- `DocumentCheckerTest.testDictionary` updated to cover contiguous multi-word
  masking and the lone-first-word case.
- Existing auto-language HTTP dictionary-suppression tests pass via union masking.
- `mvn verify` is green — tests, detekt, ktlint and the coverage gate — including
  the premium integration test against the official remote server.