### PR TITLE
Only offer external-file quick fixes when a file is configured

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -38,6 +38,9 @@
       <action type="fix">
         Fix false Typst diagnostics around `@` references. Reference parsing now preserves trailing sentence punctuation. Bibliography-style references before punctuation are represented parenthetically so LanguageTool does not read a citation key as part of the sentence grammar. Labels registered with `abbr.add` are distinguished from bibliography and document references, accepted as declared terms, and replaced with grammar-safe singular or plural words for checking. Inline footnotes followed by citations no longer leave doubled whitespace, and colon-style show rules such as `#show: abbr.show-rule` are ignored as code.
       </action>
+      <action type="fix" issue="ltex-plus/ltex-ls-plus#192">
+        Only offer the "Add to dictionary", "Disable rule" and "Hide false positive" quick fixes in server-managed mode (`ltex.externalFiles.managedByEditor` set to `false`) when the corresponding setting actually has a `:`-prefixed external file for the document's language. The command appends to the first external file listed for a language and fails outright when it could write nothing, but that failure is reported the way every other command reports one — a successful response carrying `success: false` — which is invisible to precisely the lean clients this mode exists for: Helix discards a command result without inspecting it, and has never implemented `window/showMessage` either, so a misconfigured path made the quick fix appear to succeed while doing nothing. Since the failure cannot be surfaced, it is now unreachable: an action that could not be carried out is not offered. Editor-managed clients are unaffected, as there the client performs the write itself and no external file need be configured for the server.
+      </action>
     </release>
     <release version="18.7.0" date="2026-06-13">
       <action type="add" issue="ltex-plus/ltex-ls-plus#183" due-to="Andrea Alberti (@alberti42)">

--- a/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/CodeActionProvider.kt
@@ -38,6 +38,10 @@ import java.net.URLEncoder
 class CodeActionProvider(
   val settingsManager: SettingsManager,
 ) {
+  // Mirrors LtexLanguageServer.serverManagesExternalFiles, which is only known
+  // once initializationOptions have been read — after this provider is built.
+  var serverManagesExternalFiles: Boolean = false
+
   fun createDiagnostic(
     match: LanguageToolRuleMatch,
     document: LtexTextDocumentItem,
@@ -131,23 +135,23 @@ class CodeActionProvider(
     }
 
     if (hideFalsePositivesMatches.isNotEmpty()) {
-      result.add(
-        Either.forRight(
-          getHideFalsePositivesCodeAction(
-            document,
-            hideFalsePositivesMatches,
-            annotatedTextFragments,
-          ),
-        ),
-      )
+      val hideFalsePositivesCodeAction: CodeAction? =
+        getHideFalsePositivesCodeAction(
+          document,
+          hideFalsePositivesMatches,
+          annotatedTextFragments,
+        )
+      if (hideFalsePositivesCodeAction != null) {
+        result.add(Either.forRight(hideFalsePositivesCodeAction))
+      }
     }
 
     if (disableRulesMatches.isNotEmpty()) {
-      result.add(
-        Either.forRight(
-          getDisableRulesCodeAction(document, disableRulesMatches, annotatedTextFragments),
-        ),
-      )
+      val disableRulesCodeAction: CodeAction? =
+        getDisableRulesCodeAction(document, disableRulesMatches, annotatedTextFragments)
+      if (disableRulesCodeAction != null) {
+        result.add(Either.forRight(disableRulesCodeAction))
+      }
     }
 
     return result
@@ -238,6 +242,7 @@ class CodeActionProvider(
     }
 
     if (unknownWordsMap.isEmpty()) return null
+    if (!canPersistExternally("dictionary", unknownWordsMap.keys)) return null
 
     val arguments = JsonObject()
     arguments.addProperty("uri", document.uri)
@@ -261,12 +266,30 @@ class CodeActionProvider(
     return codeAction
   }
 
+  // When the server persists these settings itself, a quick fix can only
+  // complete if at least one of the payload's languages has a ":"-prefixed
+  // external file: the command appends to the first file listed for a language
+  // and fails outright when it could write nothing at all. Lean clients discard
+  // a failed command result without showing it — Helix does not implement
+  // window/showMessage either — so an action we already know cannot complete
+  // would look like it worked and silently do nothing. Offer it only when it can
+  // actually be carried out. Editor-managed clients are unaffected: there the
+  // client performs the write, so no external file need be configured for us.
+  private fun canPersistExternally(
+    settingName: String,
+    languages: Set<String>,
+  ): Boolean {
+    if (!this.serverManagesExternalFiles) return true
+    val settings = this.settingsManager.settings
+    return languages.any { settings.firstExternalSettingFile(settingName, it) != null }
+  }
+
   @Suppress("LoopWithTooManyJumpStatements")
   private fun getHideFalsePositivesCodeAction(
     document: LtexTextDocumentItem,
     hideFalsePositivesMatches: List<LanguageToolRuleMatch>,
     annotatedTextFragments: List<AnnotatedTextFragment>,
-  ): CodeAction {
+  ): CodeAction? {
     val ruleIdSentencePairs = ArrayList<Pair<String, String>>()
     val hiddenFalsePositivesMap = HashMap<String, MutableList<String>>()
     val falsePositivesJsonObject = JsonObject()
@@ -324,6 +347,8 @@ class CodeActionProvider(
       diagnostics.add(createDiagnostic(match, document))
     }
 
+    if (!canPersistExternally("hiddenFalsePositives", hiddenFalsePositivesMap.keys)) return null
+
     val arguments = JsonObject()
     arguments.addProperty("uri", document.uri)
     arguments.add("falsePositives", falsePositivesJsonObject)
@@ -351,7 +376,7 @@ class CodeActionProvider(
     document: LtexTextDocumentItem,
     disableRuleMatches: List<LanguageToolRuleMatch>,
     annotatedTextFragments: List<AnnotatedTextFragment>,
-  ): CodeAction {
+  ): CodeAction? {
     val ruleIdsMap = HashMap<String, MutableList<String>>()
     val ruleIdsJsonObject = JsonObject()
     val diagnostics = ArrayList<Diagnostic>()
@@ -374,6 +399,8 @@ class CodeActionProvider(
 
       diagnostics.add(createDiagnostic(match, document))
     }
+
+    if (!canPersistExternally("disabledRules", ruleIdsMap.keys)) return null
 
     val arguments = JsonObject()
     arguments.addProperty("uri", document.uri)

--- a/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/server/LtexLanguageServer.kt
@@ -188,6 +188,9 @@ class LtexLanguageServer :
     }
 
     this.serverManagesExternalFiles = readServerManagesExternalFiles(initializationOptionsObject)
+    // The code action provider needs the same flag: in server-managed mode it
+    // only offers a quick fix whose external file actually exists.
+    this.codeActionProvider.serverManagesExternalFiles = this.serverManagesExternalFiles
     return localeLanguage
   }
 

--- a/src/test/kotlin/org/bsplines/ltexls/server/CodeActionProviderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/server/CodeActionProviderTest.kt
@@ -1,0 +1,111 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package org.bsplines.ltexls.server
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import org.bsplines.ltexls.languagetool.LanguageToolRuleMatch
+import org.bsplines.ltexls.parsing.AnnotatedTextFragment
+import org.bsplines.ltexls.settings.Settings
+import org.bsplines.ltexls.settings.SettingsManager
+import org.eclipse.lsp4j.CodeActionContext
+import org.eclipse.lsp4j.CodeActionParams
+import org.eclipse.lsp4j.Position
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextDocumentIdentifier
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CodeActionProviderTest {
+  // In server-managed mode a quick fix can only be carried out when the setting
+  // has a ":"-prefixed external file for the document's language. Lean clients
+  // discard a failed command result without showing it, so offering an action
+  // that is certain to fail would look like success and silently do nothing.
+  @Test
+  fun testExternalFileCodeActionsAreWithheldWhenNoFileIsConfigured() {
+    // Server-managed, no external file configured anywhere: withhold all three.
+    assertEquals(emptySet(), persistingCommandsOffered(serverManaged = true, externalFile = null))
+
+    val externalFile: File = File.createTempFile("ltex-guard-", ".txt")
+
+    try {
+      // Server-managed with a file for the document's language: offer them again.
+      assertEquals(
+        PERSISTING_COMMANDS,
+        persistingCommandsOffered(serverManaged = true, externalFile = externalFile),
+      )
+
+      // Editor-managed (the default): the client performs the write, so a missing
+      // external file must not withhold anything.
+      assertEquals(
+        PERSISTING_COMMANDS,
+        persistingCommandsOffered(serverManaged = false, externalFile = null),
+      )
+    } finally {
+      externalFile.delete()
+    }
+  }
+
+  companion object {
+    private val PERSISTING_COMMANDS: Set<String> =
+      setOf("_ltex.addToDictionary", "_ltex.disableRules", "_ltex.hideFalsePositives")
+
+    private val EXTERNAL_FILE_SETTINGS: List<String> =
+      listOf("dictionary", "disabledRules", "hiddenFalsePositives")
+
+    // Runs the code action generator over a document containing an unknown word
+    // and returns which of the three persisting commands were offered.
+    private fun persistingCommandsOffered(
+      serverManaged: Boolean,
+      externalFile: File?,
+    ): Set<String> {
+      val document: LtexTextDocumentItem =
+        DocumentCheckerTest.createDocument("markdown", "This is an unknownword.\n")
+      val settingsManager = SettingsManager()
+      val checkingResult: Pair<List<LanguageToolRuleMatch>, List<AnnotatedTextFragment>> =
+        DocumentChecker(settingsManager).check(document)
+
+      if (externalFile != null) {
+        settingsManager.settings = Settings.fromJson(buildSettings(externalFile), null, true)
+      }
+
+      val params =
+        CodeActionParams(
+          TextDocumentIdentifier(document.uri),
+          Range(Position(0, 0), Position(100, 0)),
+          CodeActionContext(emptyList()),
+        )
+
+      val codeActionProvider = CodeActionProvider(settingsManager)
+      codeActionProvider.serverManagesExternalFiles = serverManaged
+
+      return codeActionProvider
+        .generate(params, document, checkingResult)
+        .mapNotNull { it.right?.command?.command }
+        .filter { it.startsWith("_ltex.") }
+        .toSet()
+    }
+
+    // { <setting>: { "en-US": [":<path>"] } } for each writable setting.
+    private fun buildSettings(externalFile: File): JsonObject {
+      val jsonSettings = JsonObject()
+
+      for (settingName: String in EXTERNAL_FILE_SETTINGS) {
+        val entries = JsonArray()
+        entries.add(":" + externalFile.absolutePath)
+        val byLanguage = JsonObject()
+        byLanguage.add("en-US", entries)
+        jsonSettings.add(settingName, byLanguage)
+      }
+
+      return jsonSettings
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #192, which is merged but not yet released.

## The problem

In server-managed mode (`ltex.externalFiles.managedByEditor: false`) the three quick fixes — "Add to dictionary", "Disable rule", "Hide false positive" — append to the first `:`-prefixed external file listed for the document's language. If no such file is configured, `executeAppendToExternalFileCommand` can write nowhere and fails.

We report that failure the way every command in `LtexWorkspaceService` reports one: a *successful* JSON-RPC response carrying `{success: false, errorMessage: …}`. That works for a client that inspects the result — but it is invisible to precisely the lean clients this mode exists for.

Helix, the motivating client for #192, discards a command result without looking at it. `execute_lsp_command` only logs on a transport error, so a `{success: false}` payload is dropped silently and never even reaches the log. There is no fallback channel either: `window/showMessage` has been unimplemented in Helix since 2022 ([helix-editor/helix#5524](https://github.com/helix-editor/helix/issues/5524), [#6321](https://github.com/helix-editor/helix/issues/6321)).

Net effect: a user who enables the feature with a wrong or missing path picks "Add to dictionary", sees nothing happen, and has no way to distinguish that from success.

## The fix

Since the failure cannot be surfaced, make it unreachable — offer the quick fix only when the setting actually has an external file for one of the payload's languages:

```kotlin
private fun canPersistExternally(settingName: String, languages: Set<String>): Boolean {
  if (!this.serverManagesExternalFiles) return true
  val settings = this.settingsManager.settings
  return languages.any { settings.firstExternalSettingFile(settingName, it) != null }
}
```

This is the same principle we would ask of a client: do not present an action that cannot be carried out.

`CodeActionProvider` gains a `serverManagesExternalFiles` flag, set by `LtexLanguageServer` where it reads `initializationOptions` — a `var` rather than a constructor parameter because the value is not known until `initialize`, after the provider is built. `getHideFalsePositivesCodeAction` and `getDisableRulesCodeAction` become nullable to match `getAddWordToDictionaryCodeAction`, which already was.

`failCommand` stays as the backstop: settings can change between the code action and its execution, and it still serves clients that do read the result.

## Scope

**Editor-managed clients are unaffected.** There the client performs the write itself and no external file need be configured for the server, so the guard short-circuits to `true` and the offered set is unchanged. The existing `testCodeActionGenerator` expectation of four code actions still holds untouched.

## Tests

New `CodeActionProviderTest` — there was no test class for this provider before — covering all three states:

- server-managed, no external file → none of the three offered
- server-managed, file configured for the language → all three offered
- editor-managed, no external file → all three offered

## Verification

Full `mvn verify` with LanguageTool Premium credentials loaded and a local LanguageTool server on `:8081` for `LanguageToolHttpInterfaceTest`:

```
Tests run: 385, Failures: 0, Errors: 0, Skipped: 0
All coverage checks have been met.
detekt / ktlint → clean
BUILD SUCCESS
```

Nothing skipped, so the Premium integration test ran rather than opting out, and the JaCoCo gate was evaluated for real.