### PR TITLE
Fix false Typst diagnostics around references

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -29,6 +29,9 @@
       <action type="fix" issue="ltex-plus/vscode-ltex-plus#35" due-to="Daniel Spitzer (@spitzerd)">
         Fix LaTeX section commands (e.g., `\chapter`, `\section`) used as arguments to other commands (e.g., `\titleformat{\chapter}{...}`) causing false "Two consecutive dots" LanguageTool warnings. The section heading handler previously unconditionally pushed Heading mode and consumed the next character as `{`, even when the section command appeared inside a brace group as an argument.
       </action>
+      <action type="fix">
+        Fix false Typst diagnostics around `@` references. Reference parsing now preserves trailing sentence punctuation. Labels registered with `abbr.add` are distinguished from bibliography and document references, accepted as declared terms, and replaced with grammar-safe singular or plural words for checking. Inline footnotes followed by citations no longer leave doubled whitespace, and colon-style show rules such as `#show: abbr.show-rule` are ignored as code.
+      </action>
     </release>
     <release version="18.7.0" date="2026-06-13">
       <action type="add" issue="ltex-plus/ltex-ls-plus#183" due-to="Andrea Alberti (@alberti42)">

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
@@ -44,10 +44,10 @@ abstract class CodeAnnotatedTextBuilder(
   protected var dummyGenerator: DummyGenerator = DummyGenerator.getInstance()
   protected var dummyCounter = 0
 
-  // null when the per-language dictionary is empty (the common case); build()
-  // then replays the buffered parts verbatim, byte-for-byte what the eager
-  // emission used to produce.
-  protected var dictionaryMasker: DictionaryMasker? = null
+  // Entries from settings plus format-specific entries discovered while parsing.
+  // The masker is created in build(), after subclasses have seen the whole document.
+  private var configuredDictionary: Set<String> = emptySet()
+  private val additionalDictionaryEntries = mutableSetOf<String>()
 
   // Finalized parts awaiting emission into LanguageTool's AnnotatedTextBuilder.
   // Emission is deferred to build() so the dictionary masker can match entries
@@ -78,7 +78,7 @@ abstract class CodeAnnotatedTextBuilder(
     // HTTP path), so settings.dictionary — keyed on the literal "auto" — is
     // empty at build time; fall back to masking the union of every language's
     // entries so a user-added word is still honoured on the first check.
-    val dictionary: Set<String> =
+    this.configuredDictionary =
       if (settings.languageShortCode == "auto") {
         settings.allDictionaries.values
           .flatten()
@@ -86,8 +86,10 @@ abstract class CodeAnnotatedTextBuilder(
       } else {
         settings.dictionary
       }
-    val masker = DictionaryMasker(dictionary)
-    this.dictionaryMasker = if (masker.isEmpty) null else masker
+  }
+
+  protected fun addDictionaryEntry(entry: String) {
+    additionalDictionaryEntries.add(entry)
   }
 
   override fun addText(text: String?): CodeAnnotatedTextBuilder {
@@ -132,20 +134,26 @@ abstract class CodeAnnotatedTextBuilder(
     return this
   }
 
-  // Mask any user-dictionary occurrences as markup with a dummy interpretation
-  // (the same mechanism inline math `$x$` uses), so LanguageTool never sees the
-  // dictionary word — single- and multi-word entries alike — while a real typo
-  // after a masked span still reprojects to the correct source position (the
-  // dummy contributes plain-text length but zero source offset).
+  // Mask dictionary occurrences as markup with a dummy interpretation (the same
+  // mechanism inline math `$x$` uses), so LanguageTool never sees the accepted
+  // word while diagnostics after a masked span still map to the right source.
   override fun build(): AnnotatedText {
     finalizeCurrentPart()
+
+    val dictionaryMasker: DictionaryMasker? =
+      when {
+        configuredDictionary.isEmpty() && additionalDictionaryEntries.isEmpty() -> null
+        additionalDictionaryEntries.isEmpty() -> DictionaryMasker(configuredDictionary)
+        configuredDictionary.isEmpty() -> DictionaryMasker(additionalDictionaryEntries)
+        else -> DictionaryMasker(configuredDictionary + additionalDictionaryEntries)
+      }
 
     // Always the default (consonant-initial) dummy: the vowel variant "Ina<n>"
     // is itself flagged by LanguageTool Premium's AI rules, which would surface
     // a diagnostic exactly on the masked dictionary word (caught by
     // LanguageToolPremiumIntegrationTest).
     val outParts: List<DictionaryMasker.Part> =
-      this.dictionaryMasker?.maskParts(this.parts) {
+      dictionaryMasker?.maskParts(this.parts) {
         this.dummyGenerator.generate(this.language, this.dummyCounter++)
       } ?: this.parts
 

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
@@ -16,6 +16,9 @@ open class TypstAnnotatedTextBuilder(
 ) : CharacterBasedCodeAnnotatedTextBuilder(codeLanguageId) {
   private val headingParser = CharacterBasedCodeAnnotatedHeadingParser(this)
   private val modeHandler = TypstModeHandler(this)
+  private val abbreviationLabels = mutableSetOf<String>()
+
+  private var lastAbbreviationPlaceholder = ""
 
   override fun processCharacter() {
     addMarkup(NO_TEXT_INLINE_MATH_REGEX, "", true)
@@ -34,7 +37,8 @@ open class TypstAnnotatedTextBuilder(
     addMarkup(RAW_CODE_REGEX_3, "", true)
     addMarkup(CITE_REGEX)
     addMarkup(ENUM_REGEX, "\n")
-    addMarkup(FOOTNOTE_REGEX)
+    processFootnote()
+    registerAbbreviation()
     addMarkup(CODE_REGEX, "", false, true)
     addMarkup(CODE_CURLY_BRACKETS_REGEX, "", false, true, BracketType.CurlyBracket)
     addMarkup(SQUARE_BRACKETS_REGEX_MID, "\n")
@@ -69,11 +73,71 @@ open class TypstAnnotatedTextBuilder(
     addMarkup(IMPORT_REGEX, "\n")
     addMarkup(SHOW_REGEX, "\n")
     addMarkup(STYLE_REGEX)
-    addMarkup(LABEL_REGEX, " ", true)
-    addMarkup(LABEL_REF_REGEX)
+    processReference()
+    addMarkup(LABEL_REGEX)
     addMarkup(VARIABLE_REGEX, "", true)
     addMarkup(QUOTATION_MARK_REGEX)
     addMarkup(CONDITIONAL_HYPHEN_REGEX)
+  }
+
+  private fun registerAbbreviation() {
+    if (characterProcessed || this.curString != "#") return
+    val match = matchFromPosition(ABBREVIATION_DEFINITION_REGEX) ?: return
+    val label = match.groupValues[1]
+    if (abbreviationLabels.add(label)) addDictionaryEntry(label)
+  }
+
+  private fun processFootnote() {
+    if (characterProcessed || this.curString != "#") return
+    if (this.pos > 0 && this.code[this.pos - 1] in HORIZONTAL_WHITESPACE) {
+      addMarkup(FOOTNOTE_WITH_TRAILING_WHITESPACE_REGEX)
+    }
+    addMarkup(FOOTNOTE_REGEX)
+  }
+
+  private fun processReference() {
+    if (characterProcessed || this.curString != "@") return
+    val match = matchFromPosition(REFERENCE_REGEX) ?: return
+    val reference = match.value.drop(1)
+    val label = reference.substringBefore(':')
+    val interpretAs =
+      if (label !in abbreviationLabels) {
+        generateDummy()
+      } else {
+        abbreviationPlaceholder(
+          label,
+          reference.substringAfter(':', "") in PLURAL_ABBREVIATION_SPECIFIERS,
+        )
+      }
+    addMarkup(match.value, interpretAs)
+  }
+
+  private fun abbreviationPlaceholder(
+    label: String,
+    plural: Boolean,
+  ): String {
+    val vowelSound = label.first().uppercaseChar() in VOWEL_SOUND_ABBREVIATION_INITIALS
+    val candidates =
+      when {
+        vowelSound && plural -> VOWEL_SOUND_PLURAL_PLACEHOLDERS
+        vowelSound -> VOWEL_SOUND_SINGULAR_PLACEHOLDERS
+        plural -> CONSONANT_SOUND_PLURAL_PLACEHOLDERS
+        else -> CONSONANT_SOUND_SINGULAR_PLACEHOLDERS
+      }
+    val placeholder = candidates.first { it != lastAbbreviationPlaceholder }
+    lastAbbreviationPlaceholder = placeholder
+    return if (isStartOfSentence()) {
+      placeholder.replaceFirstChar { it.titlecaseChar() }
+    } else {
+      placeholder
+    }
+  }
+
+  private fun isStartOfSentence(): Boolean {
+    if (this.isStartOfLine) return true
+    var previousPos = this.pos - 1
+    while (previousPos >= 0 && this.code[previousPos].isWhitespace()) previousPos--
+    return previousPos < 0 || this.code[previousPos] in SENTENCE_ENDINGS
   }
 
   private fun processEscapeCharacter() {
@@ -104,6 +168,8 @@ open class TypstAnnotatedTextBuilder(
     private val CITE_REGEX = Regex("^#cite\\(\\S+\\)")
     private val ENUM_REGEX = Regex("^#enum(\\([\\s\\S]*?\\)\\[|\\[)")
     private val FOOTNOTE_REGEX = Regex("^#footnote\\[[\\s\\S]*?\\]")
+    private val FOOTNOTE_WITH_TRAILING_WHITESPACE_REGEX =
+      Regex("^#footnote\\[[\\s\\S]*?\\][\\t ]+")
     private val CODE_REGEX = Regex("^#.*?\\(")
     private val CODE_CURLY_BRACKETS_REGEX = Regex("^#\\{")
     private val SQUARE_BRACKETS_REGEX_MID = Regex("^\\]\\[")
@@ -114,13 +180,28 @@ open class TypstAnnotatedTextBuilder(
     private val MULTILINELINE_COMMENT_REGEX = Regex("^\\/\\*[\\s\\S]*?\\*\\/")
     private val MARKUP_REGEX = Regex("^(\\*|\\_)")
     private val IMPORT_REGEX = Regex("^(#import|#include)\\s.*\r?\n")
-    private val SHOW_REGEX = Regex("^#show\\s.*\r?\n")
+    private val SHOW_REGEX = Regex("^#show(?::|\\s).*\r?\n")
     private val STYLE_REGEX =
       Regex("^#(highlight|lower|upper|overline|smallcaps|strike|sub|super|underline|strong)(?=\\[)")
-    private val LABEL_REGEX = Regex("^\\s@[^\\s]*")
-    private val LABEL_REF_REGEX = Regex("^<[^\\s]*>")
+    private val ABBREVIATION_DEFINITION_REGEX =
+      Regex(
+        "^#abbr\\.add\\(\\s*(?:short\\s*:\\s*)?\"([\\p{L}\\p{N}\\p{M}_-]+)\"" +
+          "\\s*,\\s*(?:(?:long|entry)\\s*:\\s*)?\"([^\"]+)\"",
+      )
+    private val REFERENCE_REGEX =
+      Regex("^@[\\p{L}\\p{N}\\p{M}_-](?:[\\p{L}\\p{N}\\p{M}_:.-]*[\\p{L}\\p{N}\\p{M}_-])?")
+    private val LABEL_REGEX = Regex("^<[^\\s]*>")
     private val VARIABLE_REGEX = Regex("^#\\w*")
     private val QUOTATION_MARK_REGEX = Regex("^\"")
     private val CONDITIONAL_HYPHEN_REGEX = Regex("^-\\?")
+    private val PLURAL_ABBREVIATION_SPECIFIERS = setOf("pls", "pll", "pllo", "pla")
+    private val HORIZONTAL_WHITESPACE = charArrayOf(' ', '\t')
+    private val VOWEL_SOUND_SINGULAR_PLACEHOLDERS = arrayOf("element", "object", "item")
+    private val VOWEL_SOUND_PLURAL_PLACEHOLDERS = arrayOf("elements", "objects", "items")
+    private val CONSONANT_SOUND_SINGULAR_PLACEHOLDERS = arrayOf("device", "system", "unit")
+    private val CONSONANT_SOUND_PLURAL_PLACEHOLDERS = arrayOf("devices", "systems", "units")
+    private val SENTENCE_ENDINGS = charArrayOf('.', '!', '?')
+    private val VOWEL_SOUND_ABBREVIATION_INITIALS =
+      setOf('A', 'E', 'F', 'H', 'I', 'L', 'M', 'N', 'O', 'R', 'S', 'X')
   }
 }

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
@@ -214,13 +214,14 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
       #show: resume.with(
         author: name,
       )
+      #show: abbr.show-rule
       More text.
       #show link: underline
       #show link: set text(rgb(0, 0, 255))
       More text.
 
       """.trimIndent(),
-      "\nMore text.\n\n\nMore text.\n",
+      "\n\nMore text.\n\n\nMore text.\n",
     )
   }
 
@@ -382,6 +383,42 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
       More text.
       """.trimIndent(),
       "The sky is blue.\nThe sea is blue.\nMore text.",
+    )
+  }
+
+  @Test
+  fun testReferences() {
+    assertPlainText(
+      """
+      See @source-one, @source.two; and @source:three.
+      The Worm #footnote[a self-replicating program] @source-four. Next sentence.
+      A new sentence follows the citation.
+      """.trimIndent(),
+      """
+      See Dummy0, Dummy1; and Dummy2.
+      The Worm Dummy3. Next sentence.
+      A new sentence follows the citation.
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testAbbreviationReferences() {
+    assertPlainText(
+      """
+      #abbr.add(short: "ABI", entry: "application binary interface")
+      #abbr.add("MOL", "method of lines")
+      An @ABI protects memory.
+      The @MOL is a procedure.
+      @ABI:pls are interfaces.
+      """.trimIndent(),
+      """
+      Dummy53 application binary interface
+      Dummy54 method of lines
+      An element protects memory.
+      The object is a procedure.
+      Elements are interfaces.
+      """.trimIndent(),
     )
   }
 


### PR DESCRIPTION
## Problem

The Typst text builder matched an `@` reference as everything up to the next whitespace. A citation at the end of a sentence therefore consumed its trailing period, so LanguageTool saw two sentences joined together and reported unrelated capitalization, spacing, and `QB_NEW_EN_OTHER` diagnostics.

The same path also treated `abbr` package references like bibliography references. In addition, removing an inline footnote before a citation could leave doubled whitespace in the checked text.

## Changes

- Parse Typst reference markers using Typst's label characters, including internal `.` and `:`, while leaving trailing punctuation in the prose.
- Recognize direct `abbr.add` declarations and accept the declared short forms as format-specific dictionary entries.
- Replace abbreviation references with rotating singular/plural placeholder words. Their capitalization and initial vowel/consonant sound follow the source context, which avoids introducing article, sentence-start, or repeated-word diagnostics.
- Collapse the whitespace left by an inline `#footnote[...]` before a citation.
- Ignore colon-style show rules such as `#show: abbr.show-rule`.
- Add regression coverage for references, punctuation, footnotes, abbreviations, plural specifiers, and show rules.

The abbreviation handling intentionally covers direct `abbr.add` declarations encountered before use. Resolving abbreviations loaded from CSV files or imported modules would require evaluating Typst and remains out of scope for the regex-based parser.

## Testing

- `mvn verify` — 377 tests run, 0 failures, 0 errors, 2 skipped.
- Checked the packaged server against a real Typst thesis using `abbr` 0.3.1 and bibliography references. The false citation/spacing diagnostics disappeared while genuine prose diagnostics remained.
