### PR TITLE
Support multi-word dictionary entries via pre-LanguageTool masking (supersedes #184)

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolInterface.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolInterface.kt
@@ -13,27 +13,15 @@ import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 abstract class LanguageToolInterface {
   // Per-language buckets, keyed by `<lang>` or `<lang>-<REGION>`. The match-time
   // filter looks these up using `annotatedTextFragment.codeFragment.languageShortCode`
-  // so that dictionary / disabled-rule suppression keys correctly under the
-  // *detected* language when ltex.language="auto" — including the HTTP path,
-  // where detection happens server-side and the session-wide
-  // settings.languageShortCode stays at the literal "auto".
+  // so that disabled-rule suppression keys correctly under the *detected*
+  // language when ltex.language="auto" — including the HTTP path, where
+  // detection happens server-side and the session-wide settings.languageShortCode
+  // stays at the literal "auto".
   //
-  // The user dictionary buckets are stored verbatim. The add path
-  // (CodeActionProvider) sends bare words to the client in the "Add to
-  // dictionary" command — for matches from rule families that emit
-  // punctuation-adjacent spans (Premium QB_NEW_* / AI_*) the matched
-  // substring is stripped via DictionaryWord.normalize before being persisted,
-  // so the on-disk entry is the bare word. For every other rule family the
-  // substring is already bare and is persisted as-is. The server cannot
-  // enforce what the client actually writes to disk, but the reference
-  // clients write what we send.
-  //
-  // Hand-edited entries are intentionally left untouched at load time: the
-  // file on disk is the user's data and may carry punctuation or whitespace
-  // by deliberate choice. Normalization on the check side happens only when
-  // the match's rule id falls into the Premium punctuation-adjacent family —
-  // see isCoveredByDictionary below.
-  var allDictionaries: Map<String, Set<String>> = emptyMap()
+  // Note: the user dictionary is no longer consulted here. Dictionary words are
+  // masked out of the text before it reaches LanguageTool (see
+  // CodeAnnotatedTextBuilder / DictionaryMasker), so no match is ever produced
+  // for them and there is nothing to suppress after the fact.
   var allDisabledRules: Map<String, Set<String>> = emptyMap()
 
   var languageToolOrgUsername = ""
@@ -54,51 +42,8 @@ abstract class LanguageToolInterface {
     match: LanguageToolRuleMatch,
   ): Boolean {
     val fragmentLanguage: String = annotatedTextFragment.codeFragment.languageShortCode
-    val dictionary: Set<String> = this.allDictionaries[fragmentLanguage] ?: emptySet()
     val disabledRules: Set<String> = this.allDisabledRules[fragmentLanguage] ?: emptySet()
-    return !disabledRules.contains(match.ruleId) &&
-      (
-        !match.isUnknownWordRule() ||
-          !isCoveredByDictionary(annotatedTextFragment, match, dictionary)
-      )
-  }
-
-  // Suppress a match if the per-language dictionary contains the flagged word.
-  //
-  // The lookup key depends on which rule family fired the match. Premium's
-  // QB_NEW_* / AI_* families sometimes emit spans that include adjacent
-  // punctuation, e.g. `amazng!` (length 7) or `"amazng"` (length 8); for
-  // those rules we strip leading/trailing non-letter-non-digit characters
-  // via DictionaryWord.normalize so a single stored entry `amazng` suppresses
-  // every punctuation-context variant.
-  //
-  // For every other rule family (Morfologik / Hunspell / *_SPELLER_RULE /
-  // Slovak gender rules / _SIMPLE_REPLACE_) the span is already bare and we
-  // look it up literally — gaining a stronger no-behavior-change guarantee
-  // for free-LT and local-Java users: not just a no-op normalize call but
-  // no normalize call at all on those code paths.
-  //
-  // Multi-word phrase entries (e.g. a hand-typed `"LTEX LS"`, or the local
-  // Java backend's all-caps Morfologik collapse on `LTEX LS`) still suppress:
-  // those matches fall in the literal branch, and the dictionary holds the
-  // phrase verbatim.
-  //
-  // An entirely-punctuation span normalizes to "" (Premium branch) and is
-  // treated as not covered; the diagnostic stays visible. The user can
-  // disable the rule or fix the text in that exotic case.
-  private fun isCoveredByDictionary(
-    annotatedTextFragment: AnnotatedTextFragment,
-    match: LanguageToolRuleMatch,
-    dictionary: Set<String>,
-  ): Boolean {
-    val span: String = annotatedTextFragment.getSubstringOfPlainText(match.fromPos, match.toPos)
-    val lookupKey: String =
-      if (LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)) {
-        DictionaryWord.normalize(span)
-      } else {
-        span
-      }
-    return lookupKey.isNotEmpty() && dictionary.contains(lookupKey)
+    return !disabledRules.contains(match.ruleId)
   }
 
   abstract fun isInitialized(): Boolean

--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolJavaInterface.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolJavaInterface.kt
@@ -37,7 +37,6 @@ class LanguageToolJavaInterface(
   languageShortCode: String,
   motherTongueShortCode: String,
   sentenceCacheSize: Long,
-  dictionary: Set<String>,
 ) : LanguageToolInterface() {
   // null when sentenceCacheSize <= 0, which disables LanguageTool's internal
   // per-sentence ResultCache. LTeX's own per-paragraph FragmentCache supersedes
@@ -61,7 +60,10 @@ class LanguageToolJavaInterface(
         } else {
           null
         }
-      val userConfig = UserConfig(dictionary.toList())
+      // The user dictionary is masked out of the text upstream (DictionaryMasker),
+      // so LanguageTool needs no acceptedWords list here — masking is the single,
+      // backend-agnostic mechanism (the HTTP backend has no UserConfig at all).
+      val userConfig = UserConfig(emptyList<String>())
 
       this.languageTool = JLanguageTool(language, motherTongue, this.resultCache, userConfig)
     } else {

--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.kt
@@ -203,11 +203,13 @@ data class LanguageToolRuleMatch(
     // already matches verbatim and no normalization is needed.
     //
     // The dictionary add path (CodeActionProvider.getAddWordToDictionaryCodeAction)
-    // and check path (LanguageToolInterface.isCoveredByDictionary) consult this
-    // predicate to decide whether to normalize the span before persisting or
-    // looking up. Mirrors the rule-family allowlist convention used by
-    // isUnknownWordRule above; if Premium adds new rule families that include
-    // adjacent punctuation, extend this allowlist accordingly.
+    // consults this predicate to decide whether to normalize the span before
+    // persisting, so the on-disk entry is the bare word. (The former check-path
+    // lookup is gone: dictionary words are now masked out of the text before
+    // LanguageTool sees them — see DictionaryMasker.) Mirrors the rule-family
+    // allowlist convention used by isUnknownWordRule above; if Premium adds new
+    // rule families that include adjacent punctuation, extend this allowlist
+    // accordingly.
     fun isPremiumPunctuationAdjacentSpanRule(ruleId: String?): Boolean =
       (ruleId != null) &&
         (ruleId.startsWith("QB_NEW_") || ruleId.startsWith("AI_"))

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CharacterBasedCodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CharacterBasedCodeAnnotatedTextBuilder.kt
@@ -8,7 +8,6 @@
 
 package org.bsplines.ltexls.parsing
 
-import org.bsplines.ltexls.settings.Settings
 import org.bsplines.ltexls.tools.I18n
 import org.bsplines.ltexls.tools.Logging
 
@@ -24,22 +23,12 @@ abstract class CharacterBasedCodeAnnotatedTextBuilder(
     protected set
   val codeMode = CodeModeHandler()
 
-  protected var dummyGenerator = DummyGenerator.getInstance()
-  protected var dummyCounter = 0
-
-  protected var language: String = "en-US"
-
   var isPreventingInfiniteLoops = false
 
   var curString = ""
     protected set
   var isStartOfLine = false
     protected set
-
-  override fun setSettings(settings: Settings) {
-    super.setSettings(settings)
-    this.language = settings.languageShortCode
-  }
 
   override fun addText(text: String?): CharacterBasedCodeAnnotatedTextBuilder {
     if (text?.isNotEmpty() == true) {

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
@@ -44,9 +44,18 @@ abstract class CodeAnnotatedTextBuilder(
   protected var dummyGenerator: DummyGenerator = DummyGenerator.getInstance()
   protected var dummyCounter = 0
 
-  // null when the per-language dictionary is empty (the common case), so the
-  // TEXT fast path stays a single super.addText() with zero overhead.
+  // null when the per-language dictionary is empty (the common case); build()
+  // then replays the buffered parts verbatim, byte-for-byte what the eager
+  // emission used to produce.
   protected var dictionaryMasker: DictionaryMasker? = null
+
+  // Finalized parts awaiting emission into LanguageTool's AnnotatedTextBuilder.
+  // Emission is deferred to build() so the dictionary masker can match entries
+  // over the *assembled* plain text — a phrase wrapped over a Markdown soft
+  // line break or a word containing a LaTeX accent command is contiguous only
+  // there, never within a single TEXT part. Nothing observes the underlying
+  // builder's state before build(), so the deferral is invisible.
+  private val parts = mutableListOf<DictionaryMasker.Part>()
 
   abstract fun addCode(code: String): CodeAnnotatedTextBuilder
 
@@ -123,46 +132,45 @@ abstract class CodeAnnotatedTextBuilder(
     return this
   }
 
+  // Mask any user-dictionary occurrences as markup with a dummy interpretation
+  // (the same mechanism inline math `$x$` uses), so LanguageTool never sees the
+  // dictionary word — single- and multi-word entries alike — while a real typo
+  // after a masked span still reprojects to the correct source position (the
+  // dummy contributes plain-text length but zero source offset).
   override fun build(): AnnotatedText {
     finalizeCurrentPart()
+
+    val outParts: List<DictionaryMasker.Part> =
+      this.dictionaryMasker?.maskParts(this.parts) {
+        this.dummyGenerator.generate(this.language, this.dummyCounter++)
+      } ?: this.parts
+
+    for (part: DictionaryMasker.Part in outParts) {
+      if (part.type == TextPart.Type.TEXT) {
+        super.addText(part.code)
+      } else {
+        super.addMarkup(part.code, part.interpretAs)
+      }
+    }
+
     return super.build()
   }
 
   private fun finalizeCurrentPart() {
     if (curType == TextPart.Type.MARKUP) {
-      super.addMarkup(curMarkup.toString(), curInterpretAs.toString())
+      parts.add(
+        DictionaryMasker.Part(
+          TextPart.Type.MARKUP,
+          curMarkup.toString(),
+          curInterpretAs.toString(),
+        ),
+      )
       curMarkup.clear()
       curInterpretAs.clear()
     }
     if (curType == TextPart.Type.TEXT) {
-      emitTextWithDictionaryMasking(curText.toString())
+      parts.add(DictionaryMasker.Part(TextPart.Type.TEXT, curText.toString()))
       curText.clear()
-    }
-  }
-
-  // Emit a finalized TEXT part, masking any user-dictionary occurrences as
-  // markup with a dummy interpretation (the same mechanism inline math `$x$`
-  // uses), so LanguageTool never sees the dictionary word — single- and
-  // multi-word entries alike — while a real typo after a masked span still
-  // reprojects to the correct source position (the dummy contributes plain-text
-  // length but zero source offset).
-  private fun emitTextWithDictionaryMasking(text: String) {
-    val masker: DictionaryMasker? = this.dictionaryMasker
-
-    if (masker == null) {
-      super.addText(text)
-      return
-    }
-
-    for (segment: DictionaryMasker.Segment in masker.split(text)) {
-      if (segment.masked) {
-        super.addMarkup(
-          segment.text,
-          this.dummyGenerator.generate(this.language, this.dummyCounter++),
-        )
-      } else {
-        super.addText(segment.text)
-      }
     }
   }
 

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
@@ -140,6 +140,10 @@ abstract class CodeAnnotatedTextBuilder(
   override fun build(): AnnotatedText {
     finalizeCurrentPart()
 
+    // Always the default (consonant-initial) dummy: the vowel variant "Ina<n>"
+    // is itself flagged by LanguageTool Premium's AI rules, which would surface
+    // a diagnostic exactly on the masked dictionary word (caught by
+    // LanguageToolPremiumIntegrationTest).
     val outParts: List<DictionaryMasker.Part> =
       this.dictionaryMasker?.maskParts(this.parts) {
         this.dummyGenerator.generate(this.language, this.dummyCounter++)

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
@@ -36,6 +36,18 @@ abstract class CodeAnnotatedTextBuilder(
   protected var curInterpretAs = StringBuilder()
   protected var curType: TextPart.Type? = null
 
+  // Dummy-token state, shared by every subclass so that markup dummies (e.g.
+  // inline math `$x$`) and dictionary-masking dummies draw from one monotonic
+  // counter — two identical adjacent dummy tokens would otherwise trip
+  // LanguageTool's repeated-word rule.
+  protected var language: String = "en-US"
+  protected var dummyGenerator: DummyGenerator = DummyGenerator.getInstance()
+  protected var dummyCounter = 0
+
+  // null when the per-language dictionary is empty (the common case), so the
+  // TEXT fast path stays a single super.addText() with zero overhead.
+  protected var dictionaryMasker: DictionaryMasker? = null
+
   abstract fun addCode(code: String): CodeAnnotatedTextBuilder
 
   open fun addComment(
@@ -50,8 +62,23 @@ abstract class CodeAnnotatedTextBuilder(
     return this
   }
 
-  @Suppress("UNUSED_PARAMETER")
   open fun setSettings(settings: Settings) {
+    this.language = settings.languageShortCode
+    // Normally mask only the current language's dictionary. Under
+    // ltex.language="auto" the language is resolved later (server-side on the
+    // HTTP path), so settings.dictionary — keyed on the literal "auto" — is
+    // empty at build time; fall back to masking the union of every language's
+    // entries so a user-added word is still honoured on the first check.
+    val dictionary: Set<String> =
+      if (settings.languageShortCode == "auto") {
+        settings.allDictionaries.values
+          .flatten()
+          .toSet()
+      } else {
+        settings.dictionary
+      }
+    val masker = DictionaryMasker(dictionary)
+    this.dictionaryMasker = if (masker.isEmpty) null else masker
   }
 
   override fun addText(text: String?): CodeAnnotatedTextBuilder {
@@ -108,8 +135,34 @@ abstract class CodeAnnotatedTextBuilder(
       curInterpretAs.clear()
     }
     if (curType == TextPart.Type.TEXT) {
-      super.addText(curText.toString())
+      emitTextWithDictionaryMasking(curText.toString())
       curText.clear()
+    }
+  }
+
+  // Emit a finalized TEXT part, masking any user-dictionary occurrences as
+  // markup with a dummy interpretation (the same mechanism inline math `$x$`
+  // uses), so LanguageTool never sees the dictionary word — single- and
+  // multi-word entries alike — while a real typo after a masked span still
+  // reprojects to the correct source position (the dummy contributes plain-text
+  // length but zero source offset).
+  private fun emitTextWithDictionaryMasking(text: String) {
+    val masker: DictionaryMasker? = this.dictionaryMasker
+
+    if (masker == null) {
+      super.addText(text)
+      return
+    }
+
+    for (segment: DictionaryMasker.Segment in masker.split(text)) {
+      if (segment.masked) {
+        super.addMarkup(
+          segment.text,
+          this.dummyGenerator.generate(this.language, this.dummyCounter++),
+        )
+      } else {
+        super.addText(segment.text)
+      }
     }
   }
 

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
@@ -8,12 +8,24 @@
 
 package org.bsplines.ltexls.parsing
 
-// Splits a run of plain text into verbatim and "masked" segments based on the
-// user dictionary, so that masked segments can be replaced by a dummy token
-// before the text reaches LanguageTool. This is what gives LTeX+ multi-word
-// dictionary support: LanguageTool checks the text per token and never sees a
-// phrase like `GreenTeam Penciltest` as a unit, so a phrase entry can only be
-// honoured by removing its occurrences from the text up front.
+import org.languagetool.markup.TextPart
+
+// Masks user-dictionary occurrences in a builder's part list so that masked
+// spans can be replaced by a dummy token before the text reaches LanguageTool.
+// This is what gives LTeX+ multi-word dictionary support: LanguageTool checks
+// the text per token and never sees a phrase like `GreenTeam Penciltest` as a
+// unit, so a phrase entry can only be honoured by removing its occurrences from
+// the text up front.
+//
+// Matching runs over the *assembled plain text* — TEXT parts joined with the
+// interpretAs of MARKUP parts — i.e. exactly the string LanguageTool checks.
+// An entry therefore also matches when its occurrence is split across parts in
+// the source: a phrase wrapped over a Markdown soft line break (the newline is
+// markup interpreted as a space), a word containing a LaTeX accent command
+// (`M\"uller`), or a phrase interrupted by inline tags (`LT<sub>E</sub>X LS`).
+// The covered parts are coalesced into a single markup part whose source is the
+// concatenation of the covered source pieces, so the plain-text-to-source
+// mapping outside masked spans stays exact.
 //
 // A dictionary entry matches only as a whole token sequence: the characters
 // immediately before and after the matched span must not be letters or digits
@@ -27,10 +39,17 @@ package org.bsplines.ltexls.parsing
 class DictionaryMasker(
   dictionary: Set<String>,
 ) {
-  data class Segment(
-    val text: String,
-    val masked: Boolean,
-  )
+  // One builder part awaiting emission into LanguageTool's AnnotatedTextBuilder.
+  // TEXT: code is the plain text itself (interpretAs unused). MARKUP: code is
+  // the source markup, interpretAs its (possibly empty) plain-text stand-in.
+  data class Part(
+    val type: TextPart.Type,
+    val code: String,
+    val interpretAs: String = "",
+  ) {
+    val plainText: String
+      get() = if (type == TextPart.Type.TEXT) code else interpretAs
+  }
 
   // Longest first so the longest matching entry wins on overlap; blank entries
   // dropped (a whitespace-only entry would otherwise try to mask runs of space).
@@ -39,11 +58,12 @@ class DictionaryMasker(
 
   val isEmpty: Boolean = entries.isEmpty()
 
-  fun split(text: String): List<Segment> {
-    if (entries.isEmpty() || text.isEmpty()) return listOf(Segment(text, false))
+  // Non-overlapping match ranges in [text], ascending, each built with `until`
+  // (half-open, so text.substring(range) yields the matched entry).
+  fun findMatches(text: String): List<IntRange> {
+    if (entries.isEmpty() || text.isEmpty()) return emptyList()
 
-    val segments = ArrayList<Segment>()
-    var emittedUpTo = 0
+    val matches = ArrayList<IntRange>()
     var pos = 0
 
     while (pos < text.length) {
@@ -52,15 +72,32 @@ class DictionaryMasker(
       if (matchEnd < 0) {
         pos++
       } else {
-        if (pos > emittedUpTo) segments.add(Segment(text.substring(emittedUpTo, pos), false))
-        segments.add(Segment(text.substring(pos, matchEnd), true))
-        emittedUpTo = matchEnd
+        matches.add(pos until matchEnd)
         pos = matchEnd
       }
     }
 
-    if (emittedUpTo < text.length) segments.add(Segment(text.substring(emittedUpTo), false))
-    return segments
+    return matches
+  }
+
+  // Returns [parts] with every dictionary occurrence in the assembled plain
+  // text coalesced into one markup part interpreted as dummyProvider(). Matches
+  // whose start or end falls strictly inside a markup's interpretAs are skipped
+  // (the markup source cannot be split at a plain-text position); such a
+  // boundary requires an interpretAs of length >= 2, which is rare.
+  fun maskParts(
+    parts: List<Part>,
+    dummyProvider: () -> String,
+  ): List<Part> {
+    if (this.isEmpty || parts.isEmpty()) return parts
+
+    val plainStarts: IntArray = computePlainStarts(parts)
+    val plainText: String = parts.joinToString("") { it.plainText }
+    val matches: List<IntRange> =
+      findMatches(plainText).filter { isMaskable(it, parts, plainStarts) }
+    if (matches.isEmpty()) return parts
+
+    return PartRebuilder(parts, plainStarts, matches, dummyProvider).rebuild()
   }
 
   // Exclusive end offset of the longest entry matching [text] at [start] on
@@ -88,5 +125,134 @@ class DictionaryMasker(
       text.regionMatches(start, entry, 0, entry.length, ignoreCase = false)
     val trailingBoundaryOk: Boolean = (end >= text.length) || !text[end].isLetterOrDigit()
     return matchesLiterally && trailingBoundaryOk
+  }
+
+  // Rebuilds a part list with the given plain-text match ranges replaced by
+  // dummy markup parts. TEXT parts straddling a match boundary are split; parts
+  // covered by a match contribute their source (text or markup) to the masked
+  // part's source, so the total source is preserved and offsets outside masked
+  // spans stay exact.
+  private class PartRebuilder(
+    private val parts: List<Part>,
+    private val plainStarts: IntArray,
+    matches: List<IntRange>,
+    private val dummyProvider: () -> String,
+  ) {
+    // (start, exclusive end) plain-text offsets of the pending matches.
+    private val matchQueue = ArrayDeque(matches.map { Pair(it.first, it.last + 1) })
+    private val result = ArrayList<Part>()
+    private val maskedSource = StringBuilder()
+
+    fun rebuild(): List<Part> {
+      for ((partIndex: Int, part: Part) in parts.withIndex()) {
+        if (part.type == TextPart.Type.TEXT) {
+          consumeTextPart(part, plainStarts[partIndex], plainStarts[partIndex + 1])
+        } else {
+          consumeMarkupPart(part, plainStarts[partIndex], plainStarts[partIndex + 1])
+        }
+      }
+
+      return result
+    }
+
+    private fun consumeTextPart(
+      part: Part,
+      partStart: Int,
+      partEnd: Int,
+    ) {
+      var pos: Int = partStart
+
+      while (pos < partEnd) {
+        val match: Pair<Int, Int>? = matchQueue.firstOrNull()
+
+        if ((match == null) || (match.first >= partEnd)) {
+          result.add(Part(TextPart.Type.TEXT, part.code.substring(pos - partStart)))
+          pos = partEnd
+        } else if (pos < match.first) {
+          result.add(
+            Part(TextPart.Type.TEXT, part.code.substring(pos - partStart, match.first - partStart)),
+          )
+          pos = match.first
+        } else {
+          val pieceEnd: Int = minOf(match.second, partEnd)
+          maskedSource.append(part.code, pos - partStart, pieceEnd - partStart)
+          pos = pieceEnd
+          if (pos == match.second) closeMask()
+        }
+      }
+    }
+
+    private fun consumeMarkupPart(
+      part: Part,
+      partStart: Int,
+      partEnd: Int,
+    ) {
+      val match: Pair<Int, Int>? = matchQueue.firstOrNull()
+      // A zero-plain-length markup (empty interpretAs) exactly at a match
+      // boundary stays outside the mask (minimal span); with a nonzero plain
+      // contribution the markup is inside whenever the match covers it (a match
+      // boundary strictly inside its interpretAs was filtered out upstream).
+      val insideMask: Boolean =
+        (match != null) &&
+          if (partStart == partEnd) {
+            (match.first < partStart) && (partStart < match.second)
+          } else {
+            (match.first <= partStart) && (partEnd <= match.second)
+          }
+
+      if (insideMask) {
+        maskedSource.append(part.code)
+        if (partEnd == match.second) closeMask()
+      } else {
+        result.add(part)
+      }
+    }
+
+    private fun closeMask() {
+      result.add(Part(TextPart.Type.MARKUP, maskedSource.toString(), dummyProvider()))
+      maskedSource.clear()
+      matchQueue.removeFirst()
+    }
+  }
+
+  companion object {
+    // plainStarts[i] is the plain-text offset where part i begins; the extra
+    // trailing element is the total plain-text length.
+    private fun computePlainStarts(parts: List<Part>): IntArray {
+      val plainStarts = IntArray(parts.size + 1)
+
+      for ((partIndex: Int, part: Part) in parts.withIndex()) {
+        plainStarts[partIndex + 1] = plainStarts[partIndex] + part.plainText.length
+      }
+
+      return plainStarts
+    }
+
+    // A match is maskable iff neither boundary falls strictly inside a MARKUP
+    // part's plain-text contribution (its interpretAs cannot be split at a
+    // plain-text position — which half of the source would each piece map to?).
+    private fun isMaskable(
+      match: IntRange,
+      parts: List<Part>,
+      plainStarts: IntArray,
+    ): Boolean =
+      isSplittableBoundary(match.first, parts, plainStarts) &&
+        isSplittableBoundary(match.last + 1, parts, plainStarts)
+
+    private fun isSplittableBoundary(
+      pos: Int,
+      parts: List<Part>,
+      plainStarts: IntArray,
+    ): Boolean {
+      for (partIndex: Int in parts.indices) {
+        if (plainStarts[partIndex] >= pos) break
+
+        if (pos < plainStarts[partIndex + 1]) {
+          return parts[partIndex].type == TextPart.Type.TEXT
+        }
+      }
+
+      return true
+    }
   }
 }

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
@@ -1,0 +1,92 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.parsing
+
+// Splits a run of plain text into verbatim and "masked" segments based on the
+// user dictionary, so that masked segments can be replaced by a dummy token
+// before the text reaches LanguageTool. This is what gives LTeX+ multi-word
+// dictionary support: LanguageTool checks the text per token and never sees a
+// phrase like `GreenTeam Penciltest` as a unit, so a phrase entry can only be
+// honoured by removing its occurrences from the text up front.
+//
+// A dictionary entry matches only as a whole token sequence: the characters
+// immediately before and after the matched span must not be letters or digits
+// (Unicode-aware, via Char.isLetterOrDigit() — not a regex `\b`, whose `\w` is
+// ASCII-only and mishandles accented letters). So `GreenTeam` is not masked
+// inside `GreenTeamer`, and surrounding punctuation (`(GreenTeam Penciltest).`)
+// is left untouched. Matching is case-sensitive, preserving the exact semantics
+// of the former `dictionary.contains(span)` suppression. On overlap the longest
+// entry wins, so a lone `GreenTeam` is masked only when `GreenTeam` is itself an
+// entry — not as a by-product of the phrase entry `GreenTeam Penciltest`.
+class DictionaryMasker(
+  dictionary: Set<String>,
+) {
+  data class Segment(
+    val text: String,
+    val masked: Boolean,
+  )
+
+  // Longest first so the longest matching entry wins on overlap; blank entries
+  // dropped (a whitespace-only entry would otherwise try to mask runs of space).
+  private val entries: List<String> =
+    dictionary.filter { it.isNotBlank() }.sortedByDescending { it.length }
+
+  val isEmpty: Boolean = entries.isEmpty()
+
+  fun split(text: String): List<Segment> {
+    if (entries.isEmpty() || text.isEmpty()) return listOf(Segment(text, false))
+
+    val segments = ArrayList<Segment>()
+    var emittedUpTo = 0
+    var pos = 0
+
+    while (pos < text.length) {
+      val matchEnd: Int = matchAt(text, pos)
+
+      if (matchEnd < 0) {
+        pos++
+      } else {
+        if (pos > emittedUpTo) segments.add(Segment(text.substring(emittedUpTo, pos), false))
+        segments.add(Segment(text.substring(pos, matchEnd), true))
+        emittedUpTo = matchEnd
+        pos = matchEnd
+      }
+    }
+
+    if (emittedUpTo < text.length) segments.add(Segment(text.substring(emittedUpTo), false))
+    return segments
+  }
+
+  // Exclusive end offset of the longest entry matching [text] at [start] on
+  // whole-token boundaries, or -1 if none matches there. `entries` is sorted
+  // longest-first, so the first match found is the longest one.
+  private fun matchAt(
+    text: String,
+    start: Int,
+  ): Int {
+    if ((start > 0) && text[start - 1].isLetterOrDigit()) return -1
+    val entry: String? = entries.firstOrNull { entryMatchesAt(text, start, it) }
+    return if (entry != null) (start + entry.length) else -1
+  }
+
+  // Does [entry] occur literally at [start] in [text] with a trailing token
+  // boundary? (The leading boundary is already guaranteed by the caller.)
+  private fun entryMatchesAt(
+    text: String,
+    start: Int,
+    entry: String,
+  ): Boolean {
+    val end: Int = start + entry.length
+    if (end > text.length) return false
+    val matchesLiterally: Boolean =
+      text.regionMatches(start, entry, 0, entry.length, ignoreCase = false)
+    val trailingBoundaryOk: Boolean = (end >= text.length) || !text[end].isLetterOrDigit()
+    return matchesLiterally && trailingBoundaryOk
+  }
+}

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
@@ -32,10 +32,17 @@ import org.languagetool.markup.TextPart
 // (Unicode-aware, via Char.isLetterOrDigit() — not a regex `\b`, whose `\w` is
 // ASCII-only and mishandles accented letters). So `GreenTeam` is not masked
 // inside `GreenTeamer`, and surrounding punctuation (`(GreenTeam Penciltest).`)
-// is left untouched. Matching is case-sensitive, preserving the exact semantics
-// of the former `dictionary.contains(span)` suppression. On overlap the longest
-// entry wins, so a lone `GreenTeam` is masked only when `GreenTeam` is itself an
-// entry — not as a by-product of the phrase entry `GreenTeam Penciltest`.
+// is left untouched. On overlap the longest entry wins, so a lone `GreenTeam`
+// is masked only when `GreenTeam` is itself an entry — not as a by-product of
+// the phrase entry `GreenTeam Penciltest`.
+//
+// Case handling follows the hunspell / LanguageTool-speller convention for
+// accepted words: an entry matches its own case exactly, plus — when the entry
+// begins with a lowercase letter — its sentence-initial titlecase variant
+// (`foobar` also accepts `Foobar.` at a sentence start), plus its all-uppercase
+// variant (`GreenTeam` also accepts `GREENTEAM` in headings). General
+// case-insensitivity is deliberately not offered: adding `IT` must not accept
+// `it`.
 class DictionaryMasker(
   dictionary: Set<String>,
 ) {
@@ -51,10 +58,19 @@ class DictionaryMasker(
       get() = if (type == TextPart.Type.TEXT) code else interpretAs
   }
 
-  // Longest first so the longest matching entry wins on overlap; blank entries
-  // dropped (a whitespace-only entry would otherwise try to mask runs of space).
+  // Each entry plus its generated case variants (sentence-initial titlecase for
+  // lowercase-initial entries, all-uppercase), matched literally. Longest first
+  // so the longest matching entry wins on overlap; blank entries dropped (a
+  // whitespace-only entry would otherwise try to mask runs of space).
   private val entries: List<String> =
-    dictionary.filter { it.isNotBlank() }.sortedByDescending { it.length }
+    buildSet {
+      for (entry: String in dictionary) {
+        if (entry.isBlank()) continue
+        add(entry)
+        if (entry.first().isLowerCase()) add(entry.replaceFirstChar { it.titlecaseChar() })
+        add(entry.uppercase())
+      }
+    }.sortedByDescending { it.length }
 
   val isEmpty: Boolean = entries.isEmpty()
 

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/DictionaryMasker.kt
@@ -43,6 +43,14 @@ import org.languagetool.markup.TextPart
 // variant (`GreenTeam` also accepts `GREENTEAM` in headings). General
 // case-insensitivity is deliberately not offered: adding `IT` must not accept
 // `it`.
+//
+// Unicode space separators (e.g. the no-break space a LaTeX tie `~` puts into
+// the plain text) are normalized to a plain space on both sides of the
+// comparison — in the entries and in the checked text — so the entry
+// `GreenTeam Penciltest` also masks `GreenTeam~Penciltest`. The replacement is
+// one-for-one, so all offsets stay valid. Newlines and tabs are deliberately
+// left alone: they are structural (a heading ending, a paragraph break), and a
+// single-space entry must not match across them.
 class DictionaryMasker(
   dictionary: Set<String>,
 ) {
@@ -58,13 +66,15 @@ class DictionaryMasker(
       get() = if (type == TextPart.Type.TEXT) code else interpretAs
   }
 
-  // Each entry plus its generated case variants (sentence-initial titlecase for
-  // lowercase-initial entries, all-uppercase), matched literally. Longest first
-  // so the longest matching entry wins on overlap; blank entries dropped (a
-  // whitespace-only entry would otherwise try to mask runs of space).
+  // Each entry, space-normalized, plus its generated case variants
+  // (sentence-initial titlecase for lowercase-initial entries, all-uppercase),
+  // matched literally. Longest first so the longest matching entry wins on
+  // overlap; blank entries dropped (a space-only entry would otherwise try to
+  // mask runs of space).
   private val entries: List<String> =
     buildSet {
-      for (entry: String in dictionary) {
+      for (rawEntry: String in dictionary) {
+        val entry: String = normalizeSpaceSeparators(rawEntry)
         if (entry.isBlank()) continue
         add(entry)
         if (entry.first().isLowerCase()) add(entry.replaceFirstChar { it.titlecaseChar() })
@@ -75,15 +85,18 @@ class DictionaryMasker(
   val isEmpty: Boolean = entries.isEmpty()
 
   // Non-overlapping match ranges in [text], ascending, each built with `until`
-  // (half-open, so text.substring(range) yields the matched entry).
+  // (half-open, so text.substring(range) yields the matched span). Matching
+  // runs over the space-normalized text; normalization is one-for-one, so the
+  // ranges are valid for the original [text] as well.
   fun findMatches(text: String): List<IntRange> {
     if (entries.isEmpty() || text.isEmpty()) return emptyList()
 
+    val normalizedText: String = normalizeSpaceSeparators(text)
     val matches = ArrayList<IntRange>()
     var pos = 0
 
-    while (pos < text.length) {
-      val matchEnd: Int = matchAt(text, pos)
+    while (pos < normalizedText.length) {
+      val matchEnd: Int = matchAt(normalizedText, pos)
 
       if (matchEnd < 0) {
         pos++
@@ -232,6 +245,24 @@ class DictionaryMasker(
   }
 
   companion object {
+    // One-for-one replacement of Unicode space separators (no-break space,
+    // thin space, ...) by a plain space, preserving length and all offsets.
+    // Returns [text] itself when nothing needs replacing (the common case).
+    // Newlines and tabs are not space separators and pass through untouched.
+    private fun normalizeSpaceSeparators(text: String): String {
+      if (text.none(::isNonStandardSpaceSeparator)) return text
+
+      return String(
+        CharArray(text.length) { charIndex ->
+          val curChar: Char = text[charIndex]
+          if (isNonStandardSpaceSeparator(curChar)) ' ' else curChar
+        },
+      )
+    }
+
+    private fun isNonStandardSpaceSeparator(curChar: Char): Boolean =
+      (curChar != ' ') && (curChar.category == CharCategory.SPACE_SEPARATOR)
+
     // plainStarts[i] is the plain-text offset where part i begins; the extra
     // trailing element is the total plain-text length.
     private fun computePlainStarts(parts: List<Part>): IntArray {

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilder.kt
@@ -60,10 +60,8 @@ class MarkdownAnnotatedTextBuilder(
   private val parser: Parser = Parser.builder(PARSER_OPTIONS).build()
   private var code = ""
   private var pos = 0
-  private var dummyCounter = 0
   private var firstCellInTableRow = false
   private val nodeTypeStack = ArrayDeque<String>()
-  private var language: String = "en-US"
   private var shadowMarkups = listOf<Triple<String, Int, Int>>()
   private var shadowOffset = 0
   private val nodeSignatures: MutableList<MarkdownNodeSignature> =
@@ -328,7 +326,6 @@ class MarkdownAnnotatedTextBuilder(
 
   override fun setSettings(settings: Settings) {
     super.setSettings(settings)
-    this.language = settings.languageShortCode
 
     for ((nodeName: String, actionString: String) in settings.markdownNodes) {
       var dummyGenerator: DummyGenerator = DummyGenerator.getInstance()

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/program/ProgramAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/program/ProgramAnnotatedTextBuilder.kt
@@ -43,10 +43,12 @@ class ProgramAnnotatedTextBuilder(
   private val commentBlockRegex: Regex = commentRegexs.commentBlockRegex
   private val lineCommentPatternString: String? = commentRegexs.lineCommentRegexString
 
-  // This builder only wraps the inner Markdown/reStructuredText builder (addCode
-  // and build delegate to it), so settings must be forwarded there — otherwise
-  // the inner builder never receives ltex.language (used to pick dummy tokens)
-  // or ltex.markdownNodes for prose inside comments/docstrings.
+  // This builder is a pure wrapper: addCode/build delegate to the inner
+  // Markdown/reStructuredText builder, so settings must be configured on that
+  // inner builder, not on this outer shell whose own AnnotatedTextBuilder state
+  // is never used. Otherwise the inner builder never receives ltex.language
+  // (used to pick dummy tokens), ltex.markdownNodes, or the dictionary masker
+  // for prose inside comments/docstrings.
   override fun setSettings(settings: Settings) {
     annotatedTextBuilder.setSettings(settings)
   }

--- a/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
@@ -218,12 +218,11 @@ class CodeActionProvider(
       // Strip leading/trailing punctuation only when the match's rule family
       // is known to emit punctuation-adjacent spans (Premium's QB_NEW_* /
       // AI_*); for everyone else the span is already bare and we persist it
-      // verbatim. Same gate runs on the check path
-      // (LanguageToolInterface.isCoveredByDictionary) so the round-trip is
-      // symmetric — a word added under one rule family looks up correctly
-      // when seen again under the same family. Skip the match if the
-      // normalized form is empty (entirely-punctuation span — should never
-      // happen for a real spell-check rule).
+      // verbatim. Persisting the bare word is what lets DictionaryMasker mask
+      // it back out of the text on the next check (whole-token, case-sensitive
+      // matching). Skip the match if the normalized form is empty
+      // (entirely-punctuation span — should never happen for a real
+      // spell-check rule).
       val word: String =
         if (LanguageToolRuleMatch.isPremiumPunctuationAdjacentSpanRule(match.ruleId)) {
           DictionaryWord.normalize(matchedText)

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsManager.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsManager.kt
@@ -45,7 +45,6 @@ class SettingsManager {
           this.languageToolInterface
         }
 
-      languageToolInterface?.allDictionaries = value.allDictionaries
       languageToolInterface?.allDisabledRules = value.allDisabledRules
       languageToolInterface?.languageToolOrgUsername = value.languageToolOrgUsername
       languageToolInterface?.languageToolOrgApiKey = value.languageToolOrgApiKey
@@ -78,7 +77,6 @@ class SettingsManager {
           this.settings.languageShortCode,
           this.settings.motherTongueShortCode,
           this.settings.sentenceCacheSize,
-          this.settings.dictionary,
         )
       } else {
         LanguageToolHttpInterface(

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
@@ -101,6 +101,24 @@ class DictionaryMaskerTest {
   }
 
   @Test
+  fun lowercaseEntryMatchesSentenceInitialTitlecase() {
+    // hunspell / LT-speller convention: a lowercase-initial entry also accepts
+    // its titlecase variant (sentence start) — but no other case variant.
+    assertEquals(listOf("Foobar"), matches(setOf("foobar"), "Foobar is here."))
+    assertTrue(matches(setOf("foobar"), "fooBar is here.").isEmpty())
+    // The reverse does not hold: a capitalized entry stays capitalized.
+    assertTrue(matches(setOf("Foobar"), "foobar is here.").isEmpty())
+  }
+
+  @Test
+  fun entryMatchesAllUppercaseVariant() {
+    assertEquals(
+      listOf("GREENTEAM PENCILTEST"),
+      matches(setOf("GreenTeam Penciltest"), "GREENTEAM PENCILTEST ROADMAP"),
+    )
+  }
+
+  @Test
   fun surroundingPunctuationIsExcluded() {
     assertEquals(
       listOf("GreenTeam Penciltest"),
@@ -204,6 +222,25 @@ class DictionaryMaskerTest {
   }
 
   @Test
+  fun maskPartsMasksNbspEntryOverLatexTie() {
+    // Matching is whitespace-literal: a LaTeX tie (`~`) puts a non-breaking
+    // space (U+00A0) into the plain text, which a normal-space entry does not
+    // match. The supported remedy is adding the NBSP variant as its own entry,
+    // which matches literally — this test pins that workaround.
+    assertEquals(
+      listOf(textPart("the "), markupPart("GreenTeam~Penciltest", "Dummy0"), textPart(" firm")),
+      maskParts(
+        setOf("GreenTeam\u00a0Penciltest"),
+        listOf(
+          textPart("the GreenTeam"),
+          markupPart("~", "\u00a0"),
+          textPart("Penciltest firm"),
+        ),
+      ),
+    )
+  }
+
+  @Test
   fun maskPartsMasksEntryEqualToWholeInterpretAs() {
     // Match boundaries at part edges are fine even when the whole match lies
     // inside one markup's interpretAs.
@@ -289,5 +326,17 @@ class DictionaryMaskerTest {
   @Test
   fun builderWithoutDictionaryIsUnchanged() {
     assertFalse(plainTextWithDictionary("I met GreenTeam today.\n", emptySet()).contains("Dummy"))
+  }
+
+  @Test
+  fun builderAlwaysUsesDefaultDummy() {
+    // Deliberately NOT the vowel-initial dummy ("Ina0") for vowel-initial
+    // masked words: LanguageTool Premium's AI rules flag "Ina0" itself, which
+    // would surface a diagnostic exactly on the masked dictionary word
+    // (pinned by LanguageToolPremiumIntegrationTest).
+    assertEquals(
+      "I have an Dummy0 here.\n",
+      plainTextWithDictionary("I have an iPhone here.\n", setOf("iPhone")),
+    )
   }
 }

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
@@ -9,23 +9,44 @@
 package org.bsplines.ltexls.parsing
 
 import org.bsplines.ltexls.settings.Settings
+import org.languagetool.markup.TextPart
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DictionaryMaskerTest {
-  private fun split(
+  private fun matches(
     dictionary: Set<String>,
     text: String,
-  ): List<Pair<String, Boolean>> =
-    DictionaryMasker(dictionary).split(text).map { Pair(it.text, it.masked) }
+  ): List<String> = DictionaryMasker(dictionary).findMatches(text).map { text.substring(it) }
+
+  private fun textPart(text: String): DictionaryMasker.Part =
+    DictionaryMasker.Part(TextPart.Type.TEXT, text)
+
+  private fun markupPart(
+    code: String,
+    interpretAs: String = "",
+  ): DictionaryMasker.Part = DictionaryMasker.Part(TextPart.Type.MARKUP, code, interpretAs)
+
+  private fun maskParts(
+    dictionary: Set<String>,
+    parts: List<DictionaryMasker.Part>,
+  ): List<DictionaryMasker.Part> {
+    var dummyCounter = 0
+    return DictionaryMasker(dictionary).maskParts(parts) { "Dummy${dummyCounter++}" }
+  }
+
+  // --- findMatches: whole-token, case-sensitive, longest-match-wins scan ---
 
   @Test
   fun emptyDictionaryIsNoOp() {
     val masker = DictionaryMasker(emptySet())
     assertTrue(masker.isEmpty)
-    assertEquals(listOf(Pair("hello world", false)), split(emptySet(), "hello world"))
+    assertTrue(masker.findMatches("hello world").isEmpty())
+
+    val parts: List<DictionaryMasker.Part> = listOf(textPart("hello world"))
+    assertEquals(parts, maskParts(emptySet(), parts))
   }
 
   @Test
@@ -34,79 +55,206 @@ class DictionaryMaskerTest {
   }
 
   @Test
-  fun singleWordIsMaskedOnWholeTokenBoundaries() {
-    assertEquals(
-      listOf(Pair("I met ", false), Pair("GreenTeam", true), Pair(" today.", false)),
-      split(setOf("GreenTeam"), "I met GreenTeam today."),
-    )
+  fun singleWordIsMatchedOnWholeTokenBoundaries() {
+    assertEquals(listOf("GreenTeam"), matches(setOf("GreenTeam"), "I met GreenTeam today."))
   }
 
   @Test
-  fun singleWordNotMaskedInsideLongerWord() {
+  fun singleWordNotMatchedInsideLongerWord() {
     // "GreenTeam" must not match inside "GreenTeamer" / "aGreenTeam".
-    assertEquals(
-      listOf(Pair("a GreenTeamer b", false)),
-      split(setOf("GreenTeam"), "a GreenTeamer b"),
-    )
-    assertEquals(listOf(Pair("a aGreenTeam b", false)), split(setOf("GreenTeam"), "a aGreenTeam b"))
+    assertTrue(matches(setOf("GreenTeam"), "a GreenTeamer b").isEmpty())
+    assertTrue(matches(setOf("GreenTeam"), "a aGreenTeam b").isEmpty())
   }
 
   @Test
-  fun multiWordPhraseIsMaskedWhenAdjacent() {
+  fun multiWordPhraseIsMatchedWhenAdjacent() {
     assertEquals(
-      listOf(Pair("the ", false), Pair("GreenTeam Penciltest", true), Pair(" firm", false)),
-      split(setOf("GreenTeam Penciltest"), "the GreenTeam Penciltest firm"),
+      listOf("GreenTeam Penciltest"),
+      matches(setOf("GreenTeam Penciltest"), "the GreenTeam Penciltest firm"),
     )
   }
 
   @Test
-  fun loneFirstWordNotMaskedWhenOnlyPhraseIsAnEntry() {
+  fun loneFirstWordNotMatchedWhenOnlyPhraseIsAnEntry() {
     // The whole point of multi-word support: a bare "GreenTeam" stays visible
     // unless "GreenTeam" is itself an entry.
-    assertEquals(
-      listOf(Pair("a GreenTeam here", false)),
-      split(setOf("GreenTeam Penciltest"), "a GreenTeam here"),
-    )
+    assertTrue(matches(setOf("GreenTeam Penciltest"), "a GreenTeam here").isEmpty())
   }
 
   @Test
   fun longestEntryWinsOnOverlap() {
     // Both "GreenTeam" and the phrase are entries; the phrase wins where present.
     assertEquals(
-      listOf(Pair("GreenTeam Penciltest", true)),
-      split(setOf("GreenTeam", "GreenTeam Penciltest"), "GreenTeam Penciltest"),
+      listOf("GreenTeam Penciltest"),
+      matches(setOf("GreenTeam", "GreenTeam Penciltest"), "GreenTeam Penciltest"),
     )
-    // ...but a lone "GreenTeam" is still masked because it is also an entry.
+    // ...but a lone "GreenTeam" still matches because it is also an entry.
     assertEquals(
-      listOf(Pair("GreenTeam", true), Pair(" alone", false)),
-      split(setOf("GreenTeam", "GreenTeam Penciltest"), "GreenTeam alone"),
+      listOf("GreenTeam"),
+      matches(setOf("GreenTeam", "GreenTeam Penciltest"), "GreenTeam alone"),
     )
   }
 
   @Test
   fun matchingIsCaseSensitive() {
-    assertEquals(
-      listOf(Pair("greenteam penciltest", false)),
-      split(setOf("GreenTeam Penciltest"), "greenteam penciltest"),
-    )
+    assertTrue(matches(setOf("GreenTeam Penciltest"), "greenteam penciltest").isEmpty())
   }
 
   @Test
-  fun surroundingPunctuationIsPreserved() {
+  fun surroundingPunctuationIsExcluded() {
     assertEquals(
-      listOf(Pair("(", false), Pair("GreenTeam Penciltest", true), Pair(").", false)),
-      split(setOf("GreenTeam Penciltest"), "(GreenTeam Penciltest)."),
+      listOf("GreenTeam Penciltest"),
+      matches(setOf("GreenTeam Penciltest"), "(GreenTeam Penciltest)."),
     )
   }
 
   @Test
   fun unicodeWordBoundariesAreRespected() {
     // Accented letters are word characters (Char.isLetterOrDigit, not ASCII \b),
-    // so "café" is not masked inside "cafés", but a standalone accented entry is.
-    assertEquals(listOf(Pair("les cafés ici", false)), split(setOf("café"), "les cafés ici"))
+    // so "café" is not matched inside "cafés", but a standalone accented entry is.
+    assertTrue(matches(setOf("café"), "les cafés ici").isEmpty())
+    assertEquals(listOf("café"), matches(setOf("café"), "un café noir"))
+  }
+
+  // --- maskParts: masking over the assembled plain text of a part list ---
+
+  @Test
+  fun maskPartsMasksWithinSingleTextPart() {
     assertEquals(
-      listOf(Pair("un ", false), Pair("café", true), Pair(" noir", false)),
-      split(setOf("café"), "un café noir"),
+      listOf(textPart("I met "), markupPart("GreenTeam", "Dummy0"), textPart(" today.")),
+      maskParts(setOf("GreenTeam"), listOf(textPart("I met GreenTeam today."))),
+    )
+  }
+
+  @Test
+  fun maskPartsMasksMultipleOccurrencesWithDistinctDummies() {
+    assertEquals(
+      listOf(
+        markupPart("GreenTeam", "Dummy0"),
+        textPart(" and "),
+        markupPart("GreenTeam", "Dummy1"),
+      ),
+      maskParts(setOf("GreenTeam"), listOf(textPart("GreenTeam and GreenTeam"))),
+    )
+  }
+
+  @Test
+  fun maskPartsMasksMarkupSplitPhrase() {
+    // `LT<sub>E</sub>X LS` assembles to the plain text `LTEX LS`; the covered
+    // parts coalesce into one markup part whose source is the original code.
+    assertEquals(
+      listOf(
+        textPart("This is "),
+        markupPart("LT<sub>E</sub>X LS", "Dummy0"),
+        textPart("."),
+      ),
+      maskParts(
+        setOf("LTEX LS"),
+        listOf(
+          textPart("This is LT"),
+          markupPart("<sub>"),
+          textPart("E"),
+          markupPart("</sub>"),
+          textPart("X LS."),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun maskPartsMasksWordSplitByAccentCommand() {
+    // LaTeX `M\"uller` becomes TEXT(M) + MARKUP(\"u -> u-umlaut) + TEXT(ller);
+    // the entry matches the assembled plain text `Müller`.
+    assertEquals(
+      listOf(
+        textPart("Herr "),
+        markupPart("M\\\"uller", "Dummy0"),
+        textPart(" kommt."),
+      ),
+      maskParts(
+        setOf("Müller"),
+        listOf(
+          textPart("Herr M"),
+          markupPart("\\\"u", "ü"),
+          textPart("ller kommt."),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun maskPartsMasksPhraseAcrossSoftLineBreak() {
+    // A Markdown soft line break is markup interpreted as a space, so a phrase
+    // wrapped over the break is contiguous only in the assembled plain text.
+    assertEquals(
+      listOf(
+        textPart("the "),
+        markupPart("GreenTeam\nPenciltest", "Dummy0"),
+        textPart(" firm"),
+      ),
+      maskParts(
+        setOf("GreenTeam Penciltest"),
+        listOf(
+          textPart("the GreenTeam"),
+          markupPart("\n", " "),
+          textPart("Penciltest firm"),
+        ),
+      ),
+    )
+  }
+
+  @Test
+  fun maskPartsMasksEntryEqualToWholeInterpretAs() {
+    // Match boundaries at part edges are fine even when the whole match lies
+    // inside one markup's interpretAs.
+    assertEquals(
+      listOf(textPart("use "), markupPart("\\LaTeX", "Dummy0"), textPart(" now")),
+      maskParts(
+        setOf("LaTeX"),
+        listOf(textPart("use "), markupPart("\\LaTeX", "LaTeX"), textPart(" now")),
+      ),
+    )
+  }
+
+  @Test
+  fun maskPartsSkipsMatchWithBoundaryInsideInterpretAs() {
+    // The match would start in the middle of the markup's interpretAs; its
+    // source cannot be split at a plain-text position, so the match is skipped.
+    val parts: List<DictionaryMasker.Part> =
+      listOf(
+        markupPart("\\shorthand{}", "e.g. GreenTeam"),
+        textPart(" Penciltest here"),
+      )
+    assertEquals(parts, maskParts(setOf("GreenTeam Penciltest"), parts))
+  }
+
+  @Test
+  fun maskPartsKeepsZeroPlainMarkupAtMatchEdgesOutside() {
+    // Zero-plain-length markup exactly at a match boundary stays outside the
+    // masked span (minimal span), on both sides.
+    assertEquals(
+      listOf(
+        textPart("met "),
+        markupPart("GreenTeam", "Dummy0"),
+        markupPart("**"),
+        textPart(" more"),
+      ),
+      maskParts(
+        setOf("GreenTeam"),
+        listOf(textPart("met GreenTeam"), markupPart("**"), textPart(" more")),
+      ),
+    )
+    assertEquals(
+      listOf(
+        textPart("met "),
+        markupPart("**"),
+        markupPart("GreenTeam", "Dummy0"),
+        textPart(" more"),
+      ),
+      maskParts(
+        setOf("GreenTeam"),
+        listOf(textPart("met "), markupPart("**"), textPart("GreenTeam more")),
+      ),
     )
   }
 

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
@@ -1,0 +1,145 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.parsing
+
+import org.bsplines.ltexls.settings.Settings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DictionaryMaskerTest {
+  private fun split(
+    dictionary: Set<String>,
+    text: String,
+  ): List<Pair<String, Boolean>> =
+    DictionaryMasker(dictionary).split(text).map { Pair(it.text, it.masked) }
+
+  @Test
+  fun emptyDictionaryIsNoOp() {
+    val masker = DictionaryMasker(emptySet())
+    assertTrue(masker.isEmpty)
+    assertEquals(listOf(Pair("hello world", false)), split(emptySet(), "hello world"))
+  }
+
+  @Test
+  fun blankEntriesAreDropped() {
+    assertTrue(DictionaryMasker(setOf("", "  ", "\t")).isEmpty)
+  }
+
+  @Test
+  fun singleWordIsMaskedOnWholeTokenBoundaries() {
+    assertEquals(
+      listOf(Pair("I met ", false), Pair("GreenTeam", true), Pair(" today.", false)),
+      split(setOf("GreenTeam"), "I met GreenTeam today."),
+    )
+  }
+
+  @Test
+  fun singleWordNotMaskedInsideLongerWord() {
+    // "GreenTeam" must not match inside "GreenTeamer" / "aGreenTeam".
+    assertEquals(
+      listOf(Pair("a GreenTeamer b", false)),
+      split(setOf("GreenTeam"), "a GreenTeamer b"),
+    )
+    assertEquals(listOf(Pair("a aGreenTeam b", false)), split(setOf("GreenTeam"), "a aGreenTeam b"))
+  }
+
+  @Test
+  fun multiWordPhraseIsMaskedWhenAdjacent() {
+    assertEquals(
+      listOf(Pair("the ", false), Pair("GreenTeam Penciltest", true), Pair(" firm", false)),
+      split(setOf("GreenTeam Penciltest"), "the GreenTeam Penciltest firm"),
+    )
+  }
+
+  @Test
+  fun loneFirstWordNotMaskedWhenOnlyPhraseIsAnEntry() {
+    // The whole point of multi-word support: a bare "GreenTeam" stays visible
+    // unless "GreenTeam" is itself an entry.
+    assertEquals(
+      listOf(Pair("a GreenTeam here", false)),
+      split(setOf("GreenTeam Penciltest"), "a GreenTeam here"),
+    )
+  }
+
+  @Test
+  fun longestEntryWinsOnOverlap() {
+    // Both "GreenTeam" and the phrase are entries; the phrase wins where present.
+    assertEquals(
+      listOf(Pair("GreenTeam Penciltest", true)),
+      split(setOf("GreenTeam", "GreenTeam Penciltest"), "GreenTeam Penciltest"),
+    )
+    // ...but a lone "GreenTeam" is still masked because it is also an entry.
+    assertEquals(
+      listOf(Pair("GreenTeam", true), Pair(" alone", false)),
+      split(setOf("GreenTeam", "GreenTeam Penciltest"), "GreenTeam alone"),
+    )
+  }
+
+  @Test
+  fun matchingIsCaseSensitive() {
+    assertEquals(
+      listOf(Pair("greenteam penciltest", false)),
+      split(setOf("GreenTeam Penciltest"), "greenteam penciltest"),
+    )
+  }
+
+  @Test
+  fun surroundingPunctuationIsPreserved() {
+    assertEquals(
+      listOf(Pair("(", false), Pair("GreenTeam Penciltest", true), Pair(").", false)),
+      split(setOf("GreenTeam Penciltest"), "(GreenTeam Penciltest)."),
+    )
+  }
+
+  @Test
+  fun unicodeWordBoundariesAreRespected() {
+    // Accented letters are word characters (Char.isLetterOrDigit, not ASCII \b),
+    // so "café" is not masked inside "cafés", but a standalone accented entry is.
+    assertEquals(listOf(Pair("les cafés ici", false)), split(setOf("café"), "les cafés ici"))
+    assertEquals(
+      listOf(Pair("un ", false), Pair("café", true), Pair(" noir", false)),
+      split(setOf("café"), "un café noir"),
+    )
+  }
+
+  // --- builder-level wiring (PlaintextAnnotatedTextBuilder is verbatim, so the
+  // plain text shows the dummy substituted for the masked span) ---
+
+  private fun plainTextWithDictionary(
+    code: String,
+    dictionary: Set<String>,
+  ): String {
+    val builder: CodeAnnotatedTextBuilder = CodeAnnotatedTextBuilder.create("plaintext")
+    builder.setSettings(Settings(_allDictionaries = mapOf(Pair("en-US", dictionary))))
+    return builder.addCode(code).build().plainText
+  }
+
+  @Test
+  fun builderMasksMultiWordEntryWithDummy() {
+    assertEquals(
+      "I met Dummy0 today.\n",
+      plainTextWithDictionary("I met GreenTeam Penciltest today.\n", setOf("GreenTeam Penciltest")),
+    )
+  }
+
+  @Test
+  fun builderLeavesLoneWordUnmasked() {
+    assertEquals(
+      "I met GreenTeam today.\n",
+      plainTextWithDictionary("I met GreenTeam today.\n", setOf("GreenTeam Penciltest")),
+    )
+  }
+
+  @Test
+  fun builderWithoutDictionaryIsUnchanged() {
+    assertFalse(plainTextWithDictionary("I met GreenTeam today.\n", emptySet()).contains("Dummy"))
+  }
+}

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/DictionaryMaskerTest.kt
@@ -51,7 +51,20 @@ class DictionaryMaskerTest {
 
   @Test
   fun blankEntriesAreDropped() {
-    assertTrue(DictionaryMasker(setOf("", "  ", "\t")).isEmpty)
+    // Includes a no-break-space-only entry, which is blank after space
+    // normalization.
+    assertTrue(DictionaryMasker(setOf("", "  ", "\t", "\u00a0")).isEmpty)
+  }
+
+  @Test
+  fun spaceSeparatorsAreNormalizedForMatching() {
+    // A no-break space (U+00A0) in the text matches a normal-space entry.
+    assertEquals(
+      listOf("GreenTeam\u00a0Penciltest"),
+      matches(setOf("GreenTeam Penciltest"), "the GreenTeam\u00a0Penciltest firm"),
+    )
+    // Newlines are structural, not space separators: no match across them.
+    assertTrue(matches(setOf("GreenTeam Penciltest"), "GreenTeam\nPenciltest").isEmpty())
   }
 
   @Test
@@ -222,22 +235,21 @@ class DictionaryMaskerTest {
   }
 
   @Test
-  fun maskPartsMasksNbspEntryOverLatexTie() {
-    // Matching is whitespace-literal: a LaTeX tie (`~`) puts a non-breaking
-    // space (U+00A0) into the plain text, which a normal-space entry does not
-    // match. The supported remedy is adding the NBSP variant as its own entry,
-    // which matches literally — this test pins that workaround.
-    assertEquals(
-      listOf(textPart("the "), markupPart("GreenTeam~Penciltest", "Dummy0"), textPart(" firm")),
-      maskParts(
-        setOf("GreenTeam\u00a0Penciltest"),
-        listOf(
-          textPart("the GreenTeam"),
-          markupPart("~", "\u00a0"),
-          textPart("Penciltest firm"),
-        ),
-      ),
-    )
+  fun maskPartsMasksPlainSpaceEntryOverLatexTie() {
+    // A LaTeX tie (`~`) puts a no-break space (U+00A0) into the plain text;
+    // space separators are normalized to a plain space on both sides of the
+    // comparison, so the normal-space entry masks the tied occurrence — and
+    // an entry containing the no-break space works just the same.
+    val parts: List<DictionaryMasker.Part> =
+      listOf(
+        textPart("the GreenTeam"),
+        markupPart("~", "\u00a0"),
+        textPart("Penciltest firm"),
+      )
+    val expected: List<DictionaryMasker.Part> =
+      listOf(textPart("the "), markupPart("GreenTeam~Penciltest", "Dummy0"), textPart(" firm"))
+    assertEquals(expected, maskParts(setOf("GreenTeam Penciltest"), parts))
+    assertEquals(expected, maskParts(setOf("GreenTeam\u00a0Penciltest"), parts))
   }
 
   @Test

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderTest.kt
@@ -621,6 +621,10 @@ class LatexAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("latex") {
     // A phrase wrapped over a source line break is contiguous in the plain
     // text (the newline collapses to a space) and is masked as a unit.
     assertPlainText("the GreenTeam\nPenciltest firm\n", "the Dummy0 firm ", settings)
+
+    // A tie (`~`) becomes a no-break space in the plain text; space separators
+    // are normalized before matching, so the normal-space entry still masks.
+    assertPlainText("the GreenTeam~Penciltest firm\n", "the Dummy0 firm ", settings)
   }
 
   private fun assertPlainTextPositions(

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderTest.kt
@@ -606,6 +606,23 @@ class LatexAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("latex") {
     assertTrue(originalTextStartPos < originalTextEndPos)
   }
 
+  @Test
+  fun testDictionaryMasking() {
+    val settings =
+      Settings(
+        _allDictionaries =
+          mapOf(Pair("en-US", setOf("Müller", "GreenTeam Penciltest"))),
+      )
+
+    // Dictionary entries are masked over the assembled plain text, so an entry
+    // matches even when the word is split by an accent command in the source.
+    assertPlainText("Herr M\\\"uller kommt.\n", "Herr Dummy0 kommt. ", settings)
+
+    // A phrase wrapped over a source line break is contiguous in the plain
+    // text (the newline collapses to a space) and is masked as a unit.
+    assertPlainText("the GreenTeam\nPenciltest firm\n", "the Dummy0 firm ", settings)
+  }
+
   private fun assertPlainTextPositions(
     code: String,
     originalTextStartPos: Int,

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownAnnotatedTextBuilderTest.kt
@@ -221,4 +221,20 @@ class MarkdownAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("markdown"
       "This is a test.\n\nDummy0\n\nThis is another test.\n\n\n\n\n",
     )
   }
+
+  @Test
+  fun testDictionaryMasking() {
+    // Dictionary entries are masked over the assembled plain text, so a
+    // multi-word entry matches even when the phrase is wrapped over a soft
+    // line break (markup interpreted as a space).
+    assertPlainText(
+      """
+      the GreenTeam
+      Penciltest firm
+
+      """.trimIndent(),
+      "the Dummy0 firm\n",
+      Settings(_allDictionaries = mapOf(Pair("en-US", setOf("GreenTeam Penciltest")))),
+    )
+  }
 }

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/program/ElispAnnotatedTextBuilderTest.kt
@@ -9,9 +9,38 @@
 package org.bsplines.ltexls.parsing.program
 
 import org.bsplines.ltexls.parsing.CodeAnnotatedTextBuilderTest
+import org.bsplines.ltexls.settings.Settings
 import kotlin.test.Test
 
 class ElispAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("elisp") {
+  @Test
+  fun testDictionaryEntriesAreMaskedInCommentsAndDocstrings() {
+    // User-dictionary words are masked (replaced by a dummy) before the prose
+    // reaches LanguageTool. This exercises the elisp path end to end: it only
+    // works because ElispAnnotatedTextBuilder forwards setSettings to its inner
+    // Markdown builder, which builds the masker. Multi-word entries work because
+    // the phrase is contiguous in the comment/docstring text; longest-match-wins
+    // masks the whole "GreenTeam Penciltest" rather than the bare "GreenTeam".
+    val dictionary =
+      Settings(_allDictionaries = mapOf("en-US" to setOf("GreenTeam Penciltest", "GreenTeam")))
+
+    // Multi-word entry inside a line comment.
+    assertPlainText(
+      ";; The GreenTeam Penciltest audit was thorough.\n",
+      "\n\n\nThe Dummy0 audit was thorough.",
+      "elisp",
+      dictionary,
+    )
+
+    // Single-word entry inside a defun docstring.
+    assertPlainText(
+      "(defun foo ()\n  \"Run the GreenTeam audit now.\"\n  nil)\n",
+      "\n\n\nRun the Dummy0 audit now.",
+      "elisp",
+      dictionary,
+    )
+  }
+
   @Test
   fun testComments() {
     // Trailing/inline comments after code (line 1) ARE checked for elisp.

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -574,13 +574,22 @@ class DocumentCheckerTest {
     checkingResult = checkDocument(document, settings)
     assertEquals(0, checkingResult.first.size)
 
-    document = createDocument("markdown", "This is LT<sub>E</sub>X LS.\n")
+    // Multi-word dictionary entry: the phrase is masked out before LanguageTool
+    // sees it, so a contiguous phrase is accepted as a unit, while a lone first
+    // word stays flagged. (A phrase split by markup in the source — e.g.
+    // `LT<sub>E</sub>X LS` — is not covered by this plain-text masking; matching
+    // verbatim source-form entries is handled separately.)
+    document = createDocument("markdown", "This is GreenTeam Penciltest here.\n")
     settings = Settings()
     checkingResult = checkDocument(document, settings)
-    assertEquals(1, checkingResult.first.size)
-    settings = settings.copy(_allDictionaries = mapOf(Pair("en-US", setOf("LTEX LS"))))
+    assertTrue(checkingResult.first.isNotEmpty())
+    settings = settings.copy(_allDictionaries = mapOf(Pair("en-US", setOf("GreenTeam Penciltest"))))
     checkingResult = checkDocument(document, settings)
     assertEquals(0, checkingResult.first.size)
+
+    document = createDocument("markdown", "This is GreenTeam here.\n")
+    checkingResult = checkDocument(document, settings)
+    assertEquals(1, checkingResult.first.size)
   }
 
   @Test

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -576,9 +576,7 @@ class DocumentCheckerTest {
 
     // Multi-word dictionary entry: the phrase is masked out before LanguageTool
     // sees it, so a contiguous phrase is accepted as a unit, while a lone first
-    // word stays flagged. (A phrase split by markup in the source — e.g.
-    // `LT<sub>E</sub>X LS` — is not covered by this plain-text masking; matching
-    // verbatim source-form entries is handled separately.)
+    // word stays flagged.
     document = createDocument("markdown", "This is GreenTeam Penciltest here.\n")
     settings = Settings()
     checkingResult = checkDocument(document, settings)
@@ -590,6 +588,17 @@ class DocumentCheckerTest {
     document = createDocument("markdown", "This is GreenTeam here.\n")
     checkingResult = checkDocument(document, settings)
     assertEquals(1, checkingResult.first.size)
+
+    // A phrase split by markup in the source is masked too: the masker matches
+    // over the assembled plain text (`LTEX LS`), and the covered parts —
+    // including the <sub>/</sub> tags — coalesce into one masked markup part.
+    document = createDocument("markdown", "This is LT<sub>E</sub>X LS.\n")
+    settings = Settings()
+    checkingResult = checkDocument(document, settings)
+    assertEquals(1, checkingResult.first.size)
+    settings = settings.copy(_allDictionaries = mapOf(Pair("en-US", setOf("LTEX LS"))))
+    checkingResult = checkDocument(document, settings)
+    assertEquals(0, checkingResult.first.size)
   }
 
   @Test


### PR DESCRIPTION
Closes #141. Supersedes #184.

This PR consists of the original commit from #184 (de59c4fb, *Support multi-word dictionary entries via pre-LanguageTool masking*) — which was merged there by mistake and subsequently removed from the tree — plus three follow-up commits (a6b1914c, f62b41f7, 53562891) developed on top of it. See #184 for the full motivation, design and known-limitations discussion of the original commit; **the description below covers only the follow-ups.**

The first follow-up (a6b1914c) extends the masking mechanism so that it matches dictionary entries against the **assembled plain text** — the exact string LanguageTool checks — instead of each text fragment in isolation. This removes known limitation 1 of #184 ("a multi-word entry whose words are split by markup in the source is not masked") entirely, and fixes two further gaps of the same root cause that surfaced on review.

## Problem

The original implementation hooked the masker into `CodeAnnotatedTextBuilder.finalizeCurrentPart`, i.e. it scanned each text fragment **as the parser finalized it** — upstream of the point where fragments and markup interpretations are joined into the plain text sent to LanguageTool.  Any entry whose occurrence is contiguous only in that joined string was therefore never masked. Three concrete cases:

1. **A phrase split by inline markup** — the `LT<sub>E</sub>X LS` case documented as known limitation 1 in #184. The parser splits the text into `This is LT` · *(markup `<sub>`)* · `E` · *(markup `</sub>`)* · `X LS.`, so no single fragment contains `LTEX LS`. (Before this PR, the retired post-LT filter *did* suppress this case, and a test asserted it; the original commit had rewritten that test. It is now restored and passing.)
2. **A word split by a LaTeX accent command** — `M\"uller` parses into `M` · *(markup `\"u`, interpreted as `ü`)* · `ller`, so a dictionary entry `Müller` never saw a fragment containing the whole word. This silently broke *single-word* entries too, not just phrases, for anyone spelling accents as commands.
3. **A phrase wrapped over a Markdown soft line break** — inside a paragraph the newline becomes markup interpreted as a space, so `GreenTeam\nPenciltest` never yields a fragment containing `GreenTeam Penciltest`, even though exactly that phrase appears in the plain text LanguageTool checks. The feature would have worked or failed depending on where the author's editor happened to wrap the line. (LaTeX was unaffected: its builder collapses a single newline to a plain-text space before fragments are finalized.)

## Approach

Move the masking downstream to the one place where the full picture exists.  `CodeAnnotatedTextBuilder` now **buffers** its finalized parts (text, or markup with its interpretation) instead of emitting them eagerly, and emits them all at `build()` time. Before emission, `DictionaryMasker.maskParts` runs once over the buffered list:

1. **Assemble** — concatenate the parts' plain-text contributions (text parts contribute their text, markup parts their interpretation). This string is character-for-character what LanguageTool will check.
2. **Match** — scan it with the same whole-word, longest-match-wins matcher as before (case handling is refined by the second follow-up, see below).
3. **Coalesce** — replace each matched span's covered parts with a **single markup part** whose source is the concatenation of the covered source pieces and whose interpretation is a dummy token. Text parts straddling a match boundary are split at it.

Following the same walkthrough as in #184: for `This is LT<sub>E</sub>X LS.` with entry `LTEX LS`, the five parsed parts assemble to `This is LTEX LS.`; the scanner now *does* see `LTEX LS` as a unit, and the covered parts — including the `<sub>`/`</sub>` tags — coalesce into one markup part `LT<sub>E</sub>X LS` interpreted as `Dummy0`. Adding the plain-text form `LTEX LS` to the dictionary therefore now behaves exactly as a user would expect.

Offsets remain exact: the total source is preserved (every covered piece contributes its original source to the coalesced part), so a real typo after a masked span is still reported at the correct position — the same guarantee as before, just over a larger class of masks.

When LTeX+ prepares the text that LanguageTool reads, most characters of the file are copied over as they are, but a few constructs are **replaced by other text**: the accent command `\"u` is replaced by `ü`, inline math `$x^2$` is replaced by a placeholder word like `Dummy0`, a Markdown line break inside a paragraph is replaced by a space. Two remarks on how masking interacts with these replacements:

- **Markup that produces no text at all** — like the `<sub>`/`</sub>` tags in the walkthrough above — is masked together with the phrase when it sits between the matched words, and left alone when it merely touches the edge of the match.
- The code additionally guards one corner case that cannot occur with the current parsers (a match that would cover only part of a replacement). It is documented in the code comments and pinned by a unit test, and not further described here.

## Advantages

- **Known limitation 1 is gone**, not documented around: markup-split phrases, accent-command-split words and soft-wrap-split phrases all mask now. The pre-existing `LT<sub>E</sub>X LS` test is restored to its original assertions.
- **No behavioral risk for the common case:** with an empty dictionary the buffered parts are replayed byte-for-byte as the eager path used to emit them; nothing reads the underlying builder's state before `build()`, so the deferral is invisible.
- **Preserving a single mechanism:** this strengthens the masking approach rather than reintroducing a post-LT filter alongside it. Coverage is now a strict superset of the retired `isCoveredByDictionary` filter.
- **Marginally cheaper:** one scan over the fragment's plain text instead of one per text run.

## Conventional case variants (second follow-up, f62b41f7)

The second follow-up aligns case handling with the hunspell / LanguageTool-speller convention for accepted words: an entry matches its own case exactly, plus — when the entry begins with a lowercase letter — its sentence-initial titlecase variant (`foobar` also accepts `Foobar.` at a sentence start), plus its all-uppercase variant (`GreenTeam` also accepts `GREENTEAM` in headings). Variants are precomputed and matched literally, so the longest-match and token-boundary logic is untouched. General case-insensitivity is deliberately not offered: adding `IT` must not accept `it`.

## Space-separator normalization (third follow-up, 53562891)

A LaTeX tie (`GreenTeam~Penciltest` — standard typography for names) puts a no-break space (U+00A0) into the plain text, so a dictionary entry with a normal space silently failed to match the tied occurrence. The third follow-up normalizes Unicode space-separator characters (no-break space, thin space, …) to a plain space on both sides of the comparison — in the entries at construction and in the checked text at match time. The replacement is strictly one-for-one, so all match offsets stay valid, and the string copy is skipped entirely when nothing needs replacing (the common case) — the runtime cost is one character scan per fragment. Newlines and tabs are deliberately not normalized: they are structural (a heading ending, a paragraph break), and a single-space entry must not match across them — pinned by a test.

## Remaining limitations

- An entry with a single space does not match a doubled space in the plain text: space *characters* are normalized, but whitespace *runs* are not collapsed (that would require variable-length matching for marginal benefit — LaTeX already collapses whitespace runs before the builder).
- Masking replaces the entry with a dummy noun, so grammar context immediately around a masked span differs from what the user sees — inherent to masking and shared with the existing inline-math (`$x$`) mechanism. Using the vowel-initial dummy (`Ina0`) for vowel-initial entries — which would have kept a/an checking correct around masks — was tried and rejected: LanguageTool Premium's AI rules flag `Ina0` itself, surfacing a diagnostic exactly on the masked dictionary word. The premium integration test caught this, and the default-dummy choice is now pinned by tests.

### Key changes

- `DictionaryMasker`: the per-string `split` API is replaced by `findMatches` (same scan) plus `maskParts`, a pure function from a part list to a masked part list — unit-testable without any builder.
- `CodeAnnotatedTextBuilder.finalizeCurrentPart` appends to a part buffer; `build()` masks (only when a dictionary is configured) and replays. The masking hook `emitTextWithDictionaryMasking` is deleted.
- No changes to `setSettings` (including the union fallback under `ltex.language=auto`), the shared dummy counter, or any subclass builder.

## Testing

- `DictionaryMaskerTest` extended to 26 tests: the matcher suite (boundaries, case variants, space normalization, Unicode, longest-match-wins) plus part-level tests for each gap shape — markup-split phrase, accent-split word, soft-wrap-split phrase, the LaTeX-tie no-break space, an entry equal to a whole markup interpretation, the skipped boundary-inside-interpretation case, zero-plain markup at match edges, and the default-dummy choice.
- `DocumentCheckerTest.testDictionary`: the original `LT<sub>E</sub>X LS` assertions are restored (flagged without the entry, suppressed with it), alongside the contiguous multi-word and lone-first-word cases.
- New builder-level tests: LaTeX `Herr M\"uller kommt.` masked via entry `Müller`, a normal-space entry masking the tied `GreenTeam~Penciltest`, and a Markdown paragraph with the phrase wrapped over a soft line break masked via entry `GreenTeam Penciltest`.
- `mvn verify` is green — tests, detekt, ktlint and the coverage gate — including the premium integration test against the official remote server and the HTTP interface test against a local LanguageTool 6.8 server.