### PR TITLE
Update LSP4J to 1.0.0

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -20,6 +20,9 @@
       <action type="update" issue="ltex-plus/ltex-ls-plus#141" due-to="Andrea Alberti (@alberti42)">
         `ltex.dictionary` entries now also accept their conventional case variants, following the hunspell / LanguageTool speller convention: a lowercase-initial entry also accepts its sentence-initial titlecase form (`foobar` → `Foobar`), and every entry also accepts its all-uppercase form (`GreenTeam` → `GREENTEAM`). Entries otherwise remain case-sensitive.
       </action>
+      <action type="update">
+        Update LSP4J to 1.0.0
+      </action>
       <action type="fix" issue="ltex-plus/vscode-ltex-plus#206" due-to="Daniel Spitzer (@spitzerd)">
         Fix StackOverflowError for Typst, AsciiDoc, and Org documents. The issue occurred on long comments, for example.
       </action>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.eclipse.lsp4j</groupId>
       <artifactId>org.eclipse.lsp4j</artifactId>
-      <version>0.24.0</version>
+      <version>1.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.vladsch.flexmark</groupId>
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>org.eclipse.lsp4j</groupId>
       <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
-      <version>0.24.0</version>
+      <version>1.0.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
@@ -55,7 +55,7 @@ class CodeActionProvider(
     diagnostic.severity = diagnosticSeverity
 
     diagnostic.source = "LTeX"
-    diagnostic.message = match.message.replace(SUGGESTION_REGEX, "'$1'")
+    diagnostic.message = Either.forLeft(match.message.replace(SUGGESTION_REGEX, "'$1'"))
     diagnostic.code = Either.forLeft(match.ruleId)
 
     val urlBuilder = StringBuilder("https://community.languagetool.org/rule/show/")
@@ -168,7 +168,9 @@ class CodeActionProvider(
 
       diagnostics.add(diagnostic)
       documentChanges.add(
-        Either.forLeft(TextDocumentEdit(textDocument, listOf(TextEdit(range, newWord)))),
+        Either.forLeft(
+          TextDocumentEdit(textDocument, listOf(Either.forLeft(TextEdit(range, newWord)))),
+        ),
       )
     }
 

--- a/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/DocumentCheckerTest.kt
@@ -22,7 +22,9 @@ import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.Range
 import org.eclipse.lsp4j.TextDocumentIdentifier
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
 import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage
 import java.util.logging.Level
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -515,6 +517,55 @@ class DocumentCheckerTest {
     val result: List<Either<Command, CodeAction>> =
       codeActionProvider.generate(params, document, checkingResult)
     assertEquals(4, result.size)
+  }
+
+  @Test
+  fun testCodeActionWireFormatIsUnchangedByLsp4jEitherFields() {
+    // Regression: lsp4j 1.0.0 (LSP 3.18) widened two fields that this server writes:
+    // `Diagnostic.message` became Either<String, MarkupContent> and `TextDocumentEdit.edits`
+    // became List<Either<TextEdit, SnippetTextEdit>>. Wrapping with Either.forLeft keeps the
+    // JSON identical to LSP 3.17, so clients that predate 3.18 keep working. Only the wire
+    // form guarantees that; the Kotlin types compile either way. Hence assert the JSON.
+    val document: LtexTextDocumentItem =
+      createDocument(
+        "markdown",
+        "This is an unknownword.\n",
+      )
+    val checkingResult: Pair<List<LanguageToolRuleMatch>, List<AnnotatedTextFragment>> =
+      checkDocument(document)
+    val params =
+      CodeActionParams(
+        TextDocumentIdentifier(document.uri),
+        Range(Position(0, 0), Position(100, 0)),
+        CodeActionContext(emptyList()),
+      )
+    val codeActionProvider = CodeActionProvider(SettingsManager())
+    val result: List<Either<Command, CodeAction>> =
+      codeActionProvider.generate(params, document, checkingResult)
+
+    val acceptSuggestionsCodeAction: CodeAction =
+      result
+        .mapNotNull { it.right }
+        .first { it.kind == "quickfix.ltex.acceptSuggestions" }
+
+    val responseMessage = ResponseMessage()
+    responseMessage.result = acceptSuggestionsCodeAction
+    val json: String = MessageJsonHandler(emptyMap()).serialize(responseMessage)
+
+    // Diagnostic.message must stay a plain JSON string, not a MarkupContent object.
+    assertTrue(
+      Regex("\"message\":\"[^\"]").containsMatchIn(json),
+      "expected string diagnostic message, got: $json",
+    )
+    // TextDocumentEdit.edits must stay a list of plain TextEdit objects.
+    assertTrue(
+      Regex("\"edits\":\\[\\{\"range\":").containsMatchIn(json),
+      "expected plain TextEdit entries in edits, got: $json",
+    )
+    assertTrue(
+      !json.contains("\"snippet\"") && !json.contains("\"kind\":\"markdown\""),
+      "expected no LSP 3.18-only payload, got: $json",
+    )
   }
 
   @Test


### PR DESCRIPTION
See https://github.com/ltex-plus/vscode-ltex-plus/pull/216

@alberti42 Should we update to LSP4J 1.0.0 / LSP 3.18?