### PR TITLE
Say what a magic comment expects when its syntax is wrong

### DIFF
--- a/changelog.xml
+++ b/changelog.xml
@@ -29,6 +29,9 @@
       <action type="update">
         Update to lsp-cli-plus 3.0.0. See [lsp-cli-plus release notes](https://github.com/ltex-plus/lsp-cli-plus/releases/tag/3.0.0).
       </action>
+      <action type="fix" due-to="Andrea Alberti (@alberti42)">
+        Say what a magic comment expects when its syntax is wrong, instead of reporting it as an unknown setting. `dictionary` and `rules` are cumulative and require an operator before the `=` — `dictionary+=WORD` to accept a word, `-=` to stop accepting one, `#=` to revert to the global setting — but the operator is part of what the parser matches on, so a plain `dictionary=WORD` matched nothing and fell through to the unknown-setting branch, warning `Ignoring unknown inline setting with name 'dictionary'`. That tells users a supported setting does not exist, which is how [discussion 205](https://github.com/ltex-plus/ltex-ls-plus/discussions/205) came to be filed as a request for a dictionary magic comment that has been there all along; the operator-less forms are now reported with the message the parser already had for a malformed operator, which names `+=`, `-=` and `#=`. The related warning for a line that cannot be parsed at all now also names the expected form, since the same report shows a user pasting the JSON value of the `ltex.dictionary` client setting into a magic comment, where values are whitespace-separated and JSON is not accepted. Both are message changes: no magic comment that worked before parses differently, and settings that genuinely are not supported still report as unknown.
+      </action>
       <action type="fix" issue="ltex-plus/vscode-ltex-plus#206" due-to="Daniel Spitzer (@spitzerd)">
         Fix StackOverflowError for Typst, AsciiDoc, and Org documents. The issue occurred on long comments, for example.
       </action>

--- a/src/main/kotlin/org/bsplines/ltexls/settings/SettingsParser.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/SettingsParser.kt
@@ -25,6 +25,13 @@ object SettingsParser {
     Regex("^(?:ltex\\.)?dictionary(?<op>[+#-])$", RegexOption.IGNORE_CASE)
   private val RULE_REGEX = Regex("^(?:ltex\\.)?rules(?<op>[+#-])$", RegexOption.IGNORE_CASE)
 
+  // The two cumulative settings written without their required "+"/"-"/"#"
+  // operator, e.g. "dictionary=Foo". Such a key matches neither regex above, so
+  // without this it reaches the "unknown setting" branch and the warning claims a
+  // supported setting does not exist -- the very confusion behind discussion #205.
+  private val CUMULATIVE_WITHOUT_OPERATOR_REGEX =
+    Regex("^(?:ltex\\.)?(?<name>dictionary|rules)$", RegexOption.IGNORE_CASE)
+
   @Suppress("UnusedPrivateProperty") // False positives are too complex to parse for now.
   private val FALSE_POSITIVE_REGEX =
     Regex("^(?:ltex\\.)?hiddenFalsePositives(?<op>[+#-])$", RegexOption.IGNORE_CASE)
@@ -159,6 +166,13 @@ object SettingsParser {
                 )
               }
             },
+          )
+        } != null -> {
+        }
+
+        CUMULATIVE_WITHOUT_OPERATOR_REGEX.matchEntire(key)?.let {
+          Logging.LOGGER.warning(
+            I18n.format("ignoringMalformedInlineSettingOperation", "", key),
           )
         } != null -> {
         }

--- a/src/main/resources/LtexLsMessagesBundle.properties
+++ b/src/main/resources/LtexLsMessagesBundle.properties
@@ -60,7 +60,7 @@ hideFalsePositive = Hide false positive
 hidingFalsePositive = Hiding false positive with rule '{0}' and sentence '{1}'
 ignoreEnvironmentEndPatternNotSet = ignoreEnvironmentEndPattern not set
 ignoringMalformedHiddenFalsePositive = Ignoring malformed hiddenFalsePositives entry: {0}
-ignoringMalformedInlineSetting = Ignoring malformed inline setting '{0}'
+ignoringMalformedInlineSetting = Ignoring malformed inline setting '{0}'. A magic comment expects whitespace-separated NAME=VALUE pairs whose VALUE contains no whitespace, not a JSON value like the one 'ltex.dictionary' takes in the client settings
 ignoringMalformedInlineSettingBoolean = Ignoring malformed inline setting value '{0}' for name '{1}'. Expected a boolean: '0', '1', 'true', 'false', or '#' to remove this setting
 ignoringMalformedInlineSettingOperation = Ignoring malformed inline setting operation '{0}=' for name '{1}'. Expected '+=', '-=' or '#='
 ignoringUnknownInlineSetting = Ignoring unknown inline setting with name '{0}' and value '{1}'

--- a/src/test/kotlin/SettingsParserTest.kt
+++ b/src/test/kotlin/SettingsParserTest.kt
@@ -1,0 +1,118 @@
+/* Copyright (C) 2019-2025
+ * Julian Valentin, Daniel Spitzer, LTeX+ Development Community
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import org.bsplines.ltexls.settings.Settings
+import org.bsplines.ltexls.settings.SettingsOverride
+import org.bsplines.ltexls.tools.Logging
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SettingsParserTest {
+  private class CapturingHandler : Handler() {
+    val messages = ArrayList<String>()
+
+    override fun publish(record: LogRecord?) {
+      record?.message?.let { this.messages.add(it) }
+    }
+
+    override fun flush() = Unit
+
+    override fun close() = Unit
+  }
+
+  // Runs one magic-comment settings line, returning both the warnings it logged
+  // and the resulting settings, so a test can assert on either.
+  private fun parse(settingsLine: String): Pair<List<String>, Settings> {
+    val handler = CapturingHandler()
+    val override = SettingsOverride(Settings())
+    Logging.LOGGER.addHandler(handler)
+
+    try {
+      SettingsParser.updateSettingsOverride(settingsLine, override)
+    } finally {
+      Logging.LOGGER.removeHandler(handler)
+    }
+
+    return Pair(handler.messages, override.toSettings())
+  }
+
+  /**
+   * A cumulative setting written without its operator used to fall through to the
+   * "unknown setting" branch, telling the user that a supported setting does not
+   * exist. Regression test for
+   * https://github.com/ltex-plus/ltex-ls-plus/discussions/205.
+   */
+  @Test
+  fun testDictionaryWithoutOperatorNamesTheOperators() {
+    for (key: String in listOf("dictionary", "ltex.dictionary", "DICTIONARY")) {
+      val (warnings: List<String>, _) = parse("$key=Kryptographie")
+
+      assertEquals(1, warnings.size, key)
+      assertContains(warnings[0], key)
+      assertContains(warnings[0], "'+='")
+      assertContains(warnings[0], "'-='")
+      assertContains(warnings[0], "'#='")
+      assertFalse(warnings[0].contains("unknown", ignoreCase = true), warnings[0])
+    }
+  }
+
+  @Test
+  fun testRulesWithoutOperatorNamesTheOperators() {
+    val (warnings: List<String>, _) = parse("rules=EN_A_VS_AN")
+
+    assertEquals(1, warnings.size)
+    assertContains(warnings[0], "rules")
+    assertContains(warnings[0], "'+='")
+    assertFalse(warnings[0].contains("unknown", ignoreCase = true), warnings[0])
+  }
+
+  @Test
+  fun testGenuinelyUnknownSettingIsStillReportedAsUnknown() {
+    val (warnings: List<String>, _) = parse("dictionaries=Kryptographie")
+
+    assertEquals(1, warnings.size)
+    assertContains(warnings[0], "unknown")
+  }
+
+  /**
+   * The JSON form of `ltex.dictionary` pasted into a magic comment, as reported in
+   * https://github.com/ltex-plus/ltex-ls-plus/discussions/205. Values are separated
+   * by whitespace, so the JSON is split at the first space and its tail cannot be
+   * parsed; the warning now says what a magic comment does expect.
+   */
+  @Test
+  fun testJsonValueIsRejectedWithAdvice() {
+    val (warnings: List<String>, settings: Settings) =
+      parse("""dictionary={"en-US": ["adaptivity"], "de-DE": ["B-Splines"]}""")
+
+    val malformed: String =
+      warnings.single { it.contains("Ignoring malformed inline setting '[") }
+    assertContains(malformed, "NAME=VALUE")
+    assertContains(malformed, "JSON")
+
+    // Nothing from the JSON is mistaken for a dictionary entry.
+    val dictionary: Set<String> = settings.dictionary
+    assertTrue(
+      dictionary.none { it.contains("adaptivity") },
+      dictionary.toString(),
+    )
+  }
+
+  @Test
+  fun testDictionaryWithOperatorStillWorksSilently() {
+    val (warnings: List<String>, settings: Settings) = parse("dictionary+=Kryptographie")
+
+    assertTrue(warnings.isEmpty(), warnings.toString())
+    assertContains(settings.dictionary, "Kryptographie")
+  }
+}


### PR DESCRIPTION
The `dictionary` and `rules` magic comments require an operator before the `=`. This means`+=` to add an entry, `-=` to remove one, `#=` to revert it to the global setting. A plain `=` is not accepted, and neither is a JSON value. Both mistakes are currently reported in ways that send the user in the wrong direction — the first says the setting is *unknown*, the second says only that the line is malformed. This PR makes each warning name the syntax that was expected.

## What goes wrong

`% LTeX: dictionary+=Foo` accepts `Foo` as a word for the rest of the document. Written with a plain `=`, as every other magic-comment setting is written — `language=de-DE`, `enabled=false` — it fails:

```latex
% LTeX: dictionary=Foo
```

```
WARNING: Ignoring unknown inline setting with name 'dictionary' and value 'Foo'
```

Nothing there suggests an operator is missing. It states that `dictionary` is not a setting the server knows, which is the wrong conclusion — and users act on it. In [discussion 205](https://github.com/ltex-plus/ltex-ls-plus/discussions/205) an author writing a series of books wanted a per-document word list, tried `% LTeX: dictionary=`, read this warning, and filed a feature request asking for a dictionary magic comment. The feature had been there all along; only the operator was missing from the line.

## Why it happens

The operator is part of what the parser matches on:

```kotlin
private val DICTIONARY_REGEX =
  Regex("^(?:ltex\\.)?dictionary(?<op>[+#-])$", RegexOption.IGNORE_CASE)
private val RULE_REGEX = Regex("^(?:ltex\\.)?rules(?<op>[+#-])$", RegexOption.IGNORE_CASE)
```

`dictionary` without a trailing `+`, `-` or `#` matches neither regex, so it matches nothing else either and reaches the final `else` branch of the `when`, which exists for genuinely unrecognized keys. From the parser's point of view a bare `dictionary` and a typo like `dictionarie` are indistinguishable.

The message this case deserves already existed:

```properties
ignoringMalformedInlineSettingOperation = Ignoring malformed inline setting operation '{0}=' for name '{1}'. Expected '+=', '-=' or '#='
```

It was unreachable. Its only caller is `opToIncluded`, which receives the operator from `it.groups["op"]`, i.e. from a regex that has *already* constrained it to `[+#-]`. All three of those values satisfy `OP_REGEX`, so the `else -> throw` inside `opToIncluded` never fires and the message never prints. The parser had the right words for this exact mistake and no path that reached them.

## The fix

Match the bare forms explicitly and emit that message:

```kotlin
// The two cumulative settings written without their required "+"/"-"/"#"
// operator, e.g. "dictionary=Foo". Such a key matches neither regex above, so
// without this it reaches the "unknown setting" branch and the warning claims a
// supported setting does not exist -- the very confusion behind discussion #205.
private val CUMULATIVE_WITHOUT_OPERATOR_REGEX =
  Regex("^(?:ltex\\.)?(?<name>dictionary|rules)$", RegexOption.IGNORE_CASE)
```

```kotlin
CUMULATIVE_WITHOUT_OPERATOR_REGEX.matchEntire(key)?.let {
  Logging.LOGGER.warning(
    I18n.format("ignoringMalformedInlineSettingOperation", "", key),
  )
} != null -> {
}
```

The branch sits immediately before the `else`, so it only ever catches keys that would otherwise have been called unknown. What the user sees:

| Magic comment | Before | After |
|---|---|---|
| `% LTeX: dictionary=Foo` | `Ignoring unknown inline setting with name 'dictionary'` | `Ignoring malformed inline setting operation '=' for name 'dictionary'. Expected '+=', '-=' or '#='` |
| `% LTeX: rules=EN_A_VS_AN` | `Ignoring unknown inline setting with name 'rules'` | same, naming `rules` |
| `% LTeX: dictionaries=Foo` | unknown setting | unchanged — unknown setting |
| `% LTeX: dictionary+=Foo` | applies, no warning | unchanged |

The empty first argument renders as `operation '='`, which reads correctly: the user did write `=`, and it is the operation that is wrong.

`hiddenFalsePositives` is deliberately **not** included. Its regex exists but its branch is commented out — the parser genuinely cannot parse that setting from a magic comment — so "unknown setting" remains the honest answer there. Promising `+=` would send users chasing a form that does not work either.

## The second mistake in the same report

Having been told `dictionary` was unknown, the author of discussion 205 did the reasonable next thing: he copied the JSON from the `ltex.dictionary` settings reference into the magic comment.

```latex
% LTeX: dictionary={"en-US": ["adaptivity", "precomputed"], "de-DE": ["B-Splines"]}
```

`KEY_VALUE_REGEX` separates pairs on whitespace, so the line is split at the first space: `dictionary` takes `{"en-US":` as its value, and the rest of the JSON is left over with no `=` in it and cannot be parsed at all. That leftover was reported as

```
WARNING: Ignoring malformed inline setting '["adaptivity", "precomputed"], "de-DE": ["B-Splines"]}'
```

which is accurate and useless: it echoes the fragment back without saying what a magic comment does accept. The message now says so:

```
WARNING: Ignoring malformed inline setting '["adaptivity", "precomputed"], "de-DE": ["B-Splines"]}'.
A magic comment expects whitespace-separated NAME=VALUE pairs whose VALUE contains no whitespace,
not a JSON value like the one 'ltex.dictionary' takes in the client settings
```

This is a message change only. JSON is **not** accepted in magic comments and this PR does not make it so — the point is to say where JSON does belong, so the user stops trying to make it work here. With both changes in place the JSON line above now produces two warnings that between them describe the whole problem: the operator is missing, and the value is of the wrong kind.

## What this affects

- **Log output only.** No protocol change, no new or changed settings, no change to how any well-formed magic comment is parsed or applied.
- **Keys that were already recognized** take their existing branches unchanged; the new branch is reachable only from what previously fell through to `else`.
- **Genuinely unknown settings** still report as unknown, which the tests pin down so the new branch cannot quietly widen later.
- **Locale.** The German bundle carries none of these strings, so a German-locale user sees the English message text under a JDK-localized `WARNUNG` level, as before. Both messages live in the default bundle only; no translation is added or removed here.

## Testing

New `SettingsParserTest` with five cases: the operator-less form across `dictionary`, `ltex.dictionary` and `DICTIONARY` (prefix and case-insensitivity both matter here, since the regex accepts them); the same for `rules`; a genuinely unknown key still reporting unknown; `dictionary+=` still applying silently and putting the word in the resulting dictionary; and the JSON line from discussion 205, asserting both that the new advice appears and that nothing inside the JSON is mistaken for a dictionary entry. Warnings are captured with a `java.util.logging.Handler` attached to `Logging.LOGGER` for the duration of the call.

The test file sits at `src/test/kotlin/SettingsParserTest.kt`, in the default package, because `SettingsParser.kt` itself has no `package` declaration despite living under `settings/` — which is also why `RegexCodeFragmentizer.kt` says `import SettingsParser`. Pre-existing, untouched here, but it dictates where the test can live.

```
SettingsParserTest    5/5
DocumentCheckerTest   15/15   (covers the magic-comment paths)
detekt:check          clean
ktlint                clean
```