### PR TITLE
Fix additional Typst false positives

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -30,7 +30,7 @@
         Fix LaTeX section commands (e.g., `\chapter`, `\section`) used as arguments to other commands (e.g., `\titleformat{\chapter}{...}`) causing false "Two consecutive dots" LanguageTool warnings. The section heading handler previously unconditionally pushed Heading mode and consumed the next character as `{`, even when the section command appeared inside a brace group as an argument.
       </action>
       <action type="fix">
-        Fix false Typst diagnostics around `@` references. Reference parsing now preserves trailing sentence punctuation. Labels registered with `abbr.add` are distinguished from bibliography and document references, accepted as declared terms, and replaced with grammar-safe singular or plural words for checking. Inline footnotes followed by citations no longer leave doubled whitespace, and colon-style show rules such as `#show: abbr.show-rule` are ignored as code.
+        Fix false Typst diagnostics around `@` references. Reference parsing now preserves trailing sentence punctuation. Bibliography-style references before punctuation are represented parenthetically so LanguageTool does not read a citation key as part of the sentence grammar. Labels registered with `abbr.add` are distinguished from bibliography and document references, accepted as declared terms, and replaced with grammar-safe singular or plural words for checking. Inline footnotes followed by citations no longer leave doubled whitespace, and colon-style show rules such as `#show: abbr.show-rule` are ignored as code.
       </action>
     </release>
     <release version="18.7.0" date="2026-06-13">

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
@@ -100,14 +100,27 @@ open class TypstAnnotatedTextBuilder(
     val match = matchFromPosition(REFERENCE_REGEX) ?: return
     val reference = match.value.drop(1)
     val label = reference.substringBefore(':')
+    var nextPos = this.pos + match.value.length
+    while (nextPos < this.code.length && this.code[nextPos] in HORIZONTAL_WHITESPACE) nextPos++
+    val citationContext =
+      !reference.contains(':') &&
+        (nextPos >= this.code.length || this.code[nextPos] in CITATION_FOLLOWING_CHARACTERS)
     val interpretAs =
-      if (label !in abbreviationLabels) {
-        generateDummy()
-      } else {
-        abbreviationPlaceholder(
-          label,
-          reference.substringAfter(':', "") in PLURAL_ABBREVIATION_SPECIFIERS,
-        )
+      when {
+        label in abbreviationLabels -> {
+          abbreviationPlaceholder(
+            label,
+            reference.substringAfter(':', "") in PLURAL_ABBREVIATION_SPECIFIERS,
+          )
+        }
+
+        citationContext -> {
+          CITATION_PLACEHOLDER
+        }
+
+        else -> {
+          generateDummy()
+        }
       }
     addMarkup(match.value, interpretAs)
   }
@@ -195,6 +208,9 @@ open class TypstAnnotatedTextBuilder(
     private val QUOTATION_MARK_REGEX = Regex("^\"")
     private val CONDITIONAL_HYPHEN_REGEX = Regex("^-\\?")
     private val PLURAL_ABBREVIATION_SPECIFIERS = setOf("pls", "pll", "pllo", "pla")
+    private const val CITATION_PLACEHOLDER = "(citation)"
+    private val CITATION_FOLLOWING_CHARACTERS =
+      charArrayOf('.', ',', ';', ':', '!', '?', ')', ']', '@')
     private val HORIZONTAL_WHITESPACE = charArrayOf(' ', '\t')
     private val VOWEL_SOUND_SINGULAR_PLACEHOLDERS = arrayOf("element", "object", "item")
     private val VOWEL_SOUND_PLURAL_PLACEHOLDERS = arrayOf("elements", "objects", "items")

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
@@ -85,7 +85,7 @@ open class TypstAnnotatedTextBuilder(
     if (characterProcessed || this.curString != "#") return
     val match = matchFromPosition(ABBREVIATION_DEFINITION_REGEX) ?: return
     val label = match.groupValues[1]
-    if (abbreviationLabels.add(label)) addDictionaryEntry(label)
+    if (abbreviationLabels.add(label) && !this.code.contains("$label-")) addDictionaryEntry(label)
   }
 
   private fun processFootnote() {
@@ -196,7 +196,9 @@ open class TypstAnnotatedTextBuilder(
     private val IMPORT_REGEX = Regex("^(#import|#include)\\s.*\r?\n")
     private val SHOW_REGEX = Regex("^#show(?::|\\s).*\r?\n")
     private val STYLE_REGEX =
-      Regex("^#(highlight|lower|upper|overline|smallcaps|strike|sub|super|underline|strong)(?=\\[)")
+      Regex(
+        "^#(emph|highlight|lower|upper|overline|smallcaps|strike|sub|super|underline|strong)(?=\\[)",
+      )
     private val ABBREVIATION_DEFINITION_REGEX =
       Regex(
         "^#abbr\\.add\\(\\s*(?:short\\s*:\\s*)?\"([\\p{L}\\p{N}\\p{M}_-]+)\"" +

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilder.kt
@@ -74,6 +74,7 @@ open class TypstAnnotatedTextBuilder(
     addMarkup(SHOW_REGEX, "\n")
     addMarkup(STYLE_REGEX)
     processReference()
+    addMarkup(TRAILING_LABEL_REGEX)
     addMarkup(LABEL_REGEX)
     addMarkup(VARIABLE_REGEX, "", true)
     addMarkup(QUOTATION_MARK_REGEX)
@@ -206,6 +207,7 @@ open class TypstAnnotatedTextBuilder(
     private val LABEL_REGEX = Regex("^<[^\\s]*>")
     private val VARIABLE_REGEX = Regex("^#\\w*")
     private val QUOTATION_MARK_REGEX = Regex("^\"")
+    private val TRAILING_LABEL_REGEX = Regex("^[\\t ]*<[^\\s>]+>(?=\r?\n|$)")
     private val CONDITIONAL_HYPHEN_REGEX = Regex("^-\\?")
     private val PLURAL_ABBREVIATION_SPECIFIERS = setOf("pls", "pll", "pllo", "pla")
     private const val CITATION_PLACEHOLDER = "(citation)"

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
@@ -390,14 +390,18 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
   fun testReferences() {
     assertPlainText(
       """
-      See @source-one, @source.two; and @source:three.
+      See @source-one, @source.two; and @source-three.
       The Worm #footnote[a self-replicating program] @source-four. Next sentence.
-      A new sentence follows the citation.
+      Attacks are documented by Aleph One's work, which sparked further investigation @burow2019.
+      Multiple sources support this @first-source @second-source.
+      Open @section:three for details.
       """.trimIndent(),
       """
-      See Dummy0, Dummy1; and Dummy2.
-      The Worm Dummy3. Next sentence.
-      A new sentence follows the citation.
+      See (citation), (citation); and (citation).
+      The Worm (citation). Next sentence.
+      Attacks are documented by Aleph One's work, which sparked further investigation (citation).
+      Multiple sources support this (citation) (citation).
+      Open Dummy0 for details.
       """.trimIndent(),
     )
   }

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
@@ -36,7 +36,7 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
       === That is a bold statement!
       More text to read
       === A heading with a dot.
-      == Control-flow hijacking and code reuse attacks <sec:control-flow-hijacking-code-reuse-attacks>
+      == A heading with a spaced label <sec:spaced-heading>
       More text
       """.trimIndent(),
       """
@@ -47,7 +47,7 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
       That is a bold statement!
       More text to read
       A heading with a dot.
-      Control-flow hijacking and code reuse attacks.
+      A heading with a spaced label.
       More text
       """.trimIndent(),
     )
@@ -393,15 +393,15 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
     assertPlainText(
       """
       See @source-one, @source.two; and @source-three.
-      The Worm #footnote[a self-replicating program] @source-four. Next sentence.
-      Attacks are documented by Aleph One's work, which sparked further investigation @burow2019.
+      The claim #footnote[an explanatory note] @source-four. Next sentence.
+      The observation motivated further research @study-2024.
       Multiple sources support this @first-source @second-source.
       Open @section:three for details.
       """.trimIndent(),
       """
       See (citation), (citation); and (citation).
-      The Worm (citation). Next sentence.
-      Attacks are documented by Aleph One's work, which sparked further investigation (citation).
+      The claim (citation). Next sentence.
+      The observation motivated further research (citation).
       Multiple sources support this (citation) (citation).
       Open Dummy0 for details.
       """.trimIndent(),
@@ -432,12 +432,12 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
   fun testHyphenatedAbbreviation() {
     assertPlainText(
       """
-      #abbr.add("RISC", "reduced instruction set computer")
-      RISC-V uses @RISC:s.
+      #abbr.add("API", "application programming interface")
+      API-based clients use @API:s.
       """.trimIndent(),
       """
-      RISC reduced instruction set computer
-      RISC-V uses element.
+      API application programming interface
+      API-based clients use element.
       """.trimIndent(),
     )
   }

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
@@ -318,9 +318,9 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
   fun testStyle() {
     assertPlainText(
       """
-      Text #highlight[can] #upper[be] #sub[styled] in #strong[different] ways.
+      Text #highlight[can] #upper[be] #sub[styled] in #strong[different] ways and #emph[emphasized].
       """.trimIndent(),
-      "Text can be styled in different ways.",
+      "Text can be styled in different ways and emphasized.",
     )
   }
 
@@ -424,6 +424,20 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
       An element protects memory.
       The object is a procedure.
       Elements are interfaces.
+      """.trimIndent(),
+    )
+  }
+
+  @Test
+  fun testHyphenatedAbbreviation() {
+    assertPlainText(
+      """
+      #abbr.add("RISC", "reduced instruction set computer")
+      RISC-V uses @RISC:s.
+      """.trimIndent(),
+      """
+      RISC reduced instruction set computer
+      RISC-V uses element.
       """.trimIndent(),
     )
   }

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/typst/TypstAnnotatedTextBuilderTest.kt
@@ -36,6 +36,7 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
       === That is a bold statement!
       More text to read
       === A heading with a dot.
+      == Control-flow hijacking and code reuse attacks <sec:control-flow-hijacking-code-reuse-attacks>
       More text
       """.trimIndent(),
       """
@@ -46,6 +47,7 @@ class TypstAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("typst") {
       That is a bold statement!
       More text to read
       A heading with a dot.
+      Control-flow hijacking and code reuse attacks.
       More text
       """.trimIndent(),
     )


### PR DESCRIPTION
Follow-up to #198.

## Summary

- Treat bibliography-style references as parenthetical citations.
- Remove trailing heading labels without leaving whitespace before punctuation.
- Handle `#emph[...]` as style markup.
- Avoid masking abbreviations inside compounds such as `RISC-V`.

## Testing

- `mvn verify`: 378 tests passed.
- Added regression tests for citations, heading labels, emphasis, and hyphenated abbreviations.
