### PR TITLE
Opt-in feature: server managed external files

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -144,6 +144,15 @@ class LtexLanguageServer :
     workspaceFoldersOptions.setChangeNotifications(Either.forRight(true))
     serverCapabilities.workspace = WorkspaceServerCapabilities(workspaceFoldersOptions)
 
+    // Advertise, unconditionally, that this server can manage external setting
+    // files itself (read ":"-prefixed files and persist the quick fixes). Clients
+    // that cannot do this themselves (e.g. Zed, Helix) detect support here rather
+    // than sniffing the version, then opt in with ltex.externalFiles.managedByEditor
+    // = false. "experimental" is simply LSP's slot for non-standard capabilities.
+    val experimentalCapabilities = JsonObject()
+    experimentalCapabilities.addProperty("manageExternalFiles", true)
+    serverCapabilities.experimental = experimentalCapabilities
+
     // Advertise the server's identity and version to the client via serverInfo so it can,
     // e.g., gate features on a minimum version. The version is the JAR manifest's
     // Implementation-Version, stamped at build time as <label>.<commitsSinceReleaseTag>+g<hash>

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -69,6 +69,15 @@ class LtexLanguageServer :
   var clientSupportsWorkspaceSpecificConfiguration: Boolean = false
     private set
 
+  // When true, the server itself reads/writes the external setting files
+  // (e.g. an external dictionary file referenced with a ":" prefix). Driven by
+  // the client opt-in ltex.externalFiles.managedByEditor: the default (true)
+  // means the editor manages those files, so the server stays out and behaves
+  // exactly as before; only a client sending managedByEditor=false flips this on.
+  // Read at initialize because it gates executeCommandProvider (see below).
+  var serverManagesExternalFiles: Boolean = false
+    private set
+
   init {
     // Sweep idle fragment-cache entries on a fixed 60 s cadence. Entries idle
     // longer than ltex.paragraphCacheTtlMinutes are dropped; every cache hit
@@ -115,23 +124,8 @@ class LtexLanguageServer :
     val initializationOptions: JsonElement? = params.initializationOptions as JsonElement?
 
     if ((initializationOptions != null) && initializationOptions.isJsonObject) {
-      val initializationOptionsObject: JsonObject = initializationOptions.asJsonObject
-
-      // make it possible to set locale when using LSP 3.15 (that's what we currently require
-      // as minimum version; InitializeParams.locale was added in LSP 3.16)
-      if (initializationOptionsObject.has("locale")) {
-        localeLanguage = initializationOptionsObject.get("locale").asString
-      }
-
-      if (initializationOptionsObject.has("customCapabilities")) {
-        val customCapabilities: JsonObject =
-          initializationOptionsObject.getAsJsonObject("customCapabilities")
-
-        if (customCapabilities.has("workspaceSpecificConfiguration")) {
-          this.clientSupportsWorkspaceSpecificConfiguration =
-            customCapabilities.get("workspaceSpecificConfiguration").asBoolean
-        }
-      }
+      localeLanguage =
+        applyInitializationOptions(initializationOptions.asJsonObject, localeLanguage)
     }
 
     if (localeLanguage != null) I18n.setLocale(Locale.forLanguageTag(localeLanguage))
@@ -142,7 +136,7 @@ class LtexLanguageServer :
       Either.forRight(CodeActionOptions(CodeActionProvider.getCodeActionKinds()))
     serverCapabilities.completionProvider = CompletionOptions().apply { resolveProvider = false }
     serverCapabilities.executeCommandProvider =
-      ExecuteCommandOptions(LtexWorkspaceService.getCommandNames())
+      ExecuteCommandOptions(LtexWorkspaceService.getCommandNames(this.serverManagesExternalFiles))
     serverCapabilities.textDocumentSync = Either.forLeft(TextDocumentSyncKind.Full)
 
     val workspaceFoldersOptions = WorkspaceFoldersOptions()
@@ -156,6 +150,52 @@ class LtexLanguageServer :
     // for nightlies (see pom.xml / git-commit-id-maven-plugin) and the plain release for releases.
     val serverInfo = ServerInfo("ltex-ls-plus", ltexLsPackage?.implementationVersion)
     return CompletableFuture.completedFuture(InitializeResult(serverCapabilities, serverInfo))
+  }
+
+  // Reads locale and the custom/opt-in flags from initializationOptions, returning
+  // the (possibly updated) locale. Split out of initialize() to keep that method's
+  // complexity and nesting within bounds.
+  private fun applyInitializationOptions(
+    initializationOptionsObject: JsonObject,
+    currentLocale: String?,
+  ): String? {
+    // make it possible to set locale when using LSP 3.15 (that's what we currently require
+    // as minimum version; InitializeParams.locale was added in LSP 3.16)
+    val localeLanguage: String? =
+      if (initializationOptionsObject.has("locale")) {
+        initializationOptionsObject.get("locale").asString
+      } else {
+        currentLocale
+      }
+
+    if (initializationOptionsObject.has("customCapabilities")) {
+      val customCapabilities: JsonObject =
+        initializationOptionsObject.getAsJsonObject("customCapabilities")
+
+      if (customCapabilities.has("workspaceSpecificConfiguration")) {
+        this.clientSupportsWorkspaceSpecificConfiguration =
+          customCapabilities.get("workspaceSpecificConfiguration").asBoolean
+      }
+    }
+
+    this.serverManagesExternalFiles = readServerManagesExternalFiles(initializationOptionsObject)
+    return localeLanguage
+  }
+
+  // ltex.externalFiles.managedByEditor (default true). Thin clients that cannot
+  // manage external setting files themselves (e.g. Zed, Helix) send false to hand
+  // that responsibility to the server. Delivered via initializationOptions because
+  // the value must be known at initialize time to decide whether
+  // _ltex.addToDictionary is advertised as a server command.
+  private fun readServerManagesExternalFiles(initializationOptionsObject: JsonObject): Boolean {
+    val ltexObject: JsonObject? =
+      initializationOptionsObject.takeIf { it.has("ltex") }?.getAsJsonObject("ltex")
+    val externalFilesObject: JsonObject? =
+      ltexObject?.takeIf { it.has("externalFiles") }?.getAsJsonObject("externalFiles")
+
+    return (externalFilesObject != null) &&
+      externalFilesObject.has("managedByEditor") &&
+      !externalFilesObject.get("managedByEditor").asBoolean
   }
 
   override fun shutdown(): CompletableFuture<Any> {

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentItem.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexTextDocumentItem.kt
@@ -429,7 +429,11 @@ class LtexTextDocumentItem(
 
       this.raiseExceptionIfCanceled()
       this.languageServer.settingsManager.settings =
-        Settings.fromJson(jsonConfiguration, jsonWorkspaceSpecificConfiguration)
+        Settings.fromJson(
+          jsonConfiguration,
+          jsonWorkspaceSpecificConfiguration,
+          this.languageServer.serverManagesExternalFiles,
+        )
 
       this.raiseExceptionIfCanceled()
       val checkingResult: Pair<List<LanguageToolRuleMatch>, List<AnnotatedTextFragment>> =

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
@@ -37,6 +37,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
+@Suppress("TooManyFunctions")
 class LtexWorkspaceService(
   val languageServer: LtexLanguageServer,
 ) : WorkspaceService {
@@ -90,72 +91,86 @@ class LtexWorkspaceService(
         executeAddToDictionaryCommand(params.arguments[0] as JsonObject)
       }
 
+      DISABLE_RULES_COMMAND_NAME -> {
+        executeDisableRulesCommand(params.arguments[0] as JsonObject)
+      }
+
+      HIDE_FALSE_POSITIVES_COMMAND_NAME -> {
+        executeHideFalsePositivesCommand(params.arguments[0] as JsonObject)
+      }
+
       else -> {
         failCommand(I18n.format("unknownCommand", params.command))
       }
     }
 
-  // Server-side handling of the "Add to dictionary" quick fix, active only when
-  // the client opted into server-managed external files (see LtexLanguageServer.
-  // serverManagesExternalFiles). The command carries { uri, words: { lang: [...] } };
-  // for each language we append the new words to the first external dictionary
-  // file (a ":"-prefixed entry) listed for that language, then re-check documents.
-  fun executeAddToDictionaryCommand(arguments: JsonObject): CompletableFuture<Any> {
-    val words: JsonObject = arguments.getAsJsonObject("words")
-    val allDictionaries: Map<String, Set<String>> =
-      this.languageServer.settingsManager.settings.allDictionaries
+  // The three server-side quick fixes ("Add to dictionary", "Disable rule", "Hide
+  // false positive"), active only when the client opted into server-managed
+  // external files. Each command carries { uri, <key>: { lang: [entry, ...] } };
+  // they differ only in the argument key and which setting's external file to
+  // write, so they all delegate to executeAppendToExternalFileCommand.
+  fun executeAddToDictionaryCommand(arguments: JsonObject): CompletableFuture<Any> =
+    executeAppendToExternalFileCommand(arguments, "dictionary", "words")
 
-    var addedAnyWord = false
+  fun executeDisableRulesCommand(arguments: JsonObject): CompletableFuture<Any> =
+    executeAppendToExternalFileCommand(arguments, "disabledRules", "ruleIds")
+
+  fun executeHideFalsePositivesCommand(arguments: JsonObject): CompletableFuture<Any> =
+    executeAppendToExternalFileCommand(arguments, "hiddenFalsePositives", "falsePositives")
+
+  // Appends each language's entries to the first external file configured for that
+  // setting/language (resolved during settings expansion, see Settings), then
+  // re-checks open documents. No external file for a language → warning; if nothing
+  // could be written, the command fails.
+  private fun executeAppendToExternalFileCommand(
+    arguments: JsonObject,
+    settingName: String,
+    argumentKey: String,
+  ): CompletableFuture<Any> {
+    val entriesByLanguage: JsonObject = arguments.getAsJsonObject(argumentKey)
+    val settings = this.languageServer.settingsManager.settings
+
+    var appendedAny = false
     var languageWithoutExternalFile: String? = null
 
-    for ((language: String, wordsElement) in words.entrySet()) {
-      val newWords: List<String> = wordsElement.asJsonArray.map { it.asString }
-      val externalFilePath: Path? = resolveFirstExternalDictionaryFile(allDictionaries[language])
+    for ((language: String, element) in entriesByLanguage.entrySet()) {
+      val entries: List<String> = element.asJsonArray.map { it.asString }
+      val filePath: String? = settings.firstExternalSettingFile(settingName, language)
 
-      if (externalFilePath == null) {
+      if (filePath == null) {
         languageWithoutExternalFile = language
-        Logging.LOGGER.warning(I18n.format("noExternalDictionaryFileForLanguage", language))
+        Logging.LOGGER.warning(I18n.format("noExternalFileForSetting", settingName, language))
         continue
       }
 
-      if (appendWordsToExternalFile(externalFilePath, newWords)) addedAnyWord = true
+      if (appendEntriesToExternalFile(Paths.get(filePath), entries)) appendedAny = true
     }
 
-    if (!addedAnyWord && languageWithoutExternalFile != null) {
+    if (!appendedAny && (languageWithoutExternalFile != null)) {
       return failCommand(
-        I18n.format("noExternalDictionaryFileForLanguage", languageWithoutExternalFile),
+        I18n.format("noExternalFileForSetting", settingName, languageWithoutExternalFile),
       )
     }
 
-    if (addedAnyWord) recheckAllDocuments()
+    if (appendedAny) recheckAllDocuments()
 
     val jsonObject = JsonObject()
     jsonObject.addProperty("success", true)
     return CompletableFuture.completedFuture(jsonObject)
   }
 
-  // Returns the resolved path of the first ":"-prefixed (external file) entry in
-  // the given dictionary, or null if none is present. A leading "~" is expanded
-  // to the home directory; the demo assumes absolute paths (no workspace-root
-  // resolution yet).
-  private fun resolveFirstExternalDictionaryFile(dictionaryEntries: Set<String>?): Path? {
-    val entry: String =
-      dictionaryEntries?.firstOrNull { it.startsWith(EXTERNAL_FILE_PREFIX) } ?: return null
-    return Paths.get(FileIo.normalizePath(entry.substring(EXTERNAL_FILE_PREFIX.length)))
-  }
-
-  // Appends the given words to the external dictionary file. Mirrors the format of
+  // Appends the given entries to the external file. Mirrors the format of
   // vscode-ltex-plus's ExternalFileManager.appendToFile so a file stays compatible
   // across editors: the existing content is preserved verbatim, a trailing line
   // separator is ensured, and each new entry is appended on its own line using the
   // platform line separator. Like the VS Code extension, this does not deduplicate
   // (duplicate lines collapse anyway when the file is read back into the set-valued
-  // dictionary). Returns true if the file was modified.
-  private fun appendWordsToExternalFile(
+  // setting). Returns true if the file was modified.
+  private fun appendEntriesToExternalFile(
     path: Path,
-    newWords: List<String>,
+    newEntries: List<String>,
   ): Boolean {
-    if (newWords.isEmpty()) return false
+    if (newEntries.isEmpty()) return false
 
     val lineSeparator: String = System.lineSeparator()
     val existingContents: String = if (Files.exists(path)) (FileIo.readFile(path) ?: "") else ""
@@ -165,12 +180,12 @@ class LtexWorkspaceService(
     // does not already end with one (treating space/CR/LF as ignorable).
     val hasContent: Boolean = existingContents.any { (it != ' ') && (it != '\r') && (it != '\n') }
     if (hasContent && !existingContents.endsWith(lineSeparator)) builder.append(lineSeparator)
-    builder.append(newWords.joinToString(lineSeparator)).append(lineSeparator)
+    builder.append(newEntries.joinToString(lineSeparator)).append(lineSeparator)
 
     path.parent?.let { Files.createDirectories(it) }
     FileIo.writeFile(path, builder.toString())
     Logging.LOGGER.info(
-      I18n.format("addedWordsToExternalDictionaryFile", newWords.size, path.toString()),
+      I18n.format("addedEntriesToExternalSettingFile", newEntries.size, path.toString()),
     )
     return true
   }
@@ -306,9 +321,8 @@ class LtexWorkspaceService(
     private const val CHECK_DOCUMENT_COMMAND_NAME = "_ltex.checkDocument"
     private const val GET_SERVER_STATUS_COMMAND_NAME = "_ltex.getServerStatus"
     private const val ADD_TO_DICTIONARY_COMMAND_NAME = "_ltex.addToDictionary"
-
-    // Prefix marking a dictionary entry as an external file path (LTeX convention).
-    private const val EXTERNAL_FILE_PREFIX = ":"
+    private const val DISABLE_RULES_COMMAND_NAME = "_ltex.disableRules"
+    private const val HIDE_FALSE_POSITIVES_COMMAND_NAME = "_ltex.hideFalsePositives"
 
     private const val CHECK_CHECKING_STATUS_MILLISECONDS = 10L
     private const val MILLISECONDS_PER_SECOND = 1e3
@@ -321,14 +335,18 @@ class LtexWorkspaceService(
       return CompletableFuture.completedFuture(jsonObject)
     }
 
-    // _ltex.addToDictionary is advertised as a server command only when the client
-    // delegates external-file management to the server. Editor-managed clients
-    // (the default) keep handling that quick fix themselves, so the advertised
-    // command set — and the init response — stay byte-identical for them.
+    // The external-file quick-fix commands are advertised as server commands only
+    // when the client delegates external-file management to the server. Editor-
+    // managed clients (the default) keep handling these quick fixes themselves, so
+    // the advertised command set — and the init response — stay byte-identical.
     fun getCommandNames(serverManagesExternalFiles: Boolean = false): List<String> {
       val commandNames: MutableList<String> =
         mutableListOf(CHECK_DOCUMENT_COMMAND_NAME, GET_SERVER_STATUS_COMMAND_NAME)
-      if (serverManagesExternalFiles) commandNames.add(ADD_TO_DICTIONARY_COMMAND_NAME)
+      if (serverManagesExternalFiles) {
+        commandNames.add(ADD_TO_DICTIONARY_COMMAND_NAME)
+        commandNames.add(DISABLE_RULES_COMMAND_NAME)
+        commandNames.add(HIDE_FALSE_POSITIVES_COMMAND_NAME)
+      }
       return commandNames
     }
   }

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexWorkspaceService.kt
@@ -25,6 +25,7 @@ import org.eclipse.lsp4j.services.WorkspaceService
 import java.lang.management.ManagementFactory
 import java.net.URI
 import java.net.URISyntaxException
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Duration
@@ -40,6 +41,14 @@ class LtexWorkspaceService(
   val languageServer: LtexLanguageServer,
 ) : WorkspaceService {
   override fun didChangeConfiguration(params: DidChangeConfigurationParams) {
+    recheckAllDocuments()
+  }
+
+  // Re-check and re-publish diagnostics for every open document. Used both when
+  // configuration changes and after the server mutates an external setting file
+  // (so a freshly added dictionary word clears its diagnostic on the next check,
+  // which re-reads and re-expands the external file).
+  private fun recheckAllDocuments() {
     this.languageServer.ltexTextDocumentService
       .executeFunctionForEachDocument { document: LtexTextDocumentItem ->
         if (document.beingChecked) document.cancelCheck()
@@ -69,10 +78,102 @@ class LtexWorkspaceService(
 
   override fun executeCommand(params: ExecuteCommandParams): CompletableFuture<Any> =
     when (params.command) {
-      CHECK_DOCUMENT_COMMAND_NAME -> executeCheckDocumentCommand(params.arguments[0] as JsonObject)
-      GET_SERVER_STATUS_COMMAND_NAME -> executeGetServerStatusCommand()
-      else -> failCommand(I18n.format("unknownCommand", params.command))
+      CHECK_DOCUMENT_COMMAND_NAME -> {
+        executeCheckDocumentCommand(params.arguments[0] as JsonObject)
+      }
+
+      GET_SERVER_STATUS_COMMAND_NAME -> {
+        executeGetServerStatusCommand()
+      }
+
+      ADD_TO_DICTIONARY_COMMAND_NAME -> {
+        executeAddToDictionaryCommand(params.arguments[0] as JsonObject)
+      }
+
+      else -> {
+        failCommand(I18n.format("unknownCommand", params.command))
+      }
     }
+
+  // Server-side handling of the "Add to dictionary" quick fix, active only when
+  // the client opted into server-managed external files (see LtexLanguageServer.
+  // serverManagesExternalFiles). The command carries { uri, words: { lang: [...] } };
+  // for each language we append the new words to the first external dictionary
+  // file (a ":"-prefixed entry) listed for that language, then re-check documents.
+  fun executeAddToDictionaryCommand(arguments: JsonObject): CompletableFuture<Any> {
+    val words: JsonObject = arguments.getAsJsonObject("words")
+    val allDictionaries: Map<String, Set<String>> =
+      this.languageServer.settingsManager.settings.allDictionaries
+
+    var addedAnyWord = false
+    var languageWithoutExternalFile: String? = null
+
+    for ((language: String, wordsElement) in words.entrySet()) {
+      val newWords: List<String> = wordsElement.asJsonArray.map { it.asString }
+      val externalFilePath: Path? = resolveFirstExternalDictionaryFile(allDictionaries[language])
+
+      if (externalFilePath == null) {
+        languageWithoutExternalFile = language
+        Logging.LOGGER.warning(I18n.format("noExternalDictionaryFileForLanguage", language))
+        continue
+      }
+
+      if (appendWordsToExternalFile(externalFilePath, newWords)) addedAnyWord = true
+    }
+
+    if (!addedAnyWord && languageWithoutExternalFile != null) {
+      return failCommand(
+        I18n.format("noExternalDictionaryFileForLanguage", languageWithoutExternalFile),
+      )
+    }
+
+    if (addedAnyWord) recheckAllDocuments()
+
+    val jsonObject = JsonObject()
+    jsonObject.addProperty("success", true)
+    return CompletableFuture.completedFuture(jsonObject)
+  }
+
+  // Returns the resolved path of the first ":"-prefixed (external file) entry in
+  // the given dictionary, or null if none is present. A leading "~" is expanded
+  // to the home directory; the demo assumes absolute paths (no workspace-root
+  // resolution yet).
+  private fun resolveFirstExternalDictionaryFile(dictionaryEntries: Set<String>?): Path? {
+    val entry: String =
+      dictionaryEntries?.firstOrNull { it.startsWith(EXTERNAL_FILE_PREFIX) } ?: return null
+    return Paths.get(FileIo.normalizePath(entry.substring(EXTERNAL_FILE_PREFIX.length)))
+  }
+
+  // Appends the given words to the external dictionary file. Mirrors the format of
+  // vscode-ltex-plus's ExternalFileManager.appendToFile so a file stays compatible
+  // across editors: the existing content is preserved verbatim, a trailing line
+  // separator is ensured, and each new entry is appended on its own line using the
+  // platform line separator. Like the VS Code extension, this does not deduplicate
+  // (duplicate lines collapse anyway when the file is read back into the set-valued
+  // dictionary). Returns true if the file was modified.
+  private fun appendWordsToExternalFile(
+    path: Path,
+    newWords: List<String>,
+  ): Boolean {
+    if (newWords.isEmpty()) return false
+
+    val lineSeparator: String = System.lineSeparator()
+    val existingContents: String = if (Files.exists(path)) (FileIo.readFile(path) ?: "") else ""
+
+    val builder = StringBuilder(existingContents)
+    // Match the extension: only add a separator when the file has real content and
+    // does not already end with one (treating space/CR/LF as ignorable).
+    val hasContent: Boolean = existingContents.any { (it != ' ') && (it != '\r') && (it != '\n') }
+    if (hasContent && !existingContents.endsWith(lineSeparator)) builder.append(lineSeparator)
+    builder.append(newWords.joinToString(lineSeparator)).append(lineSeparator)
+
+    path.parent?.let { Files.createDirectories(it) }
+    FileIo.writeFile(path, builder.toString())
+    Logging.LOGGER.info(
+      I18n.format("addedWordsToExternalDictionaryFile", newWords.size, path.toString()),
+    )
+    return true
+  }
 
   fun executeCheckDocumentCommand(arguments: JsonObject): CompletableFuture<Any> {
     val uriStr: String = arguments.get("uri").asString
@@ -204,6 +305,10 @@ class LtexWorkspaceService(
   companion object {
     private const val CHECK_DOCUMENT_COMMAND_NAME = "_ltex.checkDocument"
     private const val GET_SERVER_STATUS_COMMAND_NAME = "_ltex.getServerStatus"
+    private const val ADD_TO_DICTIONARY_COMMAND_NAME = "_ltex.addToDictionary"
+
+    // Prefix marking a dictionary entry as an external file path (LTeX convention).
+    private const val EXTERNAL_FILE_PREFIX = ":"
 
     private const val CHECK_CHECKING_STATUS_MILLISECONDS = 10L
     private const val MILLISECONDS_PER_SECOND = 1e3
@@ -216,7 +321,15 @@ class LtexWorkspaceService(
       return CompletableFuture.completedFuture(jsonObject)
     }
 
-    fun getCommandNames(): List<String> =
-      listOf(CHECK_DOCUMENT_COMMAND_NAME, GET_SERVER_STATUS_COMMAND_NAME)
+    // _ltex.addToDictionary is advertised as a server command only when the client
+    // delegates external-file management to the server. Editor-managed clients
+    // (the default) keep handling that quick fix themselves, so the advertised
+    // command set — and the init response — stay byte-identical for them.
+    fun getCommandNames(serverManagesExternalFiles: Boolean = false): List<String> {
+      val commandNames: MutableList<String> =
+        mutableListOf(CHECK_DOCUMENT_COMMAND_NAME, GET_SERVER_STATUS_COMMAND_NAME)
+      if (serverManagesExternalFiles) commandNames.add(ADD_TO_DICTIONARY_COMMAND_NAME)
+      return commandNames
+    }
   }
 }

--- a/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
@@ -17,6 +17,8 @@ import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
 import org.eclipse.lsp4j.DiagnosticSeverity
 import org.languagetool.Languages
+import java.nio.file.Files
+import java.nio.file.Paths
 import java.util.logging.Level
 
 data class Settings(
@@ -247,18 +249,28 @@ data class Settings(
     fun fromJson(
       jsonSettings: JsonElement,
       jsonWorkspaceSpecificSettings: JsonElement? = null,
+      expandExternalDictionaryFiles: Boolean = false,
     ): Settings {
       val jsonWorkspaceSpecificSettings2 = jsonWorkspaceSpecificSettings ?: jsonSettings
 
       val enabled: Set<String>? = getEnabledFromJson(jsonSettings)
       val languageShortCode: String? =
         getSettingFromJsonAsString(jsonSettings, "language")?.let { normalizeLanguageShortCode(it) }
-      val allDictionaries: Map<String, Set<String>>? =
+      val rawDictionaries: Map<String, Set<String>>? =
         mergeMapOfListsIntoMapOfSets(
           convertJsonObjectToMapOfLists(
             getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "dictionary"),
           ),
         )
+      // Only when the server owns external files (client opted out) do we resolve
+      // ":"-prefixed external dictionary files here; otherwise the dictionary is
+      // passed through verbatim, exactly as before.
+      val allDictionaries: Map<String, Set<String>>? =
+        if (expandExternalDictionaryFiles && (rawDictionaries != null)) {
+          expandExternalFilesInDictionaries(rawDictionaries)
+        } else {
+          rawDictionaries
+        }
       val allDisabledRules: Map<String, Set<String>>? =
         mergeMapOfListsIntoMapOfSets(
           convertJsonObjectToMapOfLists(
@@ -515,6 +527,32 @@ data class Settings(
 
       return resolved
     }
+
+    // Resolves ":"-prefixed external dictionary files: each such entry is kept
+    // (so the server can later locate the file to write into) and the file's
+    // lines are added alongside as regular dictionary words. Missing/unreadable
+    // files are skipped. Non-":" entries pass through untouched.
+    private fun expandExternalFilesInDictionaries(
+      allDictionaries: Map<String, Set<String>>,
+    ): Map<String, Set<String>> =
+      allDictionaries.mapValues { (_, entries: Set<String>) ->
+        // Seed with all original entries (retaining the ":" markers so the server
+        // can later locate the file to write into), then add each external file's
+        // lines as regular dictionary words.
+        val expanded = LinkedHashSet<String>(entries)
+
+        for (entry: String in entries.filter { it.startsWith(":") }) {
+          val path = Paths.get(FileIo.normalizePath(entry.substring(1)))
+          if (Files.exists(path)) {
+            FileIo.readFile(path)?.lines()?.forEach { line: String ->
+              val trimmed: String = line.trim()
+              if (trimmed.isNotEmpty()) expanded.add(trimmed)
+            }
+          }
+        }
+
+        expanded
+      }
 
     private fun getEnabledFromJson(jsonSettings: JsonElement): Set<String>? {
       val jsonElement: JsonElement? = getSettingFromJsonAsJsonElement(jsonSettings, "enabled")

--- a/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
@@ -48,6 +48,10 @@ data class Settings(
   private val _paragraphCacheEnabled: Boolean? = null,
   private val _paragraphCacheTtlMinutes: Long? = null,
   private val _maxRequestSize: Int? = null,
+  // Resolved external setting files: settingName -> language -> first external
+  // file path. Populated only when the server owns external files (client opted
+  // out); used by the server-side quick-fix commands to know where to write.
+  private val _externalSettingFiles: Map<String, Map<String, String>>? = null,
 ) {
   val enabled: Set<String>
     get() = (this._enabled ?: DEFAULT_ENABLED)
@@ -67,6 +71,14 @@ data class Settings(
     get() = (this._allDisabledRules ?: emptyMap())
   val allHiddenFalsePositives: Map<String, Set<HiddenFalsePositive>>
     get() = (this._allHiddenFalsePositives ?: emptyMap())
+
+  // Path of the first external setting file for the given setting/language, or
+  // null if none is configured (or the server is not managing external files).
+  fun firstExternalSettingFile(
+    settingName: String,
+    language: String,
+  ): String? = this._externalSettingFiles?.get(settingName)?.get(language)
+
   val bibtexFields: Map<String, Boolean>
     get() = (this._bibtexFields ?: mapOf())
   val latexCommands: Map<String, String>
@@ -208,7 +220,7 @@ data class Settings(
     Manual,
   }
 
-  @Suppress("TooManyFunctions")
+  @Suppress("TooManyFunctions", "LargeClass")
   companion object {
     val DEFAULT_ENABLED =
       setOf(
@@ -245,46 +257,77 @@ data class Settings(
       mapOf(Pair("default", DiagnosticSeverity.Information))
     val DEFAULT_PREFERRED_VARIANTS: List<String> = listOf("en-US", "de-DE", "pt-BR")
 
+    // Prefix marking a setting entry as an external file path (LTeX convention).
+    private const val EXTERNAL_FILE_PREFIX = ":"
+
     @Suppress("LongMethod")
     fun fromJson(
       jsonSettings: JsonElement,
       jsonWorkspaceSpecificSettings: JsonElement? = null,
-      expandExternalDictionaryFiles: Boolean = false,
+      expandExternalFiles: Boolean = false,
     ): Settings {
       val jsonWorkspaceSpecificSettings2 = jsonWorkspaceSpecificSettings ?: jsonSettings
 
       val enabled: Set<String>? = getEnabledFromJson(jsonSettings)
       val languageShortCode: String? =
         getSettingFromJsonAsString(jsonSettings, "language")?.let { normalizeLanguageShortCode(it) }
-      val rawDictionaries: Map<String, Set<String>>? =
-        mergeMapOfListsIntoMapOfSets(
-          convertJsonObjectToMapOfLists(
-            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "dictionary"),
-          ),
-        )
-      // Only when the server owns external files (client opted out) do we resolve
-      // ":"-prefixed external dictionary files here; otherwise the dictionary is
-      // passed through verbatim, exactly as before.
+      // When the server owns external files (client opted out), ":"-prefixed
+      // entries in these settings are resolved here: the file's contents are
+      // spliced in and the first file per language is recorded (below) so the
+      // server-side quick fixes know where to write. Otherwise the values pass
+      // through verbatim, exactly as before.
+      val dictionaryFiles = HashMap<String, String>()
+      val disabledRulesFiles = HashMap<String, String>()
+      val enabledRulesFiles = HashMap<String, String>()
+      val hiddenFalsePositivesFiles = HashMap<String, String>()
+
       val allDictionaries: Map<String, Set<String>>? =
-        if (expandExternalDictionaryFiles && (rawDictionaries != null)) {
-          expandExternalFilesInDictionaries(rawDictionaries)
-        } else {
-          rawDictionaries
-        }
-      val allDisabledRules: Map<String, Set<String>>? =
-        mergeMapOfListsIntoMapOfSets(
-          convertJsonObjectToMapOfLists(
-            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "disabledRules"),
+        expandStringSetting(
+          mergeMapOfListsIntoMapOfSets(
+            convertJsonObjectToMapOfLists(
+              getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "dictionary"),
+            ),
           ),
+          expandExternalFiles,
+          dictionaryFiles,
+        )
+      val allDisabledRules: Map<String, Set<String>>? =
+        expandStringSetting(
+          mergeMapOfListsIntoMapOfSets(
+            convertJsonObjectToMapOfLists(
+              getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "disabledRules"),
+            ),
+          ),
+          expandExternalFiles,
+          disabledRulesFiles,
         )
       val allEnabledRules: Map<String, Set<String>>? =
-        mergeMapOfListsIntoMapOfSets(
-          convertJsonObjectToMapOfLists(
-            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "enabledRules"),
+        expandStringSetting(
+          mergeMapOfListsIntoMapOfSets(
+            convertJsonObjectToMapOfLists(
+              getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "enabledRules"),
+            ),
           ),
+          expandExternalFiles,
+          enabledRulesFiles,
         )
       val allHiddenFalsePositives: Map<String, Set<HiddenFalsePositive>>? =
-        getAllHiddenFalsePositivesFromJson(jsonWorkspaceSpecificSettings2)
+        getAllHiddenFalsePositivesFromJson(
+          jsonWorkspaceSpecificSettings2,
+          expandExternalFiles,
+          hiddenFalsePositivesFiles,
+        )
+
+      val externalSettingFiles: Map<String, Map<String, String>>? =
+        collectExternalSettingFiles(
+          expandExternalFiles,
+          mapOf(
+            "dictionary" to dictionaryFiles,
+            "disabledRules" to disabledRulesFiles,
+            "enabledRules" to enabledRulesFiles,
+            "hiddenFalsePositives" to hiddenFalsePositivesFiles,
+          ),
+        )
       val bibtexFields: Map<String, Boolean>? =
         convertJsonObjectToMapOfBooleans(
           getSettingFromJsonAsJsonObject(jsonSettings, "bibtex.fields"),
@@ -414,6 +457,7 @@ data class Settings(
         paragraphCacheEnabled,
         paragraphCacheTtlMinutes,
         maxRequestSize,
+        externalSettingFiles,
       )
     }
 
@@ -528,30 +572,76 @@ data class Settings(
       return resolved
     }
 
-    // Resolves ":"-prefixed external dictionary files: each such entry is kept
-    // (so the server can later locate the file to write into) and the file's
-    // lines are added alongside as regular dictionary words. Missing/unreadable
-    // files are skipped. Non-":" entries pass through untouched.
-    private fun expandExternalFilesInDictionaries(
-      allDictionaries: Map<String, Set<String>>,
-    ): Map<String, Set<String>> =
-      allDictionaries.mapValues { (_, entries: Set<String>) ->
-        // Seed with all original entries (retaining the ":" markers so the server
-        // can later locate the file to write into), then add each external file's
-        // lines as regular dictionary words.
-        val expanded = LinkedHashSet<String>(entries)
+    // Keeps only the non-empty per-setting file maps (settingName -> language ->
+    // path), or null if none / not expanding. Recorded during expansion so the
+    // server-side quick fixes know where to write.
+    private fun collectExternalSettingFiles(
+      expand: Boolean,
+      filesBySetting: Map<String, Map<String, String>>,
+    ): Map<String, Map<String, String>>? =
+      if (expand) filesBySetting.filterValues { it.isNotEmpty() }.ifEmpty { null } else null
 
-        for (entry: String in entries.filter { it.startsWith(":") }) {
-          val path = Paths.get(FileIo.normalizePath(entry.substring(1)))
-          if (Files.exists(path)) {
-            FileIo.readFile(path)?.lines()?.forEach { line: String ->
-              val trimmed: String = line.trim()
-              if (trimmed.isNotEmpty()) expanded.add(trimmed)
-            }
+    // Resolves ":"-prefixed external files for a string-valued, language-keyed
+    // setting (dictionary / disabledRules / enabledRules). When expanding, a ":"
+    // entry is replaced by the file's lines (the marker itself is dropped), and
+    // the first external file per language is recorded into `fileAccumulator` so
+    // the server-side quick fixes know where to write. Not expanding → verbatim.
+    private fun expandStringSetting(
+      raw: Map<String, Set<String>>?,
+      expand: Boolean,
+      fileAccumulator: MutableMap<String, String>,
+    ): Map<String, Set<String>>? {
+      if (!expand || (raw == null)) return raw
+
+      return raw.mapValues { (language: String, entries: Set<String>) ->
+        val expanded = LinkedHashSet<String>()
+
+        for (entry: String in entries) {
+          if (entry.startsWith(EXTERNAL_FILE_PREFIX)) {
+            recordAndReadExternalFile(entry, language, fileAccumulator) { expanded.add(it) }
+          } else {
+            expanded.add(entry)
           }
         }
 
         expanded
+      }
+    }
+
+    // Records the first external file per language into `fileAccumulator` (even if
+    // the file does not exist yet — the quick fix creates it on write), then feeds
+    // each trimmed, non-empty line of an existing file to `consume`. A leading "~"
+    // is expanded; the demo assumes "~"/absolute paths (no workspace-root resolution).
+    private fun recordAndReadExternalFile(
+      entry: String,
+      language: String,
+      fileAccumulator: MutableMap<String, String>,
+      consume: (String) -> Unit,
+    ) {
+      val normalizedPath: String =
+        FileIo.normalizePath(entry.substring(EXTERNAL_FILE_PREFIX.length))
+      if (!fileAccumulator.containsKey(language)) fileAccumulator[language] = normalizedPath
+
+      val path = Paths.get(normalizedPath)
+      if (!Files.exists(path)) return
+
+      FileIo.readFile(path)?.lines()?.forEach { line: String ->
+        val trimmed: String = line.trim()
+        if (trimmed.isNotEmpty()) consume(trimmed)
+      }
+    }
+
+    // Parses a single hiddenFalsePositives entry, returning null (with a warning)
+    // instead of throwing on anything malformed — a raw ":" marker that was not
+    // expanded (e.g. a misconfigured client), broken JSON, or the wrong shape. So
+    // one bad entry is skipped rather than breaking the whole check.
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun parseHiddenFalsePositiveOrWarn(jsonString: String): HiddenFalsePositive? =
+      try {
+        HiddenFalsePositive.fromJsonString(jsonString)
+      } catch (e: RuntimeException) {
+        Logging.LOGGER.warning(I18n.format("ignoringMalformedHiddenFalsePositive", jsonString))
+        null
       }
 
     private fun getEnabledFromJson(jsonSettings: JsonElement): Set<String>? {
@@ -576,6 +666,8 @@ data class Settings(
 
     private fun getAllHiddenFalsePositivesFromJson(
       jsonWorkspaceSpecificSettings: JsonElement,
+      expand: Boolean,
+      fileAccumulator: MutableMap<String, String>,
     ): Map<String, Set<HiddenFalsePositive>>? {
       val objectMap: Map<String, Set<JsonObject>>? =
         convertJsonObjectToMapOfJsonObjects(
@@ -588,33 +680,45 @@ data class Settings(
           ),
         )
 
-      if (objectMap == null && stringMap == null) {
-        return null
-      }
+      if ((objectMap == null) && (stringMap == null)) return null
 
       val hiddenFalsePositivesMap = HashMap<String, HashSet<HiddenFalsePositive>>()
 
-      if (objectMap != null) {
-        for ((language, jsonObjectSet) in objectMap) {
-          val falsePositivesSet = hiddenFalsePositivesMap.getOrPut(language) { HashSet() }
-          for (jsonObject in jsonObjectSet) {
-            val falsePositive = HiddenFalsePositive.fromJsonObject(jsonObject)
-            falsePositivesSet.add(falsePositive)
-          }
-        }
+      objectMap?.forEach { (language: String, jsonObjectSet: Set<JsonObject>) ->
+        val set: HashSet<HiddenFalsePositive> =
+          hiddenFalsePositivesMap.getOrPut(language) { HashSet() }
+        jsonObjectSet.forEach { set.add(HiddenFalsePositive.fromJsonObject(it)) }
       }
 
-      if (stringMap != null) {
-        for ((language, stringSet) in stringMap) {
-          val falsePositivesSet = hiddenFalsePositivesMap.getOrPut(language) { HashSet() }
-          for (jsonString in stringSet) {
-            val falsePositive = HiddenFalsePositive.fromJsonString(jsonString)
-            falsePositivesSet.add(falsePositive)
-          }
+      stringMap?.forEach { (language: String, stringSet: Set<String>) ->
+        val set: HashSet<HiddenFalsePositive> =
+          hiddenFalsePositivesMap.getOrPut(language) { HashSet() }
+        stringSet.forEach { entry: String ->
+          addHiddenFalsePositiveStringEntry(entry, language, expand, fileAccumulator, set)
         }
       }
 
       return hiddenFalsePositivesMap
+    }
+
+    // A hiddenFalsePositives string entry is either a JSON object (the usual case)
+    // or, when the server manages external files, a ":"-prefixed file whose lines
+    // are each such a JSON object. Both routes go through the hardened parser so a
+    // malformed/unexpanded entry is skipped, not thrown.
+    private fun addHiddenFalsePositiveStringEntry(
+      entry: String,
+      language: String,
+      expand: Boolean,
+      fileAccumulator: MutableMap<String, String>,
+      set: HashSet<HiddenFalsePositive>,
+    ) {
+      if (expand && entry.startsWith(EXTERNAL_FILE_PREFIX)) {
+        recordAndReadExternalFile(entry, language, fileAccumulator) { line: String ->
+          parseHiddenFalsePositiveOrWarn(line)?.let { set.add(it) }
+        }
+      } else {
+        parseHiddenFalsePositiveOrWarn(entry)?.let { set.add(it) }
+      }
     }
 
     private fun getDiagnosticSeverityFromJson(

--- a/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
@@ -260,6 +260,12 @@ data class Settings(
     // Prefix marking a setting entry as an external file path (LTeX convention).
     private const val EXTERNAL_FILE_PREFIX = ":"
 
+    // Prefix marking a setting entry as a removal (LTeX convention): "-x" deletes a
+    // previously added "x". Applied uniformly to inline entries and to the lines of
+    // an expanded external file, in order, so a "-x" from either source can cancel
+    // an "x" contributed by the other.
+    private const val REMOVE_PREFIX = "-"
+
     @Suppress("LongMethod")
     fun fromJson(
       jsonSettings: JsonElement,
@@ -283,30 +289,24 @@ data class Settings(
 
       val allDictionaries: Map<String, Set<String>>? =
         expandStringSetting(
-          mergeMapOfListsIntoMapOfSets(
-            convertJsonObjectToMapOfLists(
-              getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "dictionary"),
-            ),
+          convertJsonObjectToMapOfLists(
+            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "dictionary"),
           ),
           expandExternalFiles,
           dictionaryFiles,
         )
       val allDisabledRules: Map<String, Set<String>>? =
         expandStringSetting(
-          mergeMapOfListsIntoMapOfSets(
-            convertJsonObjectToMapOfLists(
-              getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "disabledRules"),
-            ),
+          convertJsonObjectToMapOfLists(
+            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "disabledRules"),
           ),
           expandExternalFiles,
           disabledRulesFiles,
         )
       val allEnabledRules: Map<String, Set<String>>? =
         expandStringSetting(
-          mergeMapOfListsIntoMapOfSets(
-            convertJsonObjectToMapOfLists(
-              getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "enabledRules"),
-            ),
+          convertJsonObjectToMapOfLists(
+            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings2, "enabledRules"),
           ),
           expandExternalFiles,
           enabledRulesFiles,
@@ -581,30 +581,61 @@ data class Settings(
     ): Map<String, Map<String, String>>? =
       if (expand) filesBySetting.filterValues { it.isNotEmpty() }.ifEmpty { null } else null
 
-    // Resolves ":"-prefixed external files for a string-valued, language-keyed
-    // setting (dictionary / disabledRules / enabledRules). When expanding, a ":"
-    // entry is replaced by the file's lines (the marker itself is dropped), and
-    // the first external file per language is recorded into `fileAccumulator` so
-    // the server-side quick fixes know where to write. Not expanding → verbatim.
+    // Resolves a string-valued, language-keyed setting (dictionary / disabledRules /
+    // enabledRules) from its ordered inline entries. Each language's entries are
+    // folded in order by foldStringEntries, which applies the "-" removal convention
+    // and — when the server owns external files — splices in the lines of a
+    // ":"-prefixed file (recording the first file per language into `fileAccumulator`
+    // so the server-side quick fixes know where to write). Not expanding → ":" entries
+    // pass through verbatim; only the "-" folding is applied.
     private fun expandStringSetting(
-      raw: Map<String, Set<String>>?,
+      raw: Map<String, List<String>>?,
       expand: Boolean,
       fileAccumulator: MutableMap<String, String>,
     ): Map<String, Set<String>>? {
-      if (!expand || (raw == null)) return raw
+      if (raw == null) return null
 
-      return raw.mapValues { (language: String, entries: Set<String>) ->
-        val expanded = LinkedHashSet<String>()
+      return raw.mapValues { (language: String, entries: List<String>) ->
+        foldStringEntries(entries, language, expand, fileAccumulator)
+      }
+    }
 
-        for (entry: String in entries) {
-          if (entry.startsWith(EXTERNAL_FILE_PREFIX)) {
-            recordAndReadExternalFile(entry, language, fileAccumulator) { expanded.add(it) }
-          } else {
-            expanded.add(entry)
+    // Folds one language's ordered entries into a set, honoring the "-" removal
+    // convention and, when expanding, splicing in the lines of ":"-prefixed external
+    // files (whose lines may themselves use "-"). Order is significant: a later "-x"
+    // cancels an "x" contributed earlier by an inline entry or by a file. Shared by
+    // the string settings and by hiddenFalsePositives (which parses the survivors).
+    private fun foldStringEntries(
+      entries: List<String>,
+      language: String,
+      expand: Boolean,
+      fileAccumulator: MutableMap<String, String>,
+    ): Set<String> {
+      val resolved = LinkedHashSet<String>()
+
+      for (entry: String in entries) {
+        if (expand && entry.startsWith(EXTERNAL_FILE_PREFIX)) {
+          recordAndReadExternalFile(entry, language, fileAccumulator) {
+            applyStringEntry(it, resolved)
           }
+        } else {
+          applyStringEntry(entry, resolved)
         }
+      }
 
-        expanded
+      return resolved
+    }
+
+    // Applies one entry to `target`: a "-x" entry removes a previously added "x",
+    // any other entry adds itself. See REMOVE_PREFIX.
+    private fun applyStringEntry(
+      entry: String,
+      target: MutableSet<String>,
+    ) {
+      if (entry.startsWith(REMOVE_PREFIX)) {
+        target.remove(entry.substring(REMOVE_PREFIX.length))
+      } else {
+        target.add(entry)
       }
     }
 
@@ -673,14 +704,15 @@ data class Settings(
         convertJsonObjectToMapOfJsonObjects(
           getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings, "hiddenFalsePositives"),
         )
-      val stringMap: Map<String, Set<String>>? =
-        mergeMapOfListsIntoMapOfSets(
-          convertJsonObjectToMapOfLists(
-            getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings, "hiddenFalsePositives"),
-          ),
+      // Kept as an ordered list (not pre-merged) so the "-" removals and ":"-file
+      // expansions fold in the order written, letting a "-{...}" cancel a matching
+      // entry contributed inline or by a file.
+      val stringListMap: Map<String, List<String>>? =
+        convertJsonObjectToMapOfLists(
+          getSettingFromJsonAsJsonObject(jsonWorkspaceSpecificSettings, "hiddenFalsePositives"),
         )
 
-      if ((objectMap == null) && (stringMap == null)) return null
+      if ((objectMap == null) && (stringListMap == null)) return null
 
       val hiddenFalsePositivesMap = HashMap<String, HashSet<HiddenFalsePositive>>()
 
@@ -690,35 +722,18 @@ data class Settings(
         jsonObjectSet.forEach { set.add(HiddenFalsePositive.fromJsonObject(it)) }
       }
 
-      stringMap?.forEach { (language: String, stringSet: Set<String>) ->
+      // Each surviving string is a one-line JSON object; parse through the hardened
+      // parser so a malformed or unexpanded ":" entry is skipped with a warning, not
+      // thrown.
+      stringListMap?.forEach { (language: String, entries: List<String>) ->
         val set: HashSet<HiddenFalsePositive> =
           hiddenFalsePositivesMap.getOrPut(language) { HashSet() }
-        stringSet.forEach { entry: String ->
-          addHiddenFalsePositiveStringEntry(entry, language, expand, fileAccumulator, set)
-        }
+        val jsonStrings: Set<String> =
+          foldStringEntries(entries, language, expand, fileAccumulator)
+        jsonStrings.forEach { parseHiddenFalsePositiveOrWarn(it)?.let { hfp -> set.add(hfp) } }
       }
 
       return hiddenFalsePositivesMap
-    }
-
-    // A hiddenFalsePositives string entry is either a JSON object (the usual case)
-    // or, when the server manages external files, a ":"-prefixed file whose lines
-    // are each such a JSON object. Both routes go through the hardened parser so a
-    // malformed/unexpanded entry is skipped, not thrown.
-    private fun addHiddenFalsePositiveStringEntry(
-      entry: String,
-      language: String,
-      expand: Boolean,
-      fileAccumulator: MutableMap<String, String>,
-      set: HashSet<HiddenFalsePositive>,
-    ) {
-      if (expand && entry.startsWith(EXTERNAL_FILE_PREFIX)) {
-        recordAndReadExternalFile(entry, language, fileAccumulator) { line: String ->
-          parseHiddenFalsePositiveOrWarn(line)?.let { set.add(it) }
-        }
-      } else {
-        parseHiddenFalsePositiveOrWarn(entry)?.let { set.add(it) }
-      }
     }
 
     private fun getDiagnosticSeverityFromJson(
@@ -995,29 +1010,6 @@ data class Settings(
       }
 
       return null
-    }
-
-    private fun mergeMapOfListsIntoMapOfSets(
-      mapOfLists: Map<String, List<String>>?,
-    ): Map<String, Set<String>>? {
-      if (mapOfLists == null) return null
-      val mapOfSets = HashMap<String, HashSet<String>>()
-
-      for ((key: String, set2: List<String>) in mapOfLists) {
-        val set1 = HashSet<String>()
-
-        for (string: String in set2) {
-          if (string.startsWith("-")) {
-            set1.remove(string.substring(1))
-          } else {
-            set1.add(string)
-          }
-        }
-
-        mapOfSets[key] = set1
-      }
-
-      return mapOfSets
     }
   }
 }

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -9,7 +9,7 @@
 
 addAllUnknownWordsInSelectionToDictionary = Add all unknown words in selection to dictionary
 addWordToDictionary = Add '{0}' to dictionary
-addedWordsToExternalDictionaryFile = Added {0} word(s) to external dictionary file '{1}'
+addedEntriesToExternalSettingFile = Added {0} entry(-ies) to external setting file '{1}'
 cancelingCheckDueToIncomingCheckRequest = Canceling check due to incoming check request...
 cancelingCheckDueToLspCancelNotification = Canceling check due to LSP cancel notification...
 characterBasedCodeAnnotatedTextBuilderInfiniteLoop = \
@@ -59,6 +59,7 @@ hideAllFalsePositivesInTheSelectedSentences = Hide all false positives in the se
 hideFalsePositive = Hide false positive
 hidingFalsePositive = Hiding false positive with rule '{0}' and sentence '{1}'
 ignoreEnvironmentEndPatternNotSet = ignoreEnvironmentEndPattern not set
+ignoringMalformedHiddenFalsePositive = Ignoring malformed hiddenFalsePositives entry: {0}
 ignoringMalformedInlineSetting = Ignoring malformed inline setting '{0}'
 ignoringMalformedInlineSettingBoolean = Ignoring malformed inline setting value '{0}' for name '{1}'. Expected a boolean: '0', '1', 'true', 'false', or '#' to remove this setting
 ignoringMalformedInlineSettingOperation = Ignoring malformed inline setting operation '{0}=' for name '{1}'. Expected '+=', '-=' or '#='
@@ -72,8 +73,8 @@ invalidBabelInlineCommand = Invalid babel inline command '{0}'
 invalidCommandPrototype = Invalid command prototype '{0}'
 languageToolFailed = LanguageTool failed
 languageToolFailedWithStatusCode = LanguageTool failed with HTTP status code {0}
-noExternalDictionaryFileForLanguage = No external dictionary file configured for language '{0}'; \
-    cannot persist the added word(s)
+noExternalFileForSetting = No external file configured for '{0}' in language '{1}'; \
+    cannot persist the change
 notARecognizedLanguage = '{0}' is not a recognized language. Leaving LanguageTool uninitialized, \
     checking disabled.
 obtainedRuleMatch = Obtained 1 rule match

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -9,6 +9,7 @@
 
 addAllUnknownWordsInSelectionToDictionary = Add all unknown words in selection to dictionary
 addWordToDictionary = Add '{0}' to dictionary
+addedWordsToExternalDictionaryFile = Added {0} word(s) to external dictionary file '{1}'
 cancelingCheckDueToIncomingCheckRequest = Canceling check due to incoming check request...
 cancelingCheckDueToLspCancelNotification = Canceling check due to LSP cancel notification...
 characterBasedCodeAnnotatedTextBuilderInfiniteLoop = \
@@ -71,6 +72,8 @@ invalidBabelInlineCommand = Invalid babel inline command '{0}'
 invalidCommandPrototype = Invalid command prototype '{0}'
 languageToolFailed = LanguageTool failed
 languageToolFailedWithStatusCode = LanguageTool failed with HTTP status code {0}
+noExternalDictionaryFileForLanguage = No external dictionary file configured for language '{0}'; \
+    cannot persist the added word(s)
 notARecognizedLanguage = '{0}' is not a recognized language. Leaving LanguageTool uninitialized, \
     checking disabled.
 obtainedRuleMatch = Obtained 1 rule match

--- a/src/test/kotlin/org/bsplines/ltexls/server/LtexWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/LtexWorkspaceServiceTest.kt
@@ -76,13 +76,18 @@ class LtexWorkspaceServiceTest {
   }
 
   @Test
-  fun testGetCommandNamesGatesAddToDictionary() {
-    val addToDictionary = "_ltex.addToDictionary"
-    // Editor-managed (default): command NOT advertised, init response unchanged.
-    assertFalse(LtexWorkspaceService.getCommandNames().contains(addToDictionary))
-    assertFalse(LtexWorkspaceService.getCommandNames(false).contains(addToDictionary))
-    // Server-managed: command advertised so thin clients can invoke it.
-    assertTrue(LtexWorkspaceService.getCommandNames(true).contains(addToDictionary))
+  fun testGetCommandNamesGatesExternalFileCommands() {
+    val externalFileCommands =
+      listOf("_ltex.addToDictionary", "_ltex.disableRules", "_ltex.hideFalsePositives")
+    // Editor-managed (default): commands NOT advertised, init response unchanged.
+    for (command: String in externalFileCommands) {
+      assertFalse(LtexWorkspaceService.getCommandNames().contains(command))
+      assertFalse(LtexWorkspaceService.getCommandNames(false).contains(command))
+    }
+    // Server-managed: all three advertised so thin clients can invoke them.
+    for (command: String in externalFileCommands) {
+      assertTrue(LtexWorkspaceService.getCommandNames(true).contains(command))
+    }
   }
 
   @Test
@@ -93,10 +98,14 @@ class LtexWorkspaceServiceTest {
     try {
       val server = LtexLanguageServer()
       server.settingsManager.settings =
-        Settings.fromJson(buildDictionarySettings(":" + dictionaryFile.absolutePath), null, true)
+        Settings.fromJson(
+          buildSettings("dictionary", ":" + dictionaryFile.absolutePath),
+          null,
+          true,
+        )
       val service = LtexWorkspaceService(server)
 
-      val arguments: JsonObject = buildAddWordsArguments("newword")
+      val arguments: JsonObject = buildCommandArguments("words", "newword")
       val response: Any = service.executeAddToDictionaryCommand(arguments).get()
       val result: JsonObject = (response as JsonElement).asJsonObject
 
@@ -110,14 +119,65 @@ class LtexWorkspaceServiceTest {
   }
 
   @Test
+  fun testDisableRulesCommandAppendsToExternalFile() {
+    val rulesFile: File = File.createTempFile("ltex-rules-", ".txt")
+
+    try {
+      val server = LtexLanguageServer()
+      server.settingsManager.settings =
+        Settings.fromJson(
+          buildSettings("disabledRules", ":" + rulesFile.absolutePath),
+          null,
+          true,
+        )
+      val service = LtexWorkspaceService(server)
+
+      val arguments: JsonObject = buildCommandArguments("ruleIds", "SOME_RULE")
+      val response: Any = service.executeDisableRulesCommand(arguments).get()
+      val result: JsonObject = (response as JsonElement).asJsonObject
+
+      assertTrue(result["success"].asBoolean)
+      assertTrue(rulesFile.readText().contains("SOME_RULE"))
+    } finally {
+      rulesFile.delete()
+    }
+  }
+
+  @Test
+  fun testHideFalsePositivesCommandAppendsToExternalFile() {
+    val falsePositivesFile: File = File.createTempFile("ltex-fp-", ".txt")
+
+    try {
+      val server = LtexLanguageServer()
+      server.settingsManager.settings =
+        Settings.fromJson(
+          buildSettings("hiddenFalsePositives", ":" + falsePositivesFile.absolutePath),
+          null,
+          true,
+        )
+      val service = LtexWorkspaceService(server)
+
+      val falsePositive = "{\"rule\":\"SOME_RULE\",\"sentence\":\"^Foo\$\"}"
+      val arguments: JsonObject = buildCommandArguments("falsePositives", falsePositive)
+      val response: Any = service.executeHideFalsePositivesCommand(arguments).get()
+      val result: JsonObject = (response as JsonElement).asJsonObject
+
+      assertTrue(result["success"].asBoolean)
+      assertTrue(falsePositivesFile.readText().contains("SOME_RULE"))
+    } finally {
+      falsePositivesFile.delete()
+    }
+  }
+
+  @Test
   fun testAddToDictionaryCommandFailsWithoutExternalFile() {
     val server = LtexLanguageServer()
     // Dictionary has only a literal word, no ":"-prefixed external file entry.
     server.settingsManager.settings =
-      Settings.fromJson(buildDictionarySettings("plainword"), null, true)
+      Settings.fromJson(buildSettings("dictionary", "plainword"), null, true)
     val service = LtexWorkspaceService(server)
 
-    val arguments: JsonObject = buildAddWordsArguments("newword")
+    val arguments: JsonObject = buildCommandArguments("words", "newword")
     val response: Any = service.executeAddToDictionaryCommand(arguments).get()
     val result: JsonObject = (response as JsonElement).asJsonObject
 
@@ -125,24 +185,34 @@ class LtexWorkspaceServiceTest {
   }
 
   companion object {
-    private fun buildDictionarySettings(vararg enUsEntries: String): JsonObject {
+    // Builds { <settingName>: { "en-US": [entries...] } } — the ltex settings
+    // section as the server receives it via workspace/configuration.
+    private fun buildSettings(
+      settingName: String,
+      vararg enUsEntries: String,
+    ): JsonObject {
       val entries = JsonArray()
       for (entry: String in enUsEntries) entries.add(entry)
-      val dictionary = JsonObject()
-      dictionary.add("en-US", entries)
+      val setting = JsonObject()
+      setting.add("en-US", entries)
       val jsonSettings = JsonObject()
-      jsonSettings.add("dictionary", dictionary)
+      jsonSettings.add(settingName, setting)
       return jsonSettings
     }
 
-    private fun buildAddWordsArguments(vararg words: String): JsonObject {
-      val wordArray = JsonArray()
-      for (word: String in words) wordArray.add(word)
-      val wordsObject = JsonObject()
-      wordsObject.add("en-US", wordArray)
+    // Builds { uri, <argumentKey>: { "en-US": [entries...] } } — an external-file
+    // quick-fix command's argument payload.
+    private fun buildCommandArguments(
+      argumentKey: String,
+      vararg entries: String,
+    ): JsonObject {
+      val entryArray = JsonArray()
+      for (entry: String in entries) entryArray.add(entry)
+      val byLanguage = JsonObject()
+      byLanguage.add("en-US", entryArray)
       val arguments = JsonObject()
       arguments.addProperty("uri", "file:///demo")
-      arguments.add("words", wordsObject)
+      arguments.add(argumentKey, byLanguage)
       return arguments
     }
 

--- a/src/test/kotlin/org/bsplines/ltexls/server/LtexWorkspaceServiceTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/LtexWorkspaceServiceTest.kt
@@ -8,8 +8,10 @@
 
 package org.bsplines.ltexls.server
 
+import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
 import org.eclipse.lsp4j.DidChangeConfigurationParams
@@ -73,7 +75,77 @@ class LtexWorkspaceServiceTest {
     assertTrue(result["totalMemory"].asDouble >= 0)
   }
 
+  @Test
+  fun testGetCommandNamesGatesAddToDictionary() {
+    val addToDictionary = "_ltex.addToDictionary"
+    // Editor-managed (default): command NOT advertised, init response unchanged.
+    assertFalse(LtexWorkspaceService.getCommandNames().contains(addToDictionary))
+    assertFalse(LtexWorkspaceService.getCommandNames(false).contains(addToDictionary))
+    // Server-managed: command advertised so thin clients can invoke it.
+    assertTrue(LtexWorkspaceService.getCommandNames(true).contains(addToDictionary))
+  }
+
+  @Test
+  fun testAddToDictionaryCommandAppendsToExternalFile() {
+    val dictionaryFile: File = File.createTempFile("ltex-dict-", ".txt")
+    dictionaryFile.writeText("existingword\n")
+
+    try {
+      val server = LtexLanguageServer()
+      server.settingsManager.settings =
+        Settings.fromJson(buildDictionarySettings(":" + dictionaryFile.absolutePath), null, true)
+      val service = LtexWorkspaceService(server)
+
+      val arguments: JsonObject = buildAddWordsArguments("newword")
+      val response: Any = service.executeAddToDictionaryCommand(arguments).get()
+      val result: JsonObject = (response as JsonElement).asJsonObject
+
+      assertTrue(result["success"].asBoolean)
+      val content: String = dictionaryFile.readText()
+      assertTrue(content.contains("existingword"))
+      assertTrue(content.contains("newword"))
+    } finally {
+      dictionaryFile.delete()
+    }
+  }
+
+  @Test
+  fun testAddToDictionaryCommandFailsWithoutExternalFile() {
+    val server = LtexLanguageServer()
+    // Dictionary has only a literal word, no ":"-prefixed external file entry.
+    server.settingsManager.settings =
+      Settings.fromJson(buildDictionarySettings("plainword"), null, true)
+    val service = LtexWorkspaceService(server)
+
+    val arguments: JsonObject = buildAddWordsArguments("newword")
+    val response: Any = service.executeAddToDictionaryCommand(arguments).get()
+    val result: JsonObject = (response as JsonElement).asJsonObject
+
+    assertFalse(result["success"].asBoolean)
+  }
+
   companion object {
+    private fun buildDictionarySettings(vararg enUsEntries: String): JsonObject {
+      val entries = JsonArray()
+      for (entry: String in enUsEntries) entries.add(entry)
+      val dictionary = JsonObject()
+      dictionary.add("en-US", entries)
+      val jsonSettings = JsonObject()
+      jsonSettings.add("dictionary", dictionary)
+      return jsonSettings
+    }
+
+    private fun buildAddWordsArguments(vararg words: String): JsonObject {
+      val wordArray = JsonArray()
+      for (word: String in words) wordArray.add(word)
+      val wordsObject = JsonObject()
+      wordsObject.add("en-US", wordArray)
+      val arguments = JsonObject()
+      arguments.addProperty("uri", "file:///demo")
+      arguments.add("words", wordsObject)
+      return arguments
+    }
+
     private fun assertCheckDocumentResult(
       uri: String,
       expected: Boolean,

--- a/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SettingsTest {
@@ -34,19 +35,52 @@ class SettingsTest {
       val jsonSettings = JsonObject()
       jsonSettings.add("dictionary", dictionary)
 
-      // Expansion on: the external file's lines become dictionary words, and the
-      // ":"-marker entry is retained so the server can later write back to it.
+      // Expansion on: the external file's lines become dictionary words, the ":"
+      // marker is dropped, and the resolved file path is recorded for write-back.
       val expanded = Settings.fromJson(jsonSettings, null, true)
       assertTrue(expanded.dictionary.contains("alpha"))
       assertTrue(expanded.dictionary.contains("beta"))
-      assertTrue(expanded.dictionary.contains(":" + dictionaryFile.absolutePath))
+      assertFalse(expanded.dictionary.contains(":" + dictionaryFile.absolutePath))
+      assertEquals(
+        dictionaryFile.absolutePath,
+        expanded.firstExternalSettingFile("dictionary", "en-US"),
+      )
 
-      // Expansion off (default / editor-managed): dictionary passes through verbatim.
+      // Expansion off (default / editor-managed): raw ":" entry passes through
+      // verbatim and no external file is recorded.
       val notExpanded = Settings.fromJson(jsonSettings, null, false)
       assertFalse(notExpanded.dictionary.contains("alpha"))
       assertTrue(notExpanded.dictionary.contains(":" + dictionaryFile.absolutePath))
+      assertNull(notExpanded.firstExternalSettingFile("dictionary", "en-US"))
     } finally {
       dictionaryFile.delete()
+    }
+  }
+
+  @Test
+  fun testExpandExternalHiddenFalsePositivesFileSkipsMalformed() {
+    val file: File = File.createTempFile("ltex-fp-", ".txt")
+    file.writeText(
+      "{\"rule\":\"R1\",\"sentence\":\"^A\$\"}\nnot-json\n{\"rule\":\"R2\",\"sentence\":\"^B\$\"}\n",
+    )
+
+    try {
+      val entries = JsonArray()
+      entries.add(":" + file.absolutePath)
+      val hiddenFalsePositives = JsonObject()
+      hiddenFalsePositives.add("en-US", entries)
+      val jsonSettings = JsonObject()
+      jsonSettings.add("hiddenFalsePositives", hiddenFalsePositives)
+
+      // One JSON object per line; the malformed middle line is skipped (not thrown).
+      val expanded = Settings.fromJson(jsonSettings, null, true)
+      assertEquals(2, expanded.hiddenFalsePositives.size)
+      assertEquals(
+        file.absolutePath,
+        expanded.firstExternalSettingFile("hiddenFalsePositives", "en-US"),
+      )
+    } finally {
+      file.delete()
     }
   }
 

--- a/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
@@ -11,14 +11,45 @@ package org.bsplines.ltexls.settings
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.eclipse.lsp4j.DiagnosticSeverity
+import java.io.File
 import java.util.logging.Level
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class SettingsTest {
+  @Test
+  fun testExpandExternalDictionaryFiles() {
+    val dictionaryFile: File = File.createTempFile("ltex-dict-", ".txt")
+    dictionaryFile.writeText("alpha\nbeta\n\n")
+
+    try {
+      val entries = JsonArray()
+      entries.add(":" + dictionaryFile.absolutePath)
+      val dictionary = JsonObject()
+      dictionary.add("en-US", entries)
+      val jsonSettings = JsonObject()
+      jsonSettings.add("dictionary", dictionary)
+
+      // Expansion on: the external file's lines become dictionary words, and the
+      // ":"-marker entry is retained so the server can later write back to it.
+      val expanded = Settings.fromJson(jsonSettings, null, true)
+      assertTrue(expanded.dictionary.contains("alpha"))
+      assertTrue(expanded.dictionary.contains("beta"))
+      assertTrue(expanded.dictionary.contains(":" + dictionaryFile.absolutePath))
+
+      // Expansion off (default / editor-managed): dictionary passes through verbatim.
+      val notExpanded = Settings.fromJson(jsonSettings, null, false)
+      assertFalse(notExpanded.dictionary.contains("alpha"))
+      assertTrue(notExpanded.dictionary.contains(":" + dictionaryFile.absolutePath))
+    } finally {
+      dictionaryFile.delete()
+    }
+  }
+
   @Test
   @Suppress("LongMethod")
   fun testProperties() {

--- a/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/settings/SettingsTest.kt
@@ -85,6 +85,57 @@ class SettingsTest {
   }
 
   @Test
+  fun testRemovalPrefixInteractsWithExternalDictionaryFile() {
+    val dictionaryFile: File = File.createTempFile("ltex-dict-", ".txt")
+    // A file line may itself use the "-" removal convention: "-beta" cancels the
+    // "beta" contributed earlier by the same file.
+    dictionaryFile.writeText("alpha\nbeta\n-beta\ndelta\n")
+
+    try {
+      // Folded in order: the file expands first (alpha, beta, -beta -> beta gone,
+      // delta); then the inline "-alpha" cancels the file's alpha; then "gamma" adds.
+      val entries = JsonArray()
+      entries.add(":" + dictionaryFile.absolutePath)
+      entries.add("-alpha")
+      entries.add("gamma")
+      val dictionary = JsonObject()
+      dictionary.add("en-US", entries)
+      val jsonSettings = JsonObject()
+      jsonSettings.add("dictionary", dictionary)
+
+      val expanded = Settings.fromJson(jsonSettings, null, true)
+      assertEquals(setOf("delta", "gamma"), expanded.dictionary)
+    } finally {
+      dictionaryFile.delete()
+    }
+  }
+
+  @Test
+  fun testRemovalPrefixCancelsExternalHiddenFalsePositive() {
+    val file: File = File.createTempFile("ltex-fp-", ".txt")
+    val r1 = "{\"rule\":\"R1\",\"sentence\":\"^A\$\"}"
+    val r2 = "{\"rule\":\"R2\",\"sentence\":\"^B\$\"}"
+    file.writeText("$r1\n$r2\n")
+
+    try {
+      // Inline "-{...R1...}" cancels the R1 entry supplied by the file, leaving R2.
+      val entries = JsonArray()
+      entries.add(":" + file.absolutePath)
+      entries.add("-$r1")
+      val hiddenFalsePositives = JsonObject()
+      hiddenFalsePositives.add("en-US", entries)
+      val jsonSettings = JsonObject()
+      jsonSettings.add("hiddenFalsePositives", hiddenFalsePositives)
+
+      val expanded = Settings.fromJson(jsonSettings, null, true)
+      assertEquals(1, expanded.hiddenFalsePositives.size)
+      assertTrue(expanded.hiddenFalsePositives.any { it.ruleId == "R2" })
+    } finally {
+      file.delete()
+    }
+  }
+
+  @Test
   @Suppress("LongMethod")
   fun testProperties() {
     var settings = Settings()

--- a/src/test/resources/LtexLanguageServerTestLog.txt
+++ b/src/test/resources/LtexLanguageServerTestLog.txt
@@ -290,6 +290,9 @@ Result: {
                 "supported": true,
                 "changeNotifications": true
             }
+        },
+        "experimental": {
+            "manageExternalFiles": true
         }
     },
     "serverInfo": {


### PR DESCRIPTION
Summary

On editors like Zed and Helix — and most minimal LSP clients — you cannot manage your **dictionary**, **hidden false positives**, or **disabled rules** from within the editor. The actions that would do this ("Add to dictionary", "Hide false positive", "Disable rule") rely on custom code actions that these editors do not support, so teaching LTeX a new word, silencing a false positive, or turning off a rule is simply unavailable there.

This PR gives the **language server** a way to manage those settings itself — persisting them to, and reading them back from, external files — so these code actions work on any editor, not only the ones whose extensions can implement them on their side. It is **opt-in**: editors that already handle this themselves (VS Code, Emacs, Sublime) are completely unaffected.

## Why this is needed

Managing these settings has always been done **on the client side**, and it works well there. When you invoke "Add to dictionary" (or its siblings), the editor's LTeX extension carries out the action itself — updating your dictionary inline or in an external file — and hands the language server plain, already-resolved values. VS Code and Emacs both do this, and there was never any reason for the language server to be involved: the extension resolves everything before settings reach the server, so the server simply doesn't need to know external files exist.

That works because those editors let an extension run code that hooks into these actions. **Zed, Helix, and most minimal LSP clients cannot** — they only forward settings and execute commands, with nowhere to intercept an action and write a file. So on those editors the actions can't be offered at all: there is no client-side layer to carry them out.

For that class of editors, the natural place for the logic is the **language server**. Putting it there lets any such editor offer these actions without editor-specific code — while the editors that already handle it client-side keep doing exactly what they do today.

This need was first raised in **#190**, which drafted an initial version. This PR takes that idea to a complete, opt-in implementation, adds the write-back and a discovery capability, and — importantly — matches the on-disk file format of the VS Code extension exactly so files stay interchangeable across editors.

## What it does

- **Opt-in switch** — a new setting `ltex.externalFiles.managedByEditor` (default `true`). `true` keeps today's behavior (the editor is in charge). A client that wants the server to take over sends `false`.
- **Reading** — when the server is in charge, it expands `:`-prefixed external files (e.g. `":/path/to/ltex-dictionary-en-US.txt"`) for `dictionary`, `disabledRules`, `enabledRules`, and `hiddenFalsePositives` on each check. Every file listed for a setting is read, and its contents are **merged** with any plain values the user kept inline in the editor settings — so both take effect and nothing is dropped.
- **Removals (`-` prefix)** — this is **not a new feature**. LTeX already documents a `-entry` convention: prefixing an entry with a dash cancels one that would otherwise be inherited from a higher-precedence scope (e.g. `-cromulent` in a project's `ltex.dictionary` un-adds a word that the user dictionary contributes). See the [external-setting-files docs](https://ltex-plus.github.io/ltex-plus/vscode-ltex-plus/setting-scopes-files.html#external-setting-files). The client-side code already honored it; this PR simply **re-implements the same semantics for the server-managed path**, so that when the server reads the entries it folds `-` across inline and external-file contents in the order written: an inline `-word` cancels a word supplied by a `:`-file, and a `-word` line *inside* a file cancels an earlier one. This holds uniformly across all four settings.
- **Writing** — it implements the three code-action commands (`_ltex.addToDictionary`, `_ltex.disableRules`, `_ltex.hideFalsePositives`) server-side, appending the new entry to the **first** external file listed for that setting and language. This is not a new rule: it is exactly what VS Code already does when `ltex.configurationTarget` is set to a `…ExternalFile` value such as `userExternalFile` (which writes to "the first external file listed"). If no external file is listed for that setting/language, nothing is persisted and a warning is written to the LSP log.
- **Discovery** — it advertises a capability (see below) so clients can tell the server is able to do this, without checking version numbers.
- **Format parity** — reads and writes match the VS Code extension's `ExternalFileManager` exactly (plain text, one entry per line; for `hiddenFalsePositives`, one compact JSON object per line). A file written by the server and one written by VS Code are interchangeable.

## Design principles

- **The client owns configuration by default.** LSP treats configuration as the client's responsibility. This PR does not change that: the server only steps in when a client *explicitly delegates* to it via `managedByEditor: false`. It is never a competing source of truth for editors that manage their own settings.
- **Server management is a fallback, not a replacement — so it is opt-in, not the default.** This is not merely about not breaking existing clients: where an editor *can* manage these settings itself, it can do strictly *more* than the server can, and we don't want to give that up. `managedByEditor` therefore defaults to `true` (editor-managed) and server management is opted into only by editors that need it. Two concrete reasons editor management is richer:
  - **`ltex.configurationTarget` only works client-side.** It lets a user choose *where* an added entry is stored — the user / workspace / workspace-folder settings, or an external file at any of those scopes. Honoring that requires workspace- and scope-level context that the editor owns and does not currently pass to the server. The server *could* grow this, but only by adding a lot of machinery to plumb editor-owned information down to the language server; in this PR, server management deliberately supports only the "first external file" behavior (see *Scope and limitations*).
  - **Some editors use their own storage format.** Emacs, for example, keeps dictionaries and rules in Lisp data files (`.eld`), which fits the Elisp ecosystem far better than the JSON / plain-text external files the server reads and writes. Forcing server management would impose the server's format on such editors.
- **Zero impact by default.** With the default (`true`), the server behaves exactly as before: no extra commands are advertised, and no external files are read or written. The only change to the initialize response is the always-present `experimental.manageExternalFiles` capability (see below) — an additive field that clients ignore unless they look for it. VS Code, Emacs, and Sublime are untouched.
- **Safe on old servers.** The opt-in is a plain setting; a server that predates this feature simply ignores it. So a client can always send it without harm — on an old server the feature is just inert.
- **Interoperable files.** Because the file format matches the VS Code extension, a user can move between editors, or share a project dictionary, without the file meaning something different in each.

## How an editor like Zed discovers the code actions

There are two complementary signals:

1. **The standard `executeCommandProvider` list (what Zed actually keys on).** A code action carries a *command*. Zed only shows a code action if the server advertises that command in its `executeCommandProvider` list. When a client opts in (`managedByEditor: false`), the server adds the three code-action commands to that list; when it doesn't, they aren't there. So Zed shows "Add to dictionary" etc. **only** when the server is managing external files — automatically, with no extra logic in the Zed extension. On an old or non-managing server the commands aren't advertised, so Zed simply hides those actions.

2. **An explicit capability (for anything that wants to detect support directly).** The server advertises, unconditionally, in its initialize response:

   ```jsonc
   "capabilities": {
     "experimental": {
       "manageExternalFiles": true
     }
   }
   ```

   (`experimental` is LSP's standard slot for non-standard capabilities — not a statement that the feature is unstable.) This is a version-independent way for a client or tooling to know the server can manage external files.

For Zed specifically, an extension does not even need to read the capability — it can just send `managedByEditor: false` unconditionally, and let Zed's built-in `executeCommandProvider` filtering sort out the two cases:

- A **new** server honours the opt-in and adds the three commands to `executeCommandProvider`, so Zed shows the code actions.
- An **old** server (from before this PR) doesn't know the setting, ignores it, and leaves `executeCommandProvider` unchanged. The three commands are simply absent, so Zed doesn't show those code actions — and everything behaves exactly as it does today.

So opting in unconditionally is safe: it enables the feature where the server supports it, and is a harmless no-op everywhere else — no version check required.

## Trying it out in Zed

You need a build of `ltex-ls-plus` that includes this feature (a nightly, a release after 18.7.0, or a local build). Point the Zed extension at it and opt in, in `~/.config/zed/settings.json`:

```jsonc
{
  "lsp": {
    "ltex": {
      // Use a build that includes this feature.
      "binary": { "path": "/path/to/ltex-ls-plus" },

      // Opt in: let the server manage external files. Read at startup —
      // changing it needs a language-server restart.
      "initialization_options": {
        "ltex": { "externalFiles": { "managedByEditor": false } }
      },

      // ":"-prefixed entries are external files (created on first write).
      // dictionary / disabledRules: one entry per line (plain text).
      // hiddenFalsePositives: one compact JSON object per line.
      "settings": {
        "ltex": {
          "dictionary": {
            "en-US": [":/tmp/ltex-dictionary.en-US.txt"]
          },
          "disabledRules": {
            "en-US": [":/tmp/ltex-disabled-rules.en-US.txt"]
          },
          "hiddenFalsePositives": {
            "en-US": [":/tmp/ltex-hidden-false-positives.en-US.txt"]
          }
        }
      }
    }
  }
}
```

Then in a document: trigger a spelling error and use **Add to dictionary**; a grammar issue (e.g. "I ate a apple") and use **Disable rule** or **Hide false positive**. The word/rule/false-positive is appended to the corresponding `/tmp` file and the diagnostic clears on re-check.

> Tip: the entry is keyed by the document's **active language** (which may be, say, `en-GB` rather than `en-US`). The external file must be listed under that same language, or the code action reports that no external file is configured.

## Scope and limitations

- Covers the four external-file-backed settings above. `enabledRules` is read-only (there is no "enable rule" code action).
- New entries are written **only to the first external file** listed for a setting/language. The server does not (and cannot) write to the editor's *inline* entries — those are the client's own settings — so at least one external file must be listed for a word/rule/false-positive to be persisted; if none is, the code action makes no change and a warning is logged. Inline values are still read and merged; they are just never modified.
- `ltex.configurationTarget` is effectively **inert** when the server manages external files (`managedByEditor: false`). Its scope-based values (`user`/`workspace`/`workspaceFolder`) target the editor's own settings files, which the server cannot write; and its `…ExternalFile` values all collapse to the same thing here — the first external file listed. So whatever `configurationTarget` says, the server behaves as `userExternalFile`.
- External-file paths may be absolute or start with `~`. Workspace-relative paths are **not** resolved yet (that needs project-root tracking; deliberately left out).
- No caching: files are read on each check. This is intentionally simple — reads are cheap (OS page cache) and always fresh; a cache would need file-watching just to regain that freshness.
- **Robustness against malformed input.** A `hiddenFalsePositives` entry that isn't valid single-line JSON (NDJSON) is skipped with a warning in the LSP log rather than breaking the check. In particular this covers a *client-side* mistake: a client that leaves `managedByEditor` at `true` — claiming it expands external files itself — but then still forwards an unexpanded `:file`. That is a bug on the client's side (the editor didn't do what it promised), yet the server tolerates it gracefully instead of crashing on the failed JSON parse.

## Backward compatibility

With the default `managedByEditor: true`, nothing changes behaviourally for anyone: the advertised command set is unchanged, no external files are read or written, and VS Code / Emacs / Sublime keep handling external files exactly as they do today. The only difference in the initialize response is the additive `experimental.manageExternalFiles` capability field, which clients that don't look for it ignore. (The byte-asserted launcher tests were updated solely to include that one new field.)

## Follow-up steps if this is merged upstream

1. **Update the Zed extension (`zed-ltex`)**, in two parts:
   - **Delegate to the server by default** — send `managedByEditor: false`, and don't expose *that* as a user toggle, since Zed cannot manage these files client-side. On an old server this is harmless; on a supporting server it turns on the code actions automatically via `executeCommandProvider`.
   - **Document the setup in the extension's README** — using this feature takes active configuration (the user adds the `:`-prefixed file entries to `settings.ltex.dictionary`, `disabledRules`, `hiddenFalsePositives`). The external-file **paths** are the user's choice, not something the extension hardcodes; the extension may ship a sane default path, but the user must be able to override it.
2. **Document `ltex.externalFiles.managedByEditor` in the VS Code extension (`vscode-ltex-plus`)**, so the setting is described and appears on the settings website.