### PR TITLE
Settings files support

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -12,6 +12,8 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import org.bsplines.ltexls.client.LtexLanguageClient
 import org.bsplines.ltexls.parsing.FragmentCache
+import org.bsplines.ltexls.settings.BasicSettingsFileManager
+import org.bsplines.ltexls.settings.SettingsFileManager
 import org.bsplines.ltexls.settings.SettingsManager
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
@@ -35,7 +37,6 @@ import org.eclipse.lsp4j.services.LanguageServer
 import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
 import java.net.URI
-import java.net.URISyntaxException
 import java.nio.file.Path
 import java.time.Instant
 import java.util.Locale
@@ -52,6 +53,7 @@ class LtexLanguageServer :
   var languageClient: LtexLanguageClient? = null
   val singleThreadExecutorService: ExecutorService = Executors.newSingleThreadScheduledExecutor()
   val settingsManager = SettingsManager()
+  val settingsFileManager: SettingsFileManager = BasicSettingsFileManager()
 
   // Shared across all documents; swept periodically and cleared per-document on
   // didClose.
@@ -73,7 +75,7 @@ class LtexLanguageServer :
   var clientSupportsWorkspaceSpecificConfiguration: Boolean = false
     private set
 
-  var workspaceRoots: List<CanonicalizedPath<WorkspaceFolder>> = listOf()
+  var workspaceRoots: List<Canonical<WorkspaceFolder>> = listOf()
 
   init {
     // Sweep idle fragment-cache entries on a fixed 60 s cadence. Entries idle
@@ -165,14 +167,14 @@ class LtexLanguageServer :
     if (clientCapabilities?.workspace?.workspaceFolders == true) {
       val folders: List<WorkspaceFolder>? = params.workspaceFolders
       this.workspaceRoots = folders
-        ?.mapNotNull { CanonicalizedPath.from(it) }
+        ?.mapNotNull { Canonical.from(it) }
         ?: listOf()
     } else {
       // TODO Should we keep holding onto the rootUri? It feels like a reasonable fallback for
       //  clients lacking workspaceFolders support. Otoh it's been superseded by workspaceFolders
       //  since 2018.
       @Suppress("DEPRECATION")
-      val path = CanonicalizedPath.from(WorkspaceFolder(params.rootUri, "root"))
+      val path = Canonical.from(WorkspaceFolder(params.rootUri, "root"))
       this.workspaceRoots = listOfNotNull(path)
     }
 
@@ -207,39 +209,100 @@ class LtexLanguageServer :
 
   override fun getWorkspaceService(): WorkspaceService = this.ltexWorkspaceService
 
+  /**
+   * Guess the most appropriate workspace folder for the current file.
+   * This folder will be used as the root for resolving relative file settings paths.
+   *
+   * For real files, this directory attempts to locate their corresponding workspace root.
+   * If there are multiple candidates, it picks the deepest nested (most specific) one.
+   *
+   * For virtual (for example unnamed / unsaved) files, we use the first root of the workspace.
+   *
+   * If no suitable workspace folder is found, then the user's home directory is used as a last
+   * resort fallback.
+   */
+  fun relativePathRoot(documentUri: String): Path {
+    val documentPath = Canonical.fromUri(documentUri)?.canonicalPath
+
+    if (documentPath != null) {
+      val candidateRoots =
+        this.workspaceRoots
+          .map { it.canonicalPath }
+          .filter { documentPath.startsWith(it) }
+
+      candidateRoots
+        .reduceOrNull { best, curr -> if (best.startsWith(curr)) best else curr }
+        ?.let { return it }
+    } else {
+      // This is a virtual file (unnamed/unsaved). We give it the first available root.
+      this.workspaceRoots.firstOrNull()?.canonicalPath?.let {
+        Logging.LOGGER.info(I18n.format("workspaceFolderFallback", it, documentPath))
+        return it
+      }
+    }
+
+    // We did not find a suitable root for the file. If it was a real file, then it means it was
+    // outside all current workspaces. If it was a virtual file, then it means the workspace itself
+    // is empty. Either way, we need some sane last resort callback, which is the user's home.
+
+    // TODO Do we want to send a window/showMessageRequest to indicate the root chosen?
+    //  or even let the user choose a root if more are available
+    val home = Path.of(System.getProperty("user.home")).toRealPath()
+    Logging.LOGGER.info(I18n.format("workspaceFolderFallback", home, documentPath))
+    return home
+  }
+
+  @ConsistentCopyVisibility
+  data class Canonical<T> private constructor(
+    val canonicalPath: Path,
+    val originalUri: T,
+  ) {
+    companion object {
+      // Ideally (https://youtrack.jetbrains.com/issue/KT-7128) we could multi-catch
+      // URISyntaxException, FileSystemNotFoundException, SecurityException and
+      // IOException. The handling would be the same in all cases though -- log the
+      // error and return null, so I'm just suppressing the compiler error here.
+      @Suppress("TooGenericExceptionCaught")
+      fun fromUri(uriString: String): Canonical<String>? {
+        try {
+          val uri = URI(uriString)
+          val path = Path.of(uri)
+          val canonicalPath = path.normalize().toRealPath()
+          return Canonical(canonicalPath, uriString)
+        } catch (e: Exception) {
+          Logging.LOGGER.warning(
+            I18n.format("cannotCanonicalizeUri", e, uriString),
+          )
+          return null
+        }
+      }
+
+      // Ideally (https://youtrack.jetbrains.com/issue/KT-7128) we could multi-catch
+      // FileSystemNotFoundException, SecurityException and
+      // IOException. The handling would be the same in all cases though -- log the
+      // error and return null, so I'm just suppressing the compiler error here.
+      @Suppress("TooGenericExceptionCaught")
+      fun fromPath(pathString: String): Canonical<String>? {
+        try {
+          val path = Path.of(pathString)
+          val canonicalPath = path.normalize().toRealPath()
+          return Canonical(canonicalPath, pathString)
+        } catch (e: Exception) {
+          Logging.LOGGER.warning(
+            I18n.format("cannotCanonicalizeUri", e, pathString),
+          )
+          return null
+        }
+      }
+
+      fun from(workspaceFolder: WorkspaceFolder): Canonical<WorkspaceFolder>? =
+        fromUri(workspaceFolder.uri)
+          ?.let { Canonical(it.canonicalPath, workspaceFolder) }
+    }
+  }
+
   companion object {
     private const val FRAGMENT_CACHE_SWEEP_INTERVAL_SECONDS = 60L
     private const val MILLIS_PER_MINUTE = 60_000L
-
-    @ConsistentCopyVisibility
-    data class CanonicalizedPath<T> private constructor(
-      val canonicalPath: Path,
-      val originalUri: T,
-    ) {
-      companion object {
-        // Ideally (https://youtrack.jetbrains.com/issue/KT-7128) we could multi-catch
-        // URISyntaxException, FileSystemNotFoundException, SecurityException and
-        // IOException. The handling would be the same in all cases though -- log the
-        // error and return null, so I'm just suppressing the compiler error here.
-        @Suppress("TooGenericExceptionCaught")
-        fun from(uriString: String): CanonicalizedPath<String>? {
-          try {
-            val uri = URI(uriString)
-            val path = Path.of(uri)
-            val canonicalPath = path.normalize().toRealPath()
-            return CanonicalizedPath(canonicalPath, uriString)
-          } catch (e: Exception) {
-            Logging.LOGGER.warning(
-              I18n.format("cannotCanonicalizeUri", e, uriString),
-            )
-            return null
-          }
-        }
-
-        fun from(workspaceFolder: WorkspaceFolder): CanonicalizedPath<WorkspaceFolder>? =
-          from(workspaceFolder.uri)
-            ?.let { CanonicalizedPath(it.canonicalPath, workspaceFolder) }
-      }
-    }
   }
 }

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -34,6 +34,9 @@ import org.eclipse.lsp4j.services.LanguageClientAware
 import org.eclipse.lsp4j.services.LanguageServer
 import org.eclipse.lsp4j.services.TextDocumentService
 import org.eclipse.lsp4j.services.WorkspaceService
+import java.net.URI
+import java.net.URISyntaxException
+import java.nio.file.Path
 import java.time.Instant
 import java.util.Locale
 import java.util.concurrent.CompletableFuture
@@ -70,8 +73,7 @@ class LtexLanguageServer :
   var clientSupportsWorkspaceSpecificConfiguration: Boolean = false
     private set
 
-  var rootUri: String? = null
-  var workspaceFolders: List<WorkspaceFolder>? = null
+  var workspaceRoots: List<CanonicalizedPath<WorkspaceFolder>> = listOf()
 
   init {
     // Sweep idle fragment-cache entries on a fixed 60 s cadence. Entries idle
@@ -154,12 +156,25 @@ class LtexLanguageServer :
     workspaceFoldersOptions.changeNotifications = Either.forRight(true)
     serverCapabilities.workspace = WorkspaceServerCapabilities(workspaceFoldersOptions)
 
-    this.workspaceFolders = params.workspaceFolders
-    // TODO: Should we keep holding onto the rootUri? It feels like a reasonable fallback for
-    // clients lacking workspaceFolders support. Otoh it's been superseded by workspaceFolders
-    // since 2018.
-    @Suppress("DEPRECATION")
-    this.rootUri = params.rootUri
+    // If the client supports workspace folders, then we only use those. Otherwise, we fall
+    // back on the rootUri. Either way, it should be possible to get their canonical paths --
+    // all of them should be file:// URIs pointing to real directories on the machine where the
+    // language server is running.
+    // If we do fail to get the canonical representation of any path, then we just log the reason
+    // and ignore the path.
+    if (clientCapabilities?.workspace?.workspaceFolders == true) {
+      val folders: List<WorkspaceFolder>? = params.workspaceFolders
+      this.workspaceRoots = folders
+        ?.mapNotNull { CanonicalizedPath.from(it) }
+        ?: listOf()
+    } else {
+      // TODO Should we keep holding onto the rootUri? It feels like a reasonable fallback for
+      //  clients lacking workspaceFolders support. Otoh it's been superseded by workspaceFolders
+      //  since 2018.
+      @Suppress("DEPRECATION")
+      val path = CanonicalizedPath.from(WorkspaceFolder(params.rootUri, "root"))
+      this.workspaceRoots = listOfNotNull(path)
+    }
 
     // Advertise the server's identity and version to the client via serverInfo so it can,
     // e.g., gate features on a minimum version. The version is the JAR manifest's
@@ -195,5 +210,36 @@ class LtexLanguageServer :
   companion object {
     private const val FRAGMENT_CACHE_SWEEP_INTERVAL_SECONDS = 60L
     private const val MILLIS_PER_MINUTE = 60_000L
+
+    @ConsistentCopyVisibility
+    data class CanonicalizedPath<T> private constructor(
+      val canonicalPath: Path,
+      val originalUri: T,
+    ) {
+      companion object {
+        // Ideally (https://youtrack.jetbrains.com/issue/KT-7128) we could multi-catch
+        // URISyntaxException, FileSystemNotFoundException, SecurityException and
+        // IOException. The handling would be the same in all cases though -- log the
+        // error and return null, so I'm just suppressing the compiler error here.
+        @Suppress("TooGenericExceptionCaught")
+        fun from(uriString: String): CanonicalizedPath<String>? {
+          try {
+            val uri = URI(uriString)
+            val path = Path.of(uri)
+            val canonicalPath = path.normalize().toRealPath()
+            return CanonicalizedPath(canonicalPath, uriString)
+          } catch (e: Exception) {
+            Logging.LOGGER.warning(
+              I18n.format("cannotCanonicalizeUri", e, uriString),
+            )
+            return null
+          }
+        }
+
+        fun from(workspaceFolder: WorkspaceFolder): CanonicalizedPath<WorkspaceFolder>? =
+          from(workspaceFolder.uri)
+            ?.let { CanonicalizedPath(it.canonicalPath, workspaceFolder) }
+      }
+    }
   }
 }

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.ServerCapabilities
 import org.eclipse.lsp4j.ServerInfo
 import org.eclipse.lsp4j.TextDocumentSyncKind
 import org.eclipse.lsp4j.WindowClientCapabilities
+import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.WorkspaceFoldersOptions
 import org.eclipse.lsp4j.WorkspaceServerCapabilities
 import org.eclipse.lsp4j.jsonrpc.messages.Either
@@ -68,6 +69,9 @@ class LtexLanguageServer :
     private set
   var clientSupportsWorkspaceSpecificConfiguration: Boolean = false
     private set
+
+  var rootUri: String? = null
+  var workspaceFolders: List<WorkspaceFolder>? = null
 
   init {
     // Sweep idle fragment-cache entries on a fixed 60 s cadence. Entries idle
@@ -147,8 +151,15 @@ class LtexLanguageServer :
 
     val workspaceFoldersOptions = WorkspaceFoldersOptions()
     workspaceFoldersOptions.supported = true
-    workspaceFoldersOptions.setChangeNotifications(Either.forRight(true))
+    workspaceFoldersOptions.changeNotifications = Either.forRight(true)
     serverCapabilities.workspace = WorkspaceServerCapabilities(workspaceFoldersOptions)
+
+    this.workspaceFolders = params.workspaceFolders
+    // TODO: Should we keep holding onto the rootUri? It feels like a reasonable fallback for
+    // clients lacking workspaceFolders support. Otoh it's been superseded by workspaceFolders
+    // since 2018.
+    @Suppress("DEPRECATION")
+    this.rootUri = params.rootUri
 
     // Advertise the server's identity and version to the client via serverInfo so it can,
     // e.g., gate features on a minimum version. The version is the JAR manifest's

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentItem.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentItem.kt
@@ -13,8 +13,8 @@ import com.google.gson.JsonObject
 import org.bsplines.ltexls.client.LtexLanguageClient
 import org.bsplines.ltexls.languagetool.LanguageToolRuleMatch
 import org.bsplines.ltexls.parsing.AnnotatedTextFragment
-import org.bsplines.ltexls.server.LtexLanguageServer.Companion.CanonicalizedPath
 import org.bsplines.ltexls.settings.Settings
+import org.bsplines.ltexls.settings.SettingsFileManager
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
 import org.bsplines.ltexls.tools.Tools
@@ -432,11 +432,15 @@ class LtexTextDocumentItem(
         workspaceSpecificConfiguration as JsonElement?
 
       this.raiseExceptionIfCanceled()
-      val relativePathRoot = relativePathRoot()
+      val relativePathRoot = languageServer.relativePathRoot(this.uri)
 
       this.raiseExceptionIfCanceled()
       this.languageServer.settingsManager.settings =
-        Settings.fromJson(jsonConfiguration, jsonWorkspaceSpecificConfiguration)
+        Settings.fromJson(
+          jsonConfiguration,
+          jsonWorkspaceSpecificConfiguration,
+          languageServer.settingsFileManager.rooted(relativePathRoot),
+        )
 
       this.raiseExceptionIfCanceled()
       val checkingResult: Pair<List<LanguageToolRuleMatch>, List<AnnotatedTextFragment>> =
@@ -453,48 +457,6 @@ class LtexTextDocumentItem(
 
       this.beingChecked = false
     }
-  }
-
-  /**
-   * Guess the most appropriate workspace folder for the current file.
-   * This folder will be used as the root for resolving relative file settings paths.
-   *
-   * For real files, this directory attempts to locate their corresponding workspace root.
-   * If there are multiple candidates, it picks the deepest nested (most specific) one.
-   *
-   * For virtual (for example unnamed / unsaved) files, we use the first root of the workspace.
-   *
-   * If no suitable workspace folder is found, then the user's home directory is used as a last
-   * resort fallback.
-   */
-  fun relativePathRoot(): Path {
-    val documentPath = CanonicalizedPath.from(this.uri)?.canonicalPath
-    if (documentPath != null) {
-      val candidateRoots =
-        this.languageServer.workspaceRoots
-          .map { it.canonicalPath }
-          .filter { documentPath.startsWith(it) }
-
-      candidateRoots
-        .reduceOrNull { best, curr -> if (best.startsWith(curr)) best else curr }
-        ?.let { return it }
-    } else {
-      // This is a virtual file (unnamed/unsaved). We give it the first available root.
-      this.languageServer.workspaceRoots.firstOrNull()?.canonicalPath?.let {
-        Logging.LOGGER.info(I18n.format("workspaceFolderFallback", it, documentPath))
-        return it
-      }
-    }
-
-    // We did not find a suitable root for the file. If it was a real file, then it means it was
-    // outside all current workspaces. If it was a virtual file, then it means the workspace itself
-    // is empty. Either way, we need some sane last resort callback, which is the user's home.
-
-    // TODO Do we want to send a window/showMessageRequest to indicate the root chosen?
-    //  or even let the user choose a root if more are available
-    val home = Path.of(System.getProperty("user.home")).toRealPath()
-    Logging.LOGGER.info(I18n.format("workspaceFolderFallback", home, documentPath))
-    return home
   }
 
   fun raiseExceptionIfCanceled() {

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentItem.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentItem.kt
@@ -29,10 +29,14 @@ import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.WorkDoneProgressBegin
 import org.eclipse.lsp4j.WorkDoneProgressCreateParams
 import org.eclipse.lsp4j.WorkDoneProgressEnd
+import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.eclipse.lsp4j.jsonrpc.messages.Either
+import java.net.URI
+import java.nio.file.Path
 import java.time.Instant
 import java.util.concurrent.CancellationException
+import kotlin.io.path.toPath
 
 @Suppress("JoinDeclarationAndAssignment", "TooManyFunctions")
 class LtexTextDocumentItem(
@@ -428,6 +432,9 @@ class LtexTextDocumentItem(
         workspaceSpecificConfiguration as JsonElement?
 
       this.raiseExceptionIfCanceled()
+      val relativePathRoot = relativePathRoot()
+
+      this.raiseExceptionIfCanceled()
       this.languageServer.settingsManager.settings =
         Settings.fromJson(jsonConfiguration, jsonWorkspaceSpecificConfiguration)
 
@@ -446,6 +453,37 @@ class LtexTextDocumentItem(
 
       this.beingChecked = false
     }
+  }
+
+  /**
+   * Guess the most appropriate workspace folder for the current file.
+   * This folder will be used as the root for resolving relative file settings paths.
+   *
+   * This function does not currently distinguish between workspaceFolders and rootUri, treating
+   * them equally. The shadowing of rootUri by workspaceFolders is
+   * [still somewhat murky](https://github.com/microsoft/language-server-protocol/issues/2154).
+   * In the end, the resolution works by looking at all paths that are an ancestor of the document,
+   * and picking the most specific one (i.e. the one such that all others are its prefix).
+   *
+   * This function does not do path canonicalization, so the above resolution might fail for
+   * example for symlinked paths. I suggest this as a future improvement, as that brings its own
+   * host of issues that need to be handled.
+   */
+  fun relativePathRoot(): Path? {
+    // LSP guarantees valid URI
+    val scopePath = URI.create(this.uri).toPath()
+
+    val workspaceFolderUris = this.languageServer.workspaceFolders
+      ?.asSequence().orEmpty().map { it.uri }
+      .plus(this.languageServer.rootUri)
+
+    val candidateRoots = workspaceFolderUris
+      .filterNotNull()
+      .map { URI.create(it).toPath() }
+      //TODO: Canonicalize paths?
+      .filter { scopePath.startsWith(it) }
+
+    return candidateRoots.reduceOrNull { best, curr -> if(best.startsWith(curr)) best else curr }
   }
 
   fun raiseExceptionIfCanceled() {

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentItem.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentItem.kt
@@ -13,6 +13,7 @@ import com.google.gson.JsonObject
 import org.bsplines.ltexls.client.LtexLanguageClient
 import org.bsplines.ltexls.languagetool.LanguageToolRuleMatch
 import org.bsplines.ltexls.parsing.AnnotatedTextFragment
+import org.bsplines.ltexls.server.LtexLanguageServer.Companion.CanonicalizedPath
 import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
@@ -29,7 +30,6 @@ import org.eclipse.lsp4j.TextDocumentItem
 import org.eclipse.lsp4j.WorkDoneProgressBegin
 import org.eclipse.lsp4j.WorkDoneProgressCreateParams
 import org.eclipse.lsp4j.WorkDoneProgressEnd
-import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import java.net.URI
@@ -459,31 +459,42 @@ class LtexTextDocumentItem(
    * Guess the most appropriate workspace folder for the current file.
    * This folder will be used as the root for resolving relative file settings paths.
    *
-   * This function does not currently distinguish between workspaceFolders and rootUri, treating
-   * them equally. The shadowing of rootUri by workspaceFolders is
-   * [still somewhat murky](https://github.com/microsoft/language-server-protocol/issues/2154).
-   * In the end, the resolution works by looking at all paths that are an ancestor of the document,
-   * and picking the most specific one (i.e. the one such that all others are its prefix).
+   * For real files, this directory attempts to locate their corresponding workspace root.
+   * If there are multiple candidates, it picks the deepest nested (most specific) one.
    *
-   * This function does not do path canonicalization, so the above resolution might fail for
-   * example for symlinked paths. I suggest this as a future improvement, as that brings its own
-   * host of issues that need to be handled.
+   * For virtual (for example unnamed / unsaved) files, we use the first root of the workspace.
+   *
+   * If no suitable workspace folder is found, then the user's home directory is used as a last
+   * resort fallback.
    */
-  fun relativePathRoot(): Path? {
-    // LSP guarantees valid URI
-    val scopePath = URI.create(this.uri).toPath()
+  fun relativePathRoot(): Path {
+    val documentPath = CanonicalizedPath.from(this.uri)?.canonicalPath
+    if (documentPath != null) {
+      val candidateRoots =
+        this.languageServer.workspaceRoots
+          .map { it.canonicalPath }
+          .filter { documentPath.startsWith(it) }
 
-    val workspaceFolderUris = this.languageServer.workspaceFolders
-      ?.asSequence().orEmpty().map { it.uri }
-      .plus(this.languageServer.rootUri)
+      candidateRoots
+        .reduceOrNull { best, curr -> if (best.startsWith(curr)) best else curr }
+        ?.let { return it }
+    } else {
+      // This is a virtual file (unnamed/unsaved). We give it the first available root.
+      this.languageServer.workspaceRoots.firstOrNull()?.canonicalPath?.let {
+        Logging.LOGGER.info(I18n.format("workspaceFolderFallback", it, documentPath))
+        return it
+      }
+    }
 
-    val candidateRoots = workspaceFolderUris
-      .filterNotNull()
-      .map { URI.create(it).toPath() }
-      //TODO: Canonicalize paths?
-      .filter { scopePath.startsWith(it) }
+    // We did not find a suitable root for the file. If it was a real file, then it means it was
+    // outside all current workspaces. If it was a virtual file, then it means the workspace itself
+    // is empty. Either way, we need some sane last resort callback, which is the user's home.
 
-    return candidateRoots.reduceOrNull { best, curr -> if(best.startsWith(curr)) best else curr }
+    // TODO Do we want to send a window/showMessageRequest to indicate the root chosen?
+    //  or even let the user choose a root if more are available
+    val home = Path.of(System.getProperty("user.home")).toRealPath()
+    Logging.LOGGER.info(I18n.format("workspaceFolderFallback", home, documentPath))
+    return home
   }
 
   fun raiseExceptionIfCanceled() {

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
@@ -10,6 +10,7 @@ package org.bsplines.ltexls.server
 
 import com.google.gson.JsonObject
 import com.sun.management.OperatingSystemMXBean
+import org.bsplines.ltexls.server.LtexLanguageServer.Companion.CanonicalizedPath
 import org.bsplines.ltexls.tools.FileIo
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
@@ -20,7 +21,6 @@ import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
-import org.eclipse.lsp4j.WorkspaceFolder
 import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures
@@ -79,9 +79,13 @@ class LtexWorkspaceService(
 
     this.languageServer.singleThreadExecutorService.execute {
       try {
-        val folders = this.languageServer.languageClient?.workspaceFolders()?.get()
-        this.languageServer.workspaceFolders = folders
-      } catch (e: Exception) {
+        val client = this.languageServer.languageClient ?: return@execute
+        val folders = client.workspaceFolders().get()
+
+        this.languageServer.workspaceRoots = folders
+          ?.mapNotNull { CanonicalizedPath.from(it) }
+          ?: listOf()
+      } catch (e: UnsupportedOperationException) {
         Logging.LOGGER.warning(I18n.format("workspaceFoldersRequestFailed", e))
         params?.event?.let { applyWorkspaceFolderDelta(it) }
       }
@@ -89,14 +93,17 @@ class LtexWorkspaceService(
   }
 
   private fun applyWorkspaceFolderDelta(delta: WorkspaceFoldersChangeEvent) {
-    val folders = this.languageServer.workspaceFolders?.toMutableList() ?: mutableListOf()
+    val roots = this.languageServer.workspaceRoots.toMutableList()
     for (rem in delta.removed) {
-      if (!folders.remove(rem)) {
+      val idx = roots.indexOfFirst { it.originalUri == rem }
+      if (idx == -1) {
         Logging.LOGGER.warning(I18n.format("removingNonexistentWorkspaceDir", rem))
+      } else {
+        roots.removeAt(idx)
       }
     }
-    folders.addAll(delta.added)
-    this.languageServer.workspaceFolders = folders
+    roots.addAll(delta.added.mapNotNull { CanonicalizedPath.from(it) })
+    this.languageServer.workspaceRoots = roots
   }
 
   override fun executeCommand(params: ExecuteCommandParams): CompletableFuture<Any> =

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
@@ -16,9 +16,12 @@ import org.bsplines.ltexls.tools.Logging
 import org.bsplines.ltexls.tools.Tools
 import org.eclipse.lsp4j.DidChangeConfigurationParams
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams
+import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams
 import org.eclipse.lsp4j.ExecuteCommandParams
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.WorkspaceFolder
+import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent
 import org.eclipse.lsp4j.jsonrpc.CancelChecker
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures
 import org.eclipse.lsp4j.services.WorkspaceService
@@ -65,6 +68,35 @@ class LtexWorkspaceService(
   }
 
   override fun didChangeWatchedFiles(params: DidChangeWatchedFilesParams) {
+  }
+
+  override fun didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams?) {
+    // Updating workspace folders has to be serialized both against other didChangeWsFolders and
+    // against document checking. Running on the language server's single executor does this, at the
+    // cost of workspace folder updates blocking document checking.
+    // I consider that a reasonable tradeoff, as workspace folder changes should be fairly rare
+    // and I would expect the performance tradeoff not to be too significant.
+
+    this.languageServer.singleThreadExecutorService.execute {
+      try {
+        val folders = this.languageServer.languageClient?.workspaceFolders()?.get()
+        this.languageServer.workspaceFolders = folders
+      } catch (e: Exception) {
+        Logging.LOGGER.warning(I18n.format("workspaceFoldersRequestFailed", e))
+        params?.event?.let { applyWorkspaceFolderDelta(it) }
+      }
+    }
+  }
+
+  private fun applyWorkspaceFolderDelta(delta: WorkspaceFoldersChangeEvent) {
+    val folders = this.languageServer.workspaceFolders?.toMutableList() ?: mutableListOf()
+    for (rem in delta.removed) {
+      if (!folders.remove(rem)) {
+        Logging.LOGGER.warning(I18n.format("removingNonexistentWorkspaceDir", rem))
+      }
+    }
+    folders.addAll(delta.added)
+    this.languageServer.workspaceFolders = folders
   }
 
   override fun executeCommand(params: ExecuteCommandParams): CompletableFuture<Any> =

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
@@ -10,7 +10,7 @@ package org.bsplines.ltexls.server
 
 import com.google.gson.JsonObject
 import com.sun.management.OperatingSystemMXBean
-import org.bsplines.ltexls.server.LtexLanguageServer.Companion.CanonicalizedPath
+import org.bsplines.ltexls.server.LtexLanguageServer.Canonical
 import org.bsplines.ltexls.tools.FileIo
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
@@ -83,7 +83,7 @@ class LtexWorkspaceService(
         val folders = client.workspaceFolders().get()
 
         this.languageServer.workspaceRoots = folders
-          ?.mapNotNull { CanonicalizedPath.from(it) }
+          ?.mapNotNull { Canonical.from(it) }
           ?: listOf()
       } catch (e: UnsupportedOperationException) {
         Logging.LOGGER.warning(I18n.format("workspaceFoldersRequestFailed", e))
@@ -102,7 +102,7 @@ class LtexWorkspaceService(
         roots.removeAt(idx)
       }
     }
-    roots.addAll(delta.added.mapNotNull { CanonicalizedPath.from(it) })
+    roots.addAll(delta.added.mapNotNull { Canonical.from(it) })
     this.languageServer.workspaceRoots = roots
   }
 

--- a/src/main/kotlin/org/bsplines/ltexls/server/NonServerChecker.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/NonServerChecker.kt
@@ -12,6 +12,7 @@ import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import org.bsplines.ltexls.languagetool.LanguageToolRuleMatch
 import org.bsplines.ltexls.parsing.AnnotatedTextFragment
+import org.bsplines.ltexls.server.LtexLanguageServer.Canonical
 import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.tools.FileIo
 import org.eclipse.lsp4j.Position
@@ -46,7 +47,15 @@ class NonServerChecker {
     val ltexLsJsonSettings: JsonObject = jsonSettings.getAsJsonObject("ltex-ls")
     if (!ltexLsJsonSettings.has("logLevel")) ltexLsJsonSettings.addProperty("logLevel", "warning")
 
-    this.languageServer.settingsManager.settings = Settings.fromJson(jsonSettings)
+    val root =
+      this.languageServer.workspaceRoots
+        .firstOrNull()
+        ?.canonicalPath
+        ?: Path.of(System.getProperty("user.dir"))
+
+    val settingsFileManager = this.languageServer.settingsFileManager.rooted(root)
+    this.languageServer.settingsManager.settings =
+      Settings.fromJson(jsonSettings, settingsFileManager = settingsFileManager)
   }
 
   fun check(paths: List<Path>): Int {

--- a/src/main/kotlin/org/bsplines/ltexls/settings/FileSettings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/FileSettings.kt
@@ -1,0 +1,159 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.settings
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import org.bsplines.ltexls.server.LtexLanguageServer.Canonical
+import kotlin.collections.setOf
+import kotlin.text.startsWith
+import kotlin.text.substring
+
+data class FileSettings<T>(
+  val items: List<Item<T>>,
+) {
+  sealed interface Item<T> {
+    data class Literal<T>(
+      val value: T,
+      val subtract: Boolean = false,
+    ) : Item<T> {
+      companion object {
+        fun parse(string: String): Literal<String> =
+          if (string.startsWith("-")) {
+            Literal(string.substring(1), true)
+          } else {
+            Literal(string, false)
+          }
+
+        fun <T> parse(
+          string: String,
+          parser: (String) -> T,
+        ) = with(parse(string)) { Literal(parser(value), subtract) }
+      }
+    }
+
+    data class File<T>(
+      val path: Canonical<String>,
+      val values: List<Literal<T>>,
+    ) : Item<T>
+  }
+
+  val values: Set<T> =
+    items
+      .asSequence()
+      .flatMap {
+        when (it) {
+          is Item.File<T> -> it.values.asSequence()
+          is Item.Literal<T> -> sequenceOf(it)
+        }
+      }.fold(setOf()) { values, literal ->
+        if (literal.subtract) {
+          values - literal.value
+        } else {
+          values + literal.value
+        }
+      }
+
+  // Subtle: The emptiness of the file settings is determined by the **reduced values**,
+  // not by the raw items:
+  //  this.isEmpty() implies this.items.isEmpty(),
+  //    but not necessarily the other way around
+  //
+  // For example, a set like [ "hello", "-hello" ] will be considered empty, as will one pointing
+  // to a single empty file.
+  fun isEmpty(): Boolean = this.values.isEmpty()
+
+  fun isNotEmpty(): Boolean = !this.isEmpty()
+
+  companion object {
+    fun <T> fromListOfStrings(
+      listOfStrings: List<String>,
+      settingsFileManager: SettingsFileManager.Rooted,
+      parser: (String) -> T,
+    ): FileSettings<T> =
+      listOfStrings
+        .mapNotNull {
+          parseItemFromJsonString(it, settingsFileManager, parser)
+        }.let { FileSettings(it) }
+
+    fun fromListOfStrings(
+      listOfStrings: List<String>,
+      settingsFileManager: SettingsFileManager.Rooted,
+    ): FileSettings<String> = fromListOfStrings(listOfStrings, settingsFileManager) { it }
+
+    /**
+     * Parse FileSettings from a heterogeneous JSON string.
+     *
+     * The entries in the JSON array can either be JSON objects or JSON strings. The corresponding
+     * parser is then called for each value, handling literals (including subtraction) and file
+     * paths as expected.
+     *
+     * This function mainly facilitates loading hiddenFalsePositive settings in a way where the user
+     * can combine strings (either as a JSON string of the hidden false positive, possibly prefixed
+     * with - to subtract it, or for filenames) together with actual JSON objects.
+     *
+     * That way, they can write hiddenFalsePositives naturally as an array of JSON objects, but
+     * intersperse subtracted objects of file paths.
+     *
+     * If specified in a file, the file is expected to contain newline-separated JSON strings
+     * of the hiddenFalsePositives (possibly subtracted). For example:
+     * ```
+     * // hiddenFalsePositives.en.txt
+     * { "rule": "SOME_RULE", "sentence": "My sentence" }
+     * -{ "rule": "SUBTRACT_RULE", "sentence": "This one will be subtracted" }
+     * ```
+     */
+    fun <T> fromJsonArray(
+      jsonArray: JsonArray,
+      settingsFileManager: SettingsFileManager.Rooted,
+      stringParser: (String) -> T,
+      objectParser: (JsonObject) -> T,
+    ): FileSettings<T> {
+      // TODO allow assigning IDs to hiddenFalsePositives rules and subtracting them by ID? how?
+      return jsonArray
+        .mapNotNull {
+          when {
+            it.isJsonObject -> {
+              Item.Literal(objectParser(it.asJsonObject))
+            }
+
+            it.isJsonPrimitive && it.asJsonPrimitive.isString -> {
+              parseItemFromJsonString(
+                it.asJsonPrimitive.asString,
+                settingsFileManager,
+                stringParser,
+              )
+            }
+
+            else -> {
+              null
+            }
+          }
+        }.let { FileSettings(it) }
+    }
+
+    private fun <T> parseItemFromJsonString(
+      string: String,
+      settingsFileManager: SettingsFileManager.Rooted,
+      parser: (String) -> T,
+    ): Item<T>? =
+      if (string.startsWith(":")) {
+        val path = settingsFileManager.resolve(string.substring(1)) ?: return null
+        val values = settingsFileManager.loadSettings(path.canonicalPath, parser)
+        Item.File(path, values)
+      } else {
+        Item.Literal.parse(string, parser)
+      }
+
+    fun <T> fromSet(sequence: Set<T>): FileSettings<T> =
+      FileSettings(sequence.map { Item.Literal(it) })
+
+    fun <T> of(vararg vals: T): FileSettings<T> = FileSettings(vals.map { Item.Literal(it) })
+  }
+}

--- a/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
@@ -17,15 +17,16 @@ import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
 import org.eclipse.lsp4j.DiagnosticSeverity
 import org.languagetool.Languages
+import java.nio.file.Path
 import java.util.logging.Level
 
 data class Settings(
   private val _enabled: Set<String>? = null,
   private val _languageShortCode: String? = null,
-  private val _allDictionaries: Map<String, Set<String>>? = null,
-  private val _allDisabledRules: Map<String, Set<String>>? = null,
-  private val _allEnabledRules: Map<String, Set<String>>? = null,
-  private val _allHiddenFalsePositives: Map<String, Set<HiddenFalsePositive>>? = null,
+  private val _allDictionaries: Map<String, FileSettings<String>>? = null,
+  private val _allDisabledRules: Map<String, FileSettings<String>>? = null,
+  private val _allEnabledRules: Map<String, FileSettings<String>>? = null,
+  private val _allHiddenFalsePositives: Map<String, FileSettings<HiddenFalsePositive>>? = null,
   private val _bibtexFields: Map<String, Boolean>? = null,
   private val _latexCommands: Map<String, String>? = null,
   private val _latexEnvironments: Map<String, String>? = null,
@@ -52,19 +53,21 @@ data class Settings(
   val languageShortCode: String
     get() = (this._languageShortCode ?: "en-US")
   val dictionary: Set<String>
-    get() = (this._allDictionaries?.get(this.languageShortCode) ?: setOf())
+    get() = (this._allDictionaries?.get(this.languageShortCode)?.values ?: setOf())
   val disabledRules: Set<String>
-    get() = (this._allDisabledRules?.get(this.languageShortCode) ?: setOf())
+    get() = (this._allDisabledRules?.get(this.languageShortCode)?.values ?: setOf())
   val enabledRules: Set<String>
-    get() = (this._allEnabledRules?.get(this.languageShortCode) ?: setOf())
+    get() = (this._allEnabledRules?.get(this.languageShortCode)?.values ?: setOf())
   val hiddenFalsePositives: Set<HiddenFalsePositive>
-    get() = (this._allHiddenFalsePositives?.get(this.languageShortCode) ?: setOf())
+    get() = (this._allHiddenFalsePositives?.get(this.languageShortCode)?.values ?: setOf())
   val allDictionaries: Map<String, Set<String>>
-    get() = (this._allDictionaries ?: emptyMap())
+    get() = (this._allDictionaries?.mapValues { it.value.values } ?: emptyMap())
   val allDisabledRules: Map<String, Set<String>>
-    get() = (this._allDisabledRules ?: emptyMap())
+    get() = (this._allDisabledRules?.mapValues { it.value.values } ?: emptyMap())
+  val allEnabledRules: Map<String, Set<String>>
+    get() = (this._allEnabledRules?.mapValues { it.value.values } ?: emptyMap())
   val allHiddenFalsePositives: Map<String, Set<HiddenFalsePositive>>
-    get() = (this._allHiddenFalsePositives ?: emptyMap())
+    get() = (this._allHiddenFalsePositives?.mapValues { it.value.values } ?: emptyMap())
   val bibtexFields: Map<String, Boolean>
     get() = (this._bibtexFields ?: mapOf())
   val latexCommands: Map<String, String>
@@ -105,6 +108,16 @@ data class Settings(
     get() = (this._paragraphCacheTtlMinutes ?: DEFAULT_PARAGRAPH_CACHE_TTL_MINUTES)
   val maxRequestSize: Int
     get() = (this._maxRequestSize ?: DEFAULT_MAX_REQUEST_SIZE)
+
+  // Need to expose these for overrides
+  val rawAllDictionaries: Map<String, FileSettings<String>>?
+    get() = this._allDictionaries
+  val rawAllEnabledRules: Map<String, FileSettings<String>>?
+    get() = this._allEnabledRules
+  val rawAllDisabledRules: Map<String, FileSettings<String>>?
+    get() = this._allDisabledRules
+  val rawAllHiddenFalsePositives: Map<String, FileSettings<HiddenFalsePositive>>?
+    get() = this._allHiddenFalsePositives
 
   /**
    * Returns differences between `this` and `other` that call for
@@ -171,32 +184,31 @@ data class Settings(
     return differences
   }
 
-  fun getModifiedDictionary(dictionary: Set<String>): Map<String, Set<String>> {
-    val allDictionaries = HashMap<String, Set<String>>(this._allDictionaries ?: emptyMap())
-    allDictionaries[this.languageShortCode] = dictionary
+  fun getModifiedDictionary(dictionary: Set<String>): Map<String, FileSettings<String>> {
+    val allDictionaries = HashMap(this._allDictionaries ?: mapOf())
+    allDictionaries[this.languageShortCode] = FileSettings.fromSet(dictionary)
     return allDictionaries
   }
 
-  fun getModifiedDisabledRules(disabledRules: Set<String>): Map<String, Set<String>> {
-    val allDisabledRules = HashMap<String, Set<String>>(this._allDisabledRules ?: emptyMap())
-    allDisabledRules[this.languageShortCode] = disabledRules
+  fun getModifiedDisabledRules(disabledRules: Set<String>): Map<String, FileSettings<String>> {
+    val allDisabledRules = HashMap(this._allDisabledRules ?: mapOf())
+    allDisabledRules[this.languageShortCode] = FileSettings.fromSet(disabledRules)
     return allDisabledRules
   }
 
   @Suppress("unused")
-  fun getModifiedEnabledRules(enabledRules: Set<String>): Map<String, Set<String>> {
-    val allEnabledRules = HashMap<String, Set<String>>(this._allEnabledRules ?: emptyMap())
-    allEnabledRules[this.languageShortCode] = enabledRules
+  fun getModifiedEnabledRules(enabledRules: Set<String>): Map<String, FileSettings<String>> {
+    val allEnabledRules = HashMap(this._allEnabledRules ?: mapOf())
+    allEnabledRules[this.languageShortCode] = FileSettings.fromSet(enabledRules)
     return allEnabledRules
   }
 
   @Suppress("unused")
   fun getModifiedHiddenFalsePositives(
     hiddenFalsePositives: Set<HiddenFalsePositive>,
-  ): Map<String, Set<HiddenFalsePositive>> {
-    val allHiddenFalsePositives =
-      HashMap<String, Set<HiddenFalsePositive>>(this._allHiddenFalsePositives ?: emptyMap())
-    allHiddenFalsePositives[this.languageShortCode] = hiddenFalsePositives
+  ): Map<String, FileSettings<HiddenFalsePositive>> {
+    val allHiddenFalsePositives = HashMap(this._allHiddenFalsePositives ?: mapOf())
+    allHiddenFalsePositives[this.languageShortCode] = FileSettings.fromSet(hiddenFalsePositives)
     return allHiddenFalsePositives
   }
 
@@ -247,32 +259,27 @@ data class Settings(
     fun fromJson(
       jsonSettings: JsonElement,
       jsonWorkspaceSpecificSettings: JsonElement? = null,
+      settingsFileManager: SettingsFileManager.Rooted,
     ): Settings {
       val jsonWorkspaceSpecificSettings2 = jsonWorkspaceSpecificSettings ?: jsonSettings
 
       val enabled: Set<String>? = getEnabledFromJson(jsonSettings)
       val languageShortCode: String? =
         getSettingFromJsonAsString(jsonSettings, "language")?.let { normalizeLanguageShortCode(it) }
-      val allDictionaries: Map<String, Set<String>>? =
-        mergeMapOfListsIntoMapOfSets(
-          convertJsonObjectToMapOfLists(
-            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "dictionary"),
-          ),
-        )
-      val allDisabledRules: Map<String, Set<String>>? =
-        mergeMapOfListsIntoMapOfSets(
-          convertJsonObjectToMapOfLists(
-            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "disabledRules"),
-          ),
-        )
-      val allEnabledRules: Map<String, Set<String>>? =
-        mergeMapOfListsIntoMapOfSets(
-          convertJsonObjectToMapOfLists(
-            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "enabledRules"),
-          ),
-        )
-      val allHiddenFalsePositives: Map<String, Set<HiddenFalsePositive>>? =
-        getAllHiddenFalsePositivesFromJson(jsonWorkspaceSpecificSettings2)
+      val allDictionaries: Map<String, FileSettings<String>>? =
+        convertJsonObjectToMapOfLists(
+          getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "dictionary"),
+        )?.mapValues { FileSettings.fromListOfStrings(it.value, settingsFileManager) }
+      val allDisabledRules: Map<String, FileSettings<String>>? =
+        convertJsonObjectToMapOfLists(
+          getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "disabledRules"),
+        )?.mapValues { FileSettings.fromListOfStrings(it.value, settingsFileManager) }
+      val allEnabledRules: Map<String, FileSettings<String>>? =
+        convertJsonObjectToMapOfLists(
+          getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "enabledRules"),
+        )?.mapValues { FileSettings.fromListOfStrings(it.value, settingsFileManager) }
+      val allHiddenFalsePositives: Map<String, FileSettings<HiddenFalsePositive>>? =
+        getAllHiddenFalsePositivesFromJson(jsonWorkspaceSpecificSettings2, settingsFileManager)
       val bibtexFields: Map<String, Boolean>? =
         convertJsonObjectToMapOfBooleans(
           getSettingFromJsonAsJsonObject(jsonSettings, "bibtex.fields"),
@@ -538,45 +545,21 @@ data class Settings(
 
     private fun getAllHiddenFalsePositivesFromJson(
       jsonWorkspaceSpecificSettings: JsonElement,
-    ): Map<String, Set<HiddenFalsePositive>>? {
-      val objectMap: Map<String, Set<JsonObject>>? =
-        convertJsonObjectToMapOfJsonObjects(
+      settingsFileManager: SettingsFileManager.Rooted,
+    ): Map<String, FileSettings<HiddenFalsePositive>>? {
+      val arrayMap =
+        convertJsonObjectToMapOfJsonArrays(
           getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings, "hiddenFalsePositives"),
         )
-      val stringMap: Map<String, Set<String>>? =
-        mergeMapOfListsIntoMapOfSets(
-          convertJsonObjectToMapOfLists(
-            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings, "hiddenFalsePositives"),
-          ),
+
+      return arrayMap?.mapValues {
+        FileSettings.fromJsonArray(
+          it.value,
+          settingsFileManager,
+          HiddenFalsePositive::fromJsonString,
+          HiddenFalsePositive::fromJsonObject,
         )
-
-      if (objectMap == null && stringMap == null) {
-        return null
       }
-
-      val hiddenFalsePositivesMap = HashMap<String, HashSet<HiddenFalsePositive>>()
-
-      if (objectMap != null) {
-        for ((language, jsonObjectSet) in objectMap) {
-          val falsePositivesSet = hiddenFalsePositivesMap.getOrPut(language) { HashSet() }
-          for (jsonObject in jsonObjectSet) {
-            val falsePositive = HiddenFalsePositive.fromJsonObject(jsonObject)
-            falsePositivesSet.add(falsePositive)
-          }
-        }
-      }
-
-      if (stringMap != null) {
-        for ((language, stringSet) in stringMap) {
-          val falsePositivesSet = hiddenFalsePositivesMap.getOrPut(language) { HashSet() }
-          for (jsonString in stringSet) {
-            val falsePositive = HiddenFalsePositive.fromJsonString(jsonString)
-            falsePositivesSet.add(falsePositive)
-          }
-        }
-      }
-
-      return hiddenFalsePositivesMap
     }
 
     private fun getDiagnosticSeverityFromJson(
@@ -792,6 +775,18 @@ data class Settings(
       return map
     }
 
+    private fun convertJsonObjectToMapOfJsonArrays(obj: JsonObject?): Map<String, JsonArray>? {
+      if (obj == null) return null
+      val map = HashMap<String, JsonArray>()
+
+      for (entry: Map.Entry<String, JsonElement> in obj.entrySet()) {
+        if (!entry.value.isJsonArray) return null
+        map[entry.key] = entry.value.asJsonArray
+      }
+
+      return map
+    }
+
     private fun <T> convertJsonObjectToMapOfEnums(
       obj: JsonObject?,
       enumValues: Array<T>,
@@ -802,27 +797,6 @@ data class Settings(
       for (entry: Map.Entry<String, JsonElement> in obj.entrySet()) {
         val enumValue: T? = convertJsonElementToEnum(entry.value, enumValues)
         if (enumValue != null) map[entry.key] = enumValue
-      }
-
-      return map
-    }
-
-    private fun convertJsonObjectToMapOfJsonObjects(
-      obj: JsonObject?,
-    ): Map<String, Set<JsonObject>>? {
-      if (obj == null) return null
-      val map = HashMap<String, Set<JsonObject>>()
-
-      for (entry: Map.Entry<String, JsonElement> in obj.entrySet()) {
-        if (!entry.value.isJsonArray) return null
-        val set = HashSet<JsonObject>()
-
-        for (element: JsonElement in entry.value.asJsonArray) {
-          if (!element.isJsonObject) return null
-          set.add(element.asJsonObject)
-        }
-
-        map[entry.key] = set
       }
 
       return map
@@ -853,29 +827,6 @@ data class Settings(
       }
 
       return null
-    }
-
-    private fun mergeMapOfListsIntoMapOfSets(
-      mapOfLists: Map<String, List<String>>?,
-    ): Map<String, Set<String>>? {
-      if (mapOfLists == null) return null
-      val mapOfSets = HashMap<String, HashSet<String>>()
-
-      for ((key: String, set2: List<String>) in mapOfLists) {
-        val set1 = HashSet<String>()
-
-        for (string: String in set2) {
-          if (string.startsWith("-")) {
-            set1.remove(string.substring(1))
-          } else {
-            set1.add(string)
-          }
-        }
-
-        mapOfSets[key] = set1
-      }
-
-      return mapOfSets
     }
   }
 }

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsFileManager.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsFileManager.kt
@@ -35,13 +35,15 @@ interface SettingsFileManager {
     val manager: SettingsFileManager,
     val root: Path,
   ) : Rooted {
-    override fun resolve(path: String): Canonical<String>? =
-      Canonical.fromPath(
+    override fun resolve(path: String): Canonical<String>? {
+      if (path.isEmpty()) return null
+      return Canonical.fromPath(
         when {
           path.isNotEmpty() && path.first() in arrayOf('~', '/') -> FileIo.normalizePath(path)
           else -> root.resolve(path).pathString
         },
       )
+    }
 
     override fun loadFile(path: Path): List<String> = this.manager.loadFile(path)
   }

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsFileManager.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsFileManager.kt
@@ -1,0 +1,52 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.settings
+
+import org.bsplines.ltexls.server.LtexLanguageServer.Canonical
+import org.bsplines.ltexls.settings.FileSettings.Item.Literal
+import org.bsplines.ltexls.tools.FileIo
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.pathString
+
+interface SettingsFileManager {
+  fun loadFile(path: Path): List<String>
+
+  fun <T> loadSettings(
+    path: Path,
+    parser: (String) -> T,
+  ): List<Literal<T>> =
+    loadFile(path)
+      .map { Literal.parse(it, parser) }
+
+  fun rooted(root: Path): Rooted = DefaultRooted(this, root)
+
+  interface Rooted : SettingsFileManager {
+    fun resolve(path: String): Canonical<String>?
+  }
+
+  class DefaultRooted(
+    val manager: SettingsFileManager,
+    val root: Path,
+  ) : Rooted {
+    override fun resolve(path: String): Canonical<String>? =
+      Canonical.fromPath(
+        when {
+          path.isNotEmpty() && path.first() in arrayOf('~', '/') -> FileIo.normalizePath(path)
+          else -> root.resolve(path).pathString
+        },
+      )
+
+    override fun loadFile(path: Path): List<String> = this.manager.loadFile(path)
+  }
+}
+
+class BasicSettingsFileManager : SettingsFileManager {
+  override fun loadFile(path: Path): List<String> = File(path.pathString).readLines().toList()
+}

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsOverride.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsOverride.kt
@@ -44,11 +44,7 @@ class SettingsOverride(
       newSettings =
         newSettings.copy(
           _allDictionaries =
-            overrideMapSet(
-              // hacky: get _allDictionaries.
-              newSettings.getModifiedDictionary(newSettings.dictionary),
-              it,
-            ),
+            overrideMapFileSettings(newSettings.rawAllDictionaries, it),
         )
     }
     allRules?.let {
@@ -72,13 +68,13 @@ class SettingsOverride(
       newSettings =
         newSettings.copy(
           _allEnabledRules =
-            overrideMapSet(
-              _inner.getModifiedEnabledRules(newSettings.enabledRules),
+            overrideMapFileSettings(
+              newSettings.rawAllEnabledRules,
               mapSetOverride(false),
             ),
           _allDisabledRules =
-            overrideMapSet(
-              _inner.getModifiedDisabledRules(newSettings.disabledRules),
+            overrideMapFileSettings(
+              newSettings.rawAllDisabledRules,
               mapSetOverride(true),
             ),
         )
@@ -87,10 +83,7 @@ class SettingsOverride(
       newSettings =
         newSettings.copy(
           _allHiddenFalsePositives =
-            overrideMapSet(
-              newSettings.getModifiedHiddenFalsePositives(newSettings.hiddenFalsePositives),
-              it,
-            ),
+            overrideMapFileSettings(newSettings.rawAllHiddenFalsePositives, it),
         )
     }
     bibtexFields?.let {
@@ -315,6 +308,17 @@ class SettingsOverride(
       return new
     }
 
+    fun <K, V> overrideMapFileSettings(
+      old: Map<K, FileSettings<V>>?,
+      override: Map<K, Map<V, SetUpdate>>,
+    ): Map<K, FileSettings<V>> {
+      val new = old?.toMutableMap() ?: mutableMapOf()
+      for ((mapKey, fileSettingsOverride) in override) {
+        new[mapKey] = overrideFileSettings(new[mapKey], fileSettingsOverride)
+      }
+      return new
+    }
+
     fun <V> overrideSet(
       old: Set<V>?,
       override: Map<V, SetUpdate>,
@@ -324,6 +328,19 @@ class SettingsOverride(
         setUpdate.performOn(new, setElement)
       }
       return new
+    }
+
+    fun <V> overrideFileSettings(
+      old: FileSettings<V>?,
+      override: Map<V, SetUpdate>,
+    ): FileSettings<V> {
+      val newItems = old?.items?.toMutableList() ?: mutableListOf()
+      newItems.addAll(
+        override.asSequence().map {
+          FileSettings.Item.Literal(it.key, it.value == SetUpdate.REMOVE)
+        },
+      )
+      return FileSettings(newItems)
     }
 
     fun <K, V> overrideMap(

--- a/src/main/kotlin/org/bsplines/ltexls/tools/I18n.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/tools/I18n.kt
@@ -90,7 +90,7 @@ object I18n {
     vararg messageArguments: Any?,
   ): String {
     val builder = StringBuilder()
-    builder.append(format(key, messageArguments))
+    builder.append(format(key, *messageArguments))
     builder.append(". ")
     builder.append(format(e))
     return builder.toString()

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -90,3 +90,5 @@ unsupportedCodeLanguageId = Unsupported code language ID '{0}', treating text as
 useWord = Use '{0}'
 useWordAllSelectedMatches = Use '{0}' (all selected matches)
 waitingForClientToConnectOnPort = Waiting for client to connect on port {0}...
+removingNonexistentWorkspaceDir = Client reports removing unknown workspace folder {0}
+workspaceFoldersRequestFailed = Workspace folders request failed, falling back on manual delta update

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -91,4 +91,6 @@ useWord = Use '{0}'
 useWordAllSelectedMatches = Use '{0}' (all selected matches)
 waitingForClientToConnectOnPort = Waiting for client to connect on port {0}...
 removingNonexistentWorkspaceDir = Client reports removing unknown workspace folder {0}
-workspaceFoldersRequestFailed = Workspace folders request failed, falling back on manual delta update
+workspaceFoldersRequestFailed = workspace/workspaceFolders request failed, falling back on manual delta update
+cannotCanonicalizeUri = Unable to canonicalize {0}
+workspaceFolderFallback = Falling back to workspace folder {0} for document {1}

--- a/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolHttpInterfaceTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolHttpInterfaceTest.kt
@@ -12,6 +12,7 @@ import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 import org.bsplines.ltexls.server.DocumentChecker
 import org.bsplines.ltexls.server.DocumentCheckerTest
 import org.bsplines.ltexls.server.LtexTextDocumentItem
+import org.bsplines.ltexls.settings.FileSettings
 import org.bsplines.ltexls.settings.HiddenFalsePositive
 import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.settings.SettingsManager
@@ -191,7 +192,7 @@ class LanguageToolHttpInterfaceTest {
       this.defaultSettings.copy(
         _languageShortCode = "auto",
         _preferredVariants = listOf("en-US"),
-        _allDictionaries = mapOf("en-US" to setOf("testt", "mispeling")),
+        _allDictionaries = mapOf("en-US" to FileSettings.of("testt", "mispeling")),
       )
     val settingsManager = SettingsManager(settings)
     val documentChecker = DocumentChecker(settingsManager)
@@ -229,7 +230,7 @@ class LanguageToolHttpInterfaceTest {
     val settings: Settings =
       this.defaultSettings.copy(
         _languageShortCode = "auto",
-        _allDictionaries = mapOf("de-DE" to setOf("gegesssen", "wunderschöön")),
+        _allDictionaries = mapOf("de-DE" to FileSettings.of("gegesssen", "wunderschöön")),
       )
     val settingsManager = SettingsManager(settings)
     val documentChecker = DocumentChecker(settingsManager)
@@ -273,7 +274,7 @@ class LanguageToolHttpInterfaceTest {
       this.defaultSettings.copy(
         _languageShortCode = "auto",
         _preferredVariants = listOf("en-US"),
-        _allDisabledRules = mapOf("en-US" to setOf("EN_A_VS_AN")),
+        _allDisabledRules = mapOf("en-US" to FileSettings.of("EN_A_VS_AN")),
       )
     val settingsManager = SettingsManager(settings)
     val documentChecker = DocumentChecker(settingsManager)
@@ -311,7 +312,7 @@ class LanguageToolHttpInterfaceTest {
         _languageShortCode = "auto",
         _preferredVariants = listOf("en-US"),
         _allHiddenFalsePositives =
-          mapOf("en-US" to setOf(HiddenFalsePositive("EN_A_VS_AN", "^\\Q$sentence\\E$"))),
+          mapOf("en-US" to FileSettings.of(HiddenFalsePositive("EN_A_VS_AN", "^\\Q$sentence\\E$"))),
       )
     val settingsManager = SettingsManager(settings)
     val documentChecker = DocumentChecker(settingsManager)

--- a/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolJavaInterfaceTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolJavaInterfaceTest.kt
@@ -12,6 +12,7 @@ import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 import org.bsplines.ltexls.server.DocumentChecker
 import org.bsplines.ltexls.server.DocumentCheckerTest
 import org.bsplines.ltexls.server.LtexTextDocumentItem
+import org.bsplines.ltexls.settings.FileSettings
 import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.settings.SettingsManager
 import kotlin.test.Test
@@ -27,7 +28,7 @@ class LanguageToolJavaInterfaceTest {
 
   @Test
   fun testEasterEgg() {
-    val settings = Settings(_allDictionaries = mapOf(Pair("en-US", setOf("BsPlInEs"))))
+    val settings = Settings(_allDictionaries = mapOf(Pair("en-US", FileSettings.of("BsPlInEs"))))
     val settingsManager = SettingsManager(settings)
     val documentChecker = DocumentChecker(settingsManager)
     val document: LtexTextDocumentItem =

--- a/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolPremiumIntegrationTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/languagetool/LanguageToolPremiumIntegrationTest.kt
@@ -12,6 +12,7 @@ import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 import org.bsplines.ltexls.server.DocumentChecker
 import org.bsplines.ltexls.server.DocumentCheckerTest
 import org.bsplines.ltexls.server.LtexTextDocumentItem
+import org.bsplines.ltexls.settings.FileSettings
 import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.settings.SettingsManager
 import org.junit.jupiter.api.extension.ConditionEvaluationResult
@@ -85,7 +86,7 @@ class LanguageToolPremiumIntegrationTest {
   fun testPremiumPunctuationSpansSuppressedAfterBareWordAdd() =
     withPremiumFailureHint {
       val spans: List<String> =
-        collectMatchSpans(buildSettings(dictionary = setOf("amazng")))
+        collectMatchSpans(buildSettings(dictionary = FileSettings.of("amazng")))
 
       assertTrue(
         spans.isEmpty(),
@@ -124,7 +125,7 @@ class LanguageToolPremiumIntegrationTest {
       |    code change.
       """.trimMargin()
 
-    private fun buildSettings(dictionary: Set<String> = emptySet()): Settings {
+    private fun buildSettings(dictionary: FileSettings<String> = FileSettings.of()): Settings {
       var settings =
         Settings(
           _languageShortCode = "en-US",

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/FragmentCacheTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/FragmentCacheTest.kt
@@ -8,6 +8,7 @@
 
 package org.bsplines.ltexls.parsing
 
+import org.bsplines.ltexls.settings.FileSettings
 import org.bsplines.ltexls.settings.Settings
 import org.languagetool.markup.AnnotatedTextBuilder
 import kotlin.test.Test
@@ -127,7 +128,10 @@ class FragmentCacheTest {
     }
     val base = Settings()
     assertNotEquals(key(base), key(Settings(_languageShortCode = "de-DE")))
-    assertNotEquals(key(base), key(Settings(_allDictionaries = mapOf("en-US" to setOf("x")))))
+    assertNotEquals(
+      key(base),
+      key(Settings(_allDictionaries = mapOf("en-US" to FileSettings.of("x")))),
+    )
   }
 
   @Test

--- a/src/test/kotlin/org/bsplines/ltexls/server/CompletionListProviderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/CompletionListProviderTest.kt
@@ -8,6 +8,7 @@
 
 package org.bsplines.ltexls.server
 
+import org.bsplines.ltexls.settings.FileSettings
 import org.eclipse.lsp4j.CompletionItem
 import org.eclipse.lsp4j.CompletionItemKind
 import org.eclipse.lsp4j.CompletionList
@@ -22,7 +23,7 @@ class CompletionListProviderTest {
     val languageServer = LtexLanguageServer()
     languageServer.settingsManager.settings =
       languageServer.settingsManager.settings.copy(
-        _allDictionaries = mapOf(Pair("en-US", setOf("testfoobar"))),
+        _allDictionaries = mapOf(Pair("en-US", FileSettings.of("testfoobar"))),
       )
 
     val document =
@@ -104,7 +105,7 @@ class CompletionListProviderTest {
     val languageServer = LtexLanguageServer()
     languageServer.settingsManager.settings =
       languageServer.settingsManager.settings.copy(
-        _allDictionaries = mapOf(Pair("en-US", setOf("testfoobar"))),
+        _allDictionaries = mapOf(Pair("en-US", FileSettings.of("testfoobar"))),
       )
 
     val document =

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerCacheTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerCacheTest.kt
@@ -11,6 +11,7 @@ package org.bsplines.ltexls.server
 import org.bsplines.ltexls.languagetool.LanguageToolRuleMatch
 import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 import org.bsplines.ltexls.parsing.FragmentCache
+import org.bsplines.ltexls.settings.FileSettings
 import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.settings.SettingsManager
 import org.eclipse.lsp4j.DidCloseTextDocumentParams
@@ -142,7 +143,7 @@ class DocumentCheckerCacheTest {
     checker.settingsManager.settings =
       Settings(
         _logLevel = Level.FINEST,
-        _allDictionaries = mapOf("en-US" to setOf("qwertyunknown")),
+        _allDictionaries = mapOf("en-US" to FileSettings.of("qwertyunknown")),
       )
 
     assertEquals(0, checker.check(document).first.size)

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -12,8 +12,11 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.bsplines.ltexls.languagetool.LanguageToolRuleMatch
 import org.bsplines.ltexls.parsing.AnnotatedTextFragment
+import org.bsplines.ltexls.settings.FileSettings
 import org.bsplines.ltexls.settings.HiddenFalsePositive
+import org.bsplines.ltexls.settings.MockSettingsFileManager
 import org.bsplines.ltexls.settings.Settings
+import org.bsplines.ltexls.settings.SettingsFileManager
 import org.bsplines.ltexls.settings.SettingsManager
 import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionContext
@@ -548,12 +551,14 @@ class DocumentCheckerTest {
     val jsonWorkspaceSpecificSettings = JsonObject()
     jsonWorkspaceSpecificSettings.add("dictionary", jsonDictionaryObject)
 
+    val settingsFileManager = MockSettingsFileManager()
     var document =
       createDocument(
         "latex",
         "This is an unknownword.\n% ltex: language=de-DE\nDies ist ein unbekannteswort.\n",
       )
-    var settings: Settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    var settings: Settings =
+      Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     var checkingResult: Pair<List<LanguageToolRuleMatch>, List<AnnotatedTextFragment>> =
       checkDocument(document, settings)
     assertEquals(1, checkingResult.first.size)
@@ -562,7 +567,7 @@ class DocumentCheckerTest {
     settings = Settings(_languageShortCode = "sk-SK")
     checkingResult = checkDocument(document, settings)
     assertEquals(1, checkingResult.first.size)
-    settings = settings.copy(_allDictionaries = mapOf(Pair("sk-SK", setOf("pekn\u00e9"))))
+    settings = settings.copy(_allDictionaries = mapOf(Pair("sk-SK", FileSettings.of("pekn\u00e9"))))
     checkingResult = checkDocument(document, settings)
     assertEquals(0, checkingResult.first.size)
 
@@ -570,7 +575,7 @@ class DocumentCheckerTest {
     settings = Settings(_languageShortCode = "fr")
     checkingResult = checkDocument(document, settings)
     assertEquals(1, checkingResult.first.size)
-    settings = settings.copy(_allDictionaries = mapOf(Pair("fr", setOf("mmots"))))
+    settings = settings.copy(_allDictionaries = mapOf(Pair("fr", FileSettings.of("mmots"))))
     checkingResult = checkDocument(document, settings)
     assertEquals(0, checkingResult.first.size)
 
@@ -578,7 +583,7 @@ class DocumentCheckerTest {
     settings = Settings()
     checkingResult = checkDocument(document, settings)
     assertEquals(1, checkingResult.first.size)
-    settings = settings.copy(_allDictionaries = mapOf(Pair("en-US", setOf("LTEX LS"))))
+    settings = settings.copy(_allDictionaries = mapOf(Pair("en-US", FileSettings.of("LTEX LS"))))
     checkingResult = checkDocument(document, settings)
     assertEquals(0, checkingResult.first.size)
   }
@@ -592,7 +597,8 @@ class DocumentCheckerTest {
           mapOf(
             Pair(
               "en-US",
-              setOf(HiddenFalsePositive("MORFOLOGIK_RULE_EN_US", "This is an unknownword\\.")),
+              FileSettings
+                .of(HiddenFalsePositive("MORFOLOGIK_RULE_EN_US", "This is an unknownword\\.")),
             ),
           ),
       )

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -627,21 +627,17 @@ class DocumentCheckerTest {
       val manager = BasicSettingsFileManager().rooted(tempDir)
       val document = createDocument("markdown", "Checking customword spelling.\n")
 
-      // Load settings via file reference
       val fileSettings = FileSettings.fromListOfStrings(listOf(":${testFile.fileName}"), manager)
       var settings = Settings(_allDictionaries = mapOf("en-US" to fileSettings))
 
       var checkingResult = checkDocument(document, settings)
-      // "customword" is now in the dictionary, so there should be no errors!
       assertEquals(0, checkingResult.first.size)
 
-      // Apply override to subtract "customword"
       val override = SettingsOverride(settings)
       override.updateCurrentDictionary("customword", included = false)
       settings = override.toSettings()
 
       checkingResult = checkDocument(document, settings)
-      // "customword" is removed, so it should be flagged as a typo now!
       assertEquals(1, checkingResult.first.size)
     } finally {
       Files.deleteIfExists(testFile)

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -12,12 +12,13 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.bsplines.ltexls.languagetool.LanguageToolRuleMatch
 import org.bsplines.ltexls.parsing.AnnotatedTextFragment
+import org.bsplines.ltexls.settings.BasicSettingsFileManager
 import org.bsplines.ltexls.settings.FileSettings
 import org.bsplines.ltexls.settings.HiddenFalsePositive
 import org.bsplines.ltexls.settings.MockSettingsFileManager
 import org.bsplines.ltexls.settings.Settings
-import org.bsplines.ltexls.settings.SettingsFileManager
 import org.bsplines.ltexls.settings.SettingsManager
+import org.bsplines.ltexls.settings.SettingsOverride
 import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionContext
 import org.eclipse.lsp4j.CodeActionParams
@@ -26,6 +27,7 @@ import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextDocumentIdentifier
 import org.eclipse.lsp4j.jsonrpc.messages.Either
+import java.nio.file.Files
 import java.util.logging.Level
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -614,6 +616,37 @@ class DocumentCheckerTest {
     settings = Settings(_languageShortCode = "nl")
     checkingResult = checkDocument(document, settings)
     assertEquals(1, checkingResult.first.size)
+  }
+
+  @Test
+  fun testSettingsFileLoading() {
+    val tempDir = Files.createTempDirectory("ltex-doc-check-test")
+    val testFile = Files.createTempFile(tempDir, "dict", ".txt")
+    Files.write(testFile, listOf("customword"))
+    try {
+      val manager = BasicSettingsFileManager().rooted(tempDir)
+      val document = createDocument("markdown", "Checking customword spelling.\n")
+
+      // Load settings via file reference
+      val fileSettings = FileSettings.fromListOfStrings(listOf(":${testFile.fileName}"), manager)
+      var settings = Settings(_allDictionaries = mapOf("en-US" to fileSettings))
+
+      var checkingResult = checkDocument(document, settings)
+      // "customword" is now in the dictionary, so there should be no errors!
+      assertEquals(0, checkingResult.first.size)
+
+      // Apply override to subtract "customword"
+      val override = SettingsOverride(settings)
+      override.updateCurrentDictionary("customword", included = false)
+      settings = override.toSettings()
+
+      checkingResult = checkDocument(document, settings)
+      // "customword" is removed, so it should be flagged as a typo now!
+      assertEquals(1, checkingResult.first.size)
+    } finally {
+      Files.deleteIfExists(testFile)
+      Files.deleteIfExists(tempDir)
+    }
   }
 
   companion object {

--- a/src/test/kotlin/org/bsplines/ltexls/server/LtexLanguageServerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/LtexLanguageServerTest.kt
@@ -20,20 +20,17 @@ class LtexLanguageServerTest {
   fun testDeepestWorkspaceRootSelection() {
     val server = LtexLanguageServer()
 
-    // Create real directories so Canonical.from can resolve toRealPath()
     val tempDir = Files.createTempDirectory("ltex-root-test")
     val subProjectDir = tempDir.resolve("subproject")
     subProjectDir.createDirectories()
 
     try {
       val root1 =
-        LtexLanguageServer.Canonical.from(
-          WorkspaceFolder(tempDir.toUri().toString(), "root"),
-        )!!
+        LtexLanguageServer.Canonical
+          .from(WorkspaceFolder(tempDir.toUri().toString(), "root"))!!
       val root2 =
-        LtexLanguageServer.Canonical.from(
-          WorkspaceFolder(subProjectDir.toUri().toString(), "sub"),
-        )!!
+        LtexLanguageServer.Canonical
+          .from(WorkspaceFolder(subProjectDir.toUri().toString(), "sub"))!!
 
       server.workspaceRoots = listOf(root1, root2)
 
@@ -60,13 +57,11 @@ class LtexLanguageServerTest {
     val extDir = Files.createTempDirectory("ltex-ext-other")
     try {
       val root =
-        LtexLanguageServer.Canonical.from(
-          WorkspaceFolder(tempDir.toUri().toString(), "root"),
-        )!!
+        LtexLanguageServer.Canonical
+          .from(WorkspaceFolder(tempDir.toUri().toString(), "root"))!!
 
       server.workspaceRoots = listOf(root)
 
-      // Resolve root for a file outside the workspace
       val externalFile = extDir.resolve("doc.md")
       Files.createFile(externalFile)
       val resolvedRoot = server.relativePathRoot(externalFile.toUri().toString())
@@ -88,16 +83,11 @@ class LtexLanguageServerTest {
     val tempDir = Files.createTempDirectory("ltex-virt-test")
     try {
       val root =
-        LtexLanguageServer.Canonical.from(
-          WorkspaceFolder(tempDir.toUri().toString(), "root"),
-        )!!
+        LtexLanguageServer.Canonical
+          .from(WorkspaceFolder(tempDir.toUri().toString(), "root"))!!
 
       server.workspaceRoots = listOf(root)
-
-      // Resolve root for an unsaved file (virtual URI scheme)
       val resolvedRoot = server.relativePathRoot("untitled:Untitled-1")
-
-      // Should fall back to the first available workspace root
       assertEquals(tempDir.toRealPath(), resolvedRoot.toRealPath())
     } finally {
       Files.deleteIfExists(tempDir)

--- a/src/test/kotlin/org/bsplines/ltexls/server/LtexLanguageServerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/LtexLanguageServerTest.kt
@@ -1,0 +1,106 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.server
+
+import org.eclipse.lsp4j.WorkspaceFolder
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LtexLanguageServerTest {
+  @Test
+  fun testDeepestWorkspaceRootSelection() {
+    val server = LtexLanguageServer()
+
+    // Create real directories so Canonical.from can resolve toRealPath()
+    val tempDir = Files.createTempDirectory("ltex-root-test")
+    val subProjectDir = tempDir.resolve("subproject")
+    subProjectDir.createDirectories()
+
+    try {
+      val root1 =
+        LtexLanguageServer.Canonical.from(
+          WorkspaceFolder(tempDir.toUri().toString(), "root"),
+        )!!
+      val root2 =
+        LtexLanguageServer.Canonical.from(
+          WorkspaceFolder(subProjectDir.toUri().toString(), "sub"),
+        )!!
+
+      server.workspaceRoots = listOf(root1, root2)
+
+      // Nested file should resolve to the subproject root
+      val nestedFile = subProjectDir.resolve("src/Main.kt")
+      nestedFile.parent.createDirectories()
+      Files.createFile(nestedFile)
+
+      val resolvedRoot = server.relativePathRoot(nestedFile.toUri().toString())
+      assertEquals(subProjectDir.toRealPath(), resolvedRoot.toRealPath())
+    } finally {
+      Files.deleteIfExists(subProjectDir.resolve("src/Main.kt"))
+      Files.deleteIfExists(subProjectDir.resolve("src"))
+      Files.deleteIfExists(subProjectDir)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+
+  @Test
+  fun testExternalFileFallback() {
+    val server = LtexLanguageServer()
+
+    val tempDir = Files.createTempDirectory("ltex-ext-test")
+    val extDir = Files.createTempDirectory("ltex-ext-other")
+    try {
+      val root =
+        LtexLanguageServer.Canonical.from(
+          WorkspaceFolder(tempDir.toUri().toString(), "root"),
+        )!!
+
+      server.workspaceRoots = listOf(root)
+
+      // Resolve root for a file outside the workspace
+      val externalFile = extDir.resolve("doc.md")
+      Files.createFile(externalFile)
+      val resolvedRoot = server.relativePathRoot(externalFile.toUri().toString())
+
+      // Should fall back to user home directory
+      val expectedHome = Path.of(System.getProperty("user.home")).toRealPath()
+      assertEquals(expectedHome, resolvedRoot.toRealPath())
+    } finally {
+      Files.deleteIfExists(extDir.resolve("doc.md"))
+      Files.deleteIfExists(extDir)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+
+  @Test
+  fun testVirtualDocumentFallback() {
+    val server = LtexLanguageServer()
+
+    val tempDir = Files.createTempDirectory("ltex-virt-test")
+    try {
+      val root =
+        LtexLanguageServer.Canonical.from(
+          WorkspaceFolder(tempDir.toUri().toString(), "root"),
+        )!!
+
+      server.workspaceRoots = listOf(root)
+
+      // Resolve root for an unsaved file (virtual URI scheme)
+      val resolvedRoot = server.relativePathRoot("untitled:Untitled-1")
+
+      // Should fall back to the first available workspace root
+      assertEquals(tempDir.toRealPath(), resolvedRoot.toRealPath())
+    } finally {
+      Files.deleteIfExists(tempDir)
+    }
+  }
+}

--- a/src/test/kotlin/org/bsplines/ltexls/settings/FileSettingsTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/settings/FileSettingsTest.kt
@@ -1,0 +1,116 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.settings
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FileSettingsTest {
+  @Test
+  fun testPrecedenceLastWins() {
+    val fileSettings1 =
+      FileSettings(
+        listOf(
+          FileSettings.Item.Literal("FOO", subtract = false),
+          FileSettings.Item.Literal("FOO", subtract = true),
+        ),
+      )
+    assertTrue(fileSettings1.values.isEmpty())
+
+    val fileSettings2 =
+      FileSettings(
+        listOf(
+          FileSettings.Item.Literal("FOO", subtract = true),
+          FileSettings.Item.Literal("FOO", subtract = false),
+        ),
+      )
+    assertEquals(setOf("FOO"), fileSettings2.values)
+
+    val fileSettings3 =
+      FileSettings(
+        listOf(
+          FileSettings.Item.Literal("FOO", subtract = false),
+          FileSettings.Item.Literal("FOO", subtract = true),
+          FileSettings.Item.Literal("FOO", subtract = false),
+        ),
+      )
+    assertEquals(setOf("FOO"), fileSettings3.values)
+  }
+
+  @Test
+  fun testSubtractionOnEmpty() {
+    val fileSettings =
+      FileSettings(listOf(FileSettings.Item.Literal("BAR", subtract = true)))
+    assertTrue(fileSettings.values.isEmpty())
+  }
+
+  @Test
+  fun testEmptyPathHandling() {
+    val tempDir = Files.createTempDirectory("ltex-empty-path-test")
+    try {
+      val manager = BasicSettingsFileManager().rooted(tempDir)
+      assertNull(manager.resolve(""))
+    } finally {
+      Files.deleteIfExists(tempDir)
+    }
+  }
+
+  @Test
+  fun testRelativePathResolution() {
+    val tempDir = Files.createTempDirectory("ltex-rel-path-test")
+    val testFile = Files.createTempFile(tempDir, "dict", ".txt")
+    try {
+      val manager = BasicSettingsFileManager().rooted(tempDir)
+      val resolved = manager.resolve(testFile.fileName.toString())
+      assertEquals(testFile.toRealPath(), resolved?.canonicalPath)
+    } finally {
+      Files.deleteIfExists(testFile)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+
+  @Test
+  fun testFromJsonArray() {
+    val tempDir = Files.createTempDirectory("ltex-json-array-test")
+    val testFile = Files.createTempFile(tempDir, "dict", ".txt")
+    Files.write(testFile, listOf("file-word-1", "-file-word-2", "-file-subtracted-word"))
+    try {
+      val manager = BasicSettingsFileManager().rooted(tempDir)
+      val jsonArray = JsonArray()
+      jsonArray.add("literal-word")
+      jsonArray.add("-subtracted-word")
+      jsonArray.add("file-subtracted-word")
+      jsonArray.add(":${testFile.fileName}")
+
+      val objectElement = JsonObject()
+      objectElement.addProperty("value", "object-word")
+      objectElement.addProperty("ignored", "ignored-word")
+      jsonArray.add(objectElement)
+
+      val fileSettings =
+        FileSettings.fromJsonArray(
+          jsonArray,
+          manager,
+          stringParser = { it },
+          objectParser = { it.get("value").asJsonPrimitive.asString },
+        )
+
+      val expected = setOf("literal-word", "file-word-1", "object-word")
+      assertEquals(expected, fileSettings.values)
+    } finally {
+      Files.deleteIfExists(testFile)
+      Files.deleteIfExists(tempDir)
+    }
+  }
+}

--- a/src/test/kotlin/org/bsplines/ltexls/settings/MockSettingsFileManager.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/settings/MockSettingsFileManager.kt
@@ -1,0 +1,23 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.settings
+
+import org.bsplines.ltexls.server.LtexLanguageServer
+import java.nio.file.Path
+
+class MockSettingsFileManager : SettingsFileManager.Rooted {
+  override fun loadFile(path: Path): List<String> =
+    throw UnsupportedOperationException("MockSettingsFileManager does not support loading files")
+
+  override fun resolve(path: String): LtexLanguageServer.Canonical<String> =
+    throw UnsupportedOperationException("MockSettingsFileManager does not support resolving paths")
+
+  override fun rooted(root: Path): SettingsFileManager.Rooted =
+    throw UnsupportedOperationException("MockSettingsFileManager does not support explicit roots")
+}

--- a/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
@@ -12,6 +12,7 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.eclipse.lsp4j.DiagnosticSeverity
 import java.util.logging.Level
+import kotlin.io.path.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -414,7 +415,9 @@ class SettingsTest {
     jsonWorkspaceSpecificSettings.add("dictionary", dictionary)
     jsonWorkspaceSpecificSettings.add("hiddenFalsePositives", hiddenFalsePositives)
 
-    var settings: Settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    val settingsFileManager = MockSettingsFileManager()
+    var settings: Settings =
+      Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(emptySet<Any>(), settings.enabled)
     assertEquals(setOf("wordtwo"), settings.dictionary)
     assertEquals(setOf(HiddenFalsePositive("rule", "sentence")), settings.hiddenFalsePositives)
@@ -431,26 +434,26 @@ class SettingsTest {
     hiddenFalsePositives.add("en-US", vscodeLTeXJSON)
     jsonWorkspaceSpecificSettings = JsonObject()
     jsonWorkspaceSpecificSettings.add("hiddenFalsePositives", hiddenFalsePositives)
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(setOf(HiddenFalsePositive("rule", "sentence")), settings.hiddenFalsePositives)
 
     jsonSettings.addProperty("diagnosticSeverity", "error")
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(mapOf(Pair("default", DiagnosticSeverity.Error)), settings.diagnosticSeverity)
 
     jsonSettings.addProperty("diagnosticSeverity", "warning")
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(mapOf(Pair("default", DiagnosticSeverity.Warning)), settings.diagnosticSeverity)
 
     jsonSettings.addProperty("diagnosticSeverity", "information")
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(
       mapOf(Pair("default", DiagnosticSeverity.Information)),
       settings.diagnosticSeverity,
     )
 
     jsonSettings.addProperty("diagnosticSeverity", "hint")
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(mapOf(Pair("default", DiagnosticSeverity.Hint)), settings.diagnosticSeverity)
 
     val diagnosticSeverity = JsonObject()
@@ -458,29 +461,29 @@ class SettingsTest {
     diagnosticSeverity.addProperty("default", "error")
 
     jsonSettings.add("diagnosticSeverity", diagnosticSeverity)
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(
       mapOf(Pair("ruleId", DiagnosticSeverity.Warning), Pair("default", DiagnosticSeverity.Error)),
       settings.diagnosticSeverity,
     )
 
     jsonSettings.addProperty("checkFrequency", "edit")
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(Settings.CheckFrequency.Edit, settings.checkFrequency)
 
     jsonSettings.addProperty("checkFrequency", "save")
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(Settings.CheckFrequency.Save, settings.checkFrequency)
 
     jsonSettings.addProperty("checkFrequency", "manual")
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     assertEquals(Settings.CheckFrequency.Manual, settings.checkFrequency)
 
     val preferredVariantsArray = JsonArray()
     preferredVariantsArray.add("en-gb")
     preferredVariantsArray.add("DE-at")
     jsonSettings.add("preferredVariants", preferredVariantsArray)
-    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings)
+    settings = Settings.fromJson(jsonSettings, jsonWorkspaceSpecificSettings, settingsFileManager)
     // Each entry is canonicalised (lang lowercase + region uppercase, variant preserved)
     // and merged with DEFAULT_PREFERRED_VARIANTS: en-GB and de-AT override the default
     // en-US and de-DE; the default pt-BR is kept since the user did not specify a


### PR DESCRIPTION
This is the first of three PRs aimed at bringing settings files support and server-side implementation of `addToDictionary`, `disableRules` and `hideFalsePositive` commands. 

**This PR is a draft and should not be merged yet.** I'm making this PR to get feedback on it before I sink more time into the subsequent PRs. The second PR will bring file caching and watching, and this PR probably should not be merged before that one is ready.

This PR lays the groundwork for supporting settings files. The bulk of that is a new `FileSettings` abstraction -- under the hood just a value of a sealed hierarchy, `FileSettings.Item`, representing either a literal setting value or a loaded settings file, aiming to mirror the structure of the settings' format. It's written to be generic across any type (and works for `String` for dictionary and enabled/disabled rules as well as `HiddenFalsePositive`), but assumes some basic structure of these settings:
- They are specified as a JSON array.
- The values in the array are strings, except for hidden false positives, where actual JSON objects are allowed too.
- A string starting with ":" is a settings file path. If the path begins with "~" or "/" it is considered absolute, otherwise it is resolved as relative.
- A string starting with "-" represents undoing the corresponding setting.

The settings files require a format of one setting value per line. That is intuitive for dictionary and rules settings, but slightly unintuitive for hidden false positives. There, it means that a hidden false positives settings file cannot be a normal JSON array file, but instead must be a newline-separated list of single-line JSON objects. It might be worth it to allow this setting to be a normal JSON file too, I leave that for the discussion in this PR.

A second abstraction is `SettingsFileManager`. This is an interface for loading a settings file. Currently, two implementations are provided: one for just reading the file and a mocked one for tests. In the followup PR, I would like to add a cached one, which would keep track of the necessary settings files, cache them and use LSP watched files to reload them when needed.

### Relative path resolution

In the vscode extension, relative paths are resolved relative to the `.vscode` directory in which they are defined. That is not possible in the LS, since it has no knowledge of the client's user / workspace / workspace folder settings hierarchy. 

As an aside, I believe this is the main reason settings files were left client-side up until now. I believe this PR should not break that -- extensions which inject themselves between the client and the LS and provide a better experience should not be affected by this PR (in other words I believe this PR does not break the vscode extension which resolves all settings files itself and passes raw settings values down to the LS; I don't use vscode and haven't tested this yet myself). This PR just adds a client-independent implementation.

Since we cannot rely on the settings file hierarchy, we need a different way to resolve relative files. As such, this PR tracks workspace roots, then resolves paths relative to the most specific workspace root of the currently checked document. When a document does not match any open workspace root, the user's home directory is used as a fallback. To facilitate this, the language server now tracks the workspace folder roots using the [workspace folders request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_workspaceFolders) and the [corresponding didChange notification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_didChangeWorkspaceFolders). For clients that do not support workspace folders, this falls back on the `rootUri` property of the initialize request (I decided **not** to go further down the rabbit hole by falling back to `rootPath` for clients not even supporting `rootUri` -- `rootUri` was introduced with LSP 3.0 in 2017. I'm open to discussion on this, haven't really done an analysis of what clients support which capabilities).

This has the caveat that the same relative path in the LS configuration can be resolved relative to different root for documents in different root folders of one workspace. That should be fine in my opinion though; IIUC workspace folders should allow users to overwrite LSP configuration, so it should be possible to set different relative paths if necessary.

## Followup PRs

I want to follow this PR up with two PRs:
1. settings file caching
2. LS-side implementation of `addToDictionary`, `disableRule` and `hideFalsePositive` commands.

I believe this PR should not be merged without the second, as I am really not happy with reloading and reparsing all settings files on every document check. The third PR can come later.

Furthermore, I would like to follow up with another PR adding proper error handling for incorrect server configuration and settings files format -- ideally one which would not crash the server and report back to the client using either diagnostics or `showMessage` notifications. That will come later and I'd probably like more discussion before diving into it.