### PR TITLE
Treat Typst citations as parenthetical

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -30,7 +30,7 @@
         Fix LaTeX section commands (e.g., `\chapter`, `\section`) used as arguments to other commands (e.g., `\titleformat{\chapter}{...}`) causing false "Two consecutive dots" LanguageTool warnings. The section heading handler previously unconditionally pushed Heading mode and consumed the next character as `{`, even when the section command appeared inside a brace group as an argument.
       </action>
       <action type="fix">
-        Fix false Typst diagnostics around `@` references. Reference parsing now preserves trailing sentence punctuation. Labels registered with `abbr.add` are distinguished from bibliography and document references, accepted as declared terms, and replaced with grammar-safe singular or plural words for checking. Inline footnotes followed by citations no longer leave doubled whitespace, and colon-style show rules such as `#show: abbr.show-rule` are ignored as code.
+        Fix false Typst diagnostics around `@` references. Reference parsing now preserves trailing sentence punctuation. Bibliography-style references before punctuation are represented parenthetically so LanguageTool does not read a citation key as part of the sentence grammar. Labels registered with `abbr.add` are distinguished from bibliography and document references, accepted as declared terms, and replaced with grammar-safe singular or plural words for checking. Inline footnotes followed by citations no longer leave doubled whitespace, and colon-style show rules such as `#show: abbr.show-rule` are ignored as code.
       </action>
     </release>
     <release version="18.7.0" date="2026-06-13">

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
@@ -100,14 +100,27 @@ open class TypstAnnotatedTextBuilder(
     val match = matchFromPosition(REFERENCE_REGEX) ?: return
     val reference = match.value.drop(1)
     val label = reference.substringBefore(':')
+    var nextPos = this.pos + match.value.length
+    while (nextPos < this.code.length && this.code[nextPos] in HORIZONTAL_WHITESPACE) nextPos++
+    val citationContext =
+      !reference.contains(':') &&
+        (nextPos >= this.code.length || this.code[nextPos] in CITATION_FOLLOWING_CHARACTERS)
     val interpretAs =
-      if (label !in abbreviationLabels) {
-        generateDummy()
-      } else {
-        abbreviationPlaceholder(
-          label,
-          reference.substringAfter(':', "") in PLURAL_ABBREVIATION_SPECIFIERS,
-        )
+      when {
+        label in abbreviationLabels -> {
+          abbreviationPlaceholder(
+            label,
+            reference.substringAfter(':', "") in PLURAL_ABBREVIATION_SPECIFIERS,
+          )
+        }
+
+        citationContext -> {
+          CITATION_PLACEHOLDER
+        }
+
+        else -> {
+          generateDummy()
+        }
       }
     addMarkup(match.value, interpretAs)
   }
@@ -195,6 +208,9 @@ open class TypstAnnotatedTextBuilder(
     private val QUOTATION_MARK_REGEX = Regex("^\"")
     private val CONDITIONAL_HYPHEN_REGEX = Regex("^-\\?")
     private val PLURAL_ABBREVIATION_SPECIFIERS = setOf("pls", "pll", "pllo", "pla")
+    private const val CITATION_PLACEHOLDER = "(citation)"
+    private val CITATION_FOLLOWING_CHARACTERS =
+      charArrayOf('.', ',', ';', ':', '!', '?', ')', ']', '@')
     private val HORIZONTAL_WHITESPACE = charArrayOf(' ', '\t')
     private val VOWEL_SOUND_SINGULAR_PLACEHOLDERS = arrayOf("element", "object", "item")
     private val VOWEL_SOUND_PLURAL_PLACEHOLDERS = arrayOf("elements", "objects", "items")

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
@@ -390,14 +390,18 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
   fun testReferences() {
     assertPlainText(
       """
-      See @source-one, @source.two; and @source:three.
+      See @source-one, @source.two; and @source-three.
       The Worm #footnote[a self-replicating program] @source-four. Next sentence.
-      A new sentence follows the citation.
+      Attacks are documented by Aleph One's work, which sparked further investigation @burow2019.
+      Multiple sources support this @first-source @second-source.
+      Open @section:three for details.
       """.trimIndent(),
       """
-      See Dummy0, Dummy1; and Dummy2.
-      The Worm Dummy3. Next sentence.
-      A new sentence follows the citation.
+      See (citation), (citation); and (citation).
+      The Worm (citation). Next sentence.
+      Attacks are documented by Aleph One's work, which sparked further investigation (citation).
+      Multiple sources support this (citation) (citation).
+      Open Dummy0 for details.
       """.trimIndent(),
     )
   }


### PR DESCRIPTION
Follow-up to #198.

## Problem

References that were neither registered abbreviations nor colon-qualified document labels still used a noun placeholder. At the end of a sentence, LanguageTool could read that placeholder as part of the prose and suggest a preposition that belongs before a person or source rather than a citation.

For example:

```typst
Attacks against the stack integrity, so-called stack smashing, are documented by Aleph One's work, which also sparked further investigation @burowShiningLightShadow2019.
```

was checked like `... further investigation Dummy0.` and prompted a suggestion equivalent to `... further investigation by @burow...`.

## Change

Use `(citation)` for bibliography-style references followed by punctuation or another reference. The parenthetical shape matches how citations function in the sentence and prevents grammar rules from treating the key as a noun.

Colon-qualified document references such as `@section:introduction` keep the existing dummy-word behavior because they commonly fill a grammatical role in the prose. Registered `abbr.add` references keep their singular/plural abbreviation placeholders.

## Testing

- Added coverage for sentence-final citations, citations before commas/semicolons, consecutive citations, inline footnote citations, and colon-qualified document references.
- `mvn verify`: 377 tests run, 0 failures, 0 errors, 2 skipped.
- Checked the reported sentence through the packaged Typst CLI; it now produces no diagnostic.
